### PR TITLE
Add post-install/pre-removal scripts to link bins

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,20 @@ override_dh_auto_configure:
 	+pg_buildext configure build-%v
 
 override_dh_auto_install:
-	+pg_buildext install build-%v postgresql-%v-citus 
+	+pg_buildext install build-%v postgresql-%v-citus
+
+	# Install alternatives for our binaries. Could simply link to pg_wrapper,
+	# but there's no harm in just using the binary installed with the latest
+	# version. Below inspired by a similar block in pg_repack's installer.
+	set -ex; \
+	binaries="csql copy_to_distributed_table"; \
+	for v in $(shell pg_buildext supported-versions); do \
+		i=$$(echo $$v | tr -d .); \
+		for bin in $$binaries; do \
+			echo "update-alternatives --install /usr/bin/$$bin citus-$$bin /usr/lib/postgresql/$$v/bin/$$bin $$i" >> debian/postgresql-$$v-citus.postinst.debhelper; \
+			echo "update-alternatives --remove citus-$$bin /usr/lib/postgresql/$$v/bin/$$bin" >> debian/postgresql-$$v-citus.prerm.debhelper; \
+		done \
+	done
 
 %:
 	dh $@

--- a/rpm/citus.spec
+++ b/rpm/citus.spec
@@ -9,8 +9,10 @@ License:    GPLv2+
 Group:      Applications/Databases
 Source0:    https://api.github.com/repos/citusdata/citus/tarball/%{ghtag}
 URL:        https://github.com/citusdata/citus
-BuildRequires:  postgresql%{pgmajorversion}-devel libxml2-devel libxslt-devel openssl-devel pam-devel readline-devel
-Requires:   postgresql%{pgmajorversion}-server
+BuildRequires:    postgresql%{pgmajorversion}-devel libxml2-devel libxslt-devel openssl-devel pam-devel readline-devel
+Requires:         postgresql%{pgmajorversion}-server
+Requires(post):   %{_sbindir}/update-alternatives
+Requires(postun): %{_sbindir}/update-alternatives
 BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %description
@@ -30,6 +32,20 @@ make %{?_smp_mflags}
 
 %clean
 %{__rm} -rf %{buildroot}
+
+%post
+%{_sbindir}/update-alternatives --install %{_bindir}/csql \
+    %{sname}-csql %{pginstdir}/bin/csql %{pgmajorversion}0
+%{_sbindir}/update-alternatives --install %{_bindir}/copy_to_distributed_table \
+    %{sname}-copy_to_distributed_table %{pginstdir}/bin/copy_to_distributed_table %{pgmajorversion}0
+
+%postun
+if [ $1 -eq 0 ] ; then
+    %{_sbindir}/update-alternatives --remove %{sname}-csql \
+        %{pginstdir}/bin/csql
+    %{_sbindir}/update-alternatives --remove %{sname}-copy_to_distributed_table \
+        %{pginstdir}/bin/copy_to_distributed_table
+fi
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
These simply use `update-alternatives` to add alternative listings for the binaries packaged with Citus. If a system has Citus installed both for PostgreSQL 9.4 _and_ 9.5, then then 9.5 binaries have precedence unless the user manually changes their alternatives settings.

If only a single PostgreSQL version has Citus installed, then the alternatives system is technically extraneous, but results in all our binaries just showing up on the user's path.
