### PR TITLE
Register PGDG dependencies in install scripts

### DIFF
--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -8,14 +8,61 @@ unknown_os ()
   exit 1
 }
 
+arch_check ()
+{
+  if [ "$(uname -m)" != 'x86_64' ]; then
+    echo "Unfortunately, the Citus repository does not contain packages for non-x86_64 architectures."
+    echo
+    echo "Please email engage@citusdata.com with any issues."
+    exit 1
+  fi
+}
+
 curl_check ()
 {
   echo "Checking for curl..."
   if command -v curl > /dev/null; then
     echo "Detected curl..."
   else
-    echo "Installing curl..."
-    apt-get install -q -y curl
+    echo -n "Installing curl... "
+    apt-get install -y --no-install-recommends curl &> /dev/null
+    echo "done."
+  fi
+}
+
+pgdg_check ()
+{
+  echo "Checking for postgresql-9.5..."
+  if apt-cache show postgresql-9.5 &> /dev/null; then
+    echo "Detected postgresql-9.5..."
+  else
+    pgdg_list='/etc/apt/sources.list.d/pgdg.list'
+    pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"
+    pgdg_key_url='https://www.postgresql.org/media/keys/ACCC4CF8.asc'
+
+    if [ -e $pgdg_list ]; then
+      echo "Unable to install PostgreSQL Apt Repository"
+      echo
+      echo "The file ${pgdg_list} already exists."
+      echo
+      echo "Contact engage@citusdata.com with information about your system for help."
+      exit 1
+    fi
+
+    echo -n "Installing ${pgdg_list}... "
+
+    # create an apt config file for the PGDG repository
+    echo "${pgdg_source_path}" > $pgdg_list
+    echo "done."
+
+    echo -n "Installing ca-certificates... "
+    apt-get install -y --no-install-recommends ca-certificates &> /dev/null
+    echo "done."
+
+    echo -n "Importing PostgreSQL gpg key... "
+    # import the gpg key
+    curl -L "${pgdg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
+    echo "done."
   fi
 }
 
@@ -79,16 +126,45 @@ detect_os ()
   echo "Detected operating system as $os/$dist."
 }
 
+detect_codename ()
+{
+  if [ "${os}" = "debian" ]; then
+    case "${dist}" in
+      7)
+        codename='wheezy'
+        ;;
+      8)
+        codename='jessie'
+        ;;
+      wheezy)
+        codename="${dist}"
+        ;;
+      jessie)
+        codename="${dist}"
+        ;;
+      *)
+        unknown_os
+        ;;
+    esac
+  else
+    codename=${dist}
+  fi
+}
+
 main ()
 {
   detect_os
-  curl_check
+  detect_codename
 
   # Need to first run apt-get update so that apt-transport-https can be
   # installed
   echo -n "Running apt-get update... "
   apt-get update &> /dev/null
   echo "done."
+
+  arch_check
+  curl_check
+  pgdg_check
 
   # Install the debian-archive-keyring package on debian systems so that
   # apt-transport-https can be installed next
@@ -104,7 +180,7 @@ main ()
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_community-nightlies.list"
 
-  echo -n "Installing $apt_source_path..."
+  echo -n "Installing $apt_source_path... "
 
   # create an apt config file for this repository
   curl -sSf "${apt_config_url}" > $apt_source_path
@@ -157,7 +233,7 @@ main ()
   echo "done."
 
   echo
-  echo "The repository is setup! You can now install packages."
+  echo "The repository is set up! You can now install packages."
 }
 
 main

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -8,14 +8,61 @@ unknown_os ()
   exit 1
 }
 
+arch_check ()
+{
+  if [ "$(uname -m)" != 'x86_64' ]; then
+    echo "Unfortunately, the Citus repository does not contain packages for non-x86_64 architectures."
+    echo
+    echo "Please email engage@citusdata.com with any issues."
+    exit 1
+  fi
+}
+
 curl_check ()
 {
   echo "Checking for curl..."
   if command -v curl > /dev/null; then
     echo "Detected curl..."
   else
-    echo "Installing curl..."
-    apt-get install -q -y curl
+    echo -n "Installing curl... "
+    apt-get install -y --no-install-recommends curl &> /dev/null
+    echo "done."
+  fi
+}
+
+pgdg_check ()
+{
+  echo "Checking for postgresql-9.5..."
+  if apt-cache show postgresql-9.5 &> /dev/null; then
+    echo "Detected postgresql-9.5..."
+  else
+    pgdg_list='/etc/apt/sources.list.d/pgdg.list'
+    pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"
+    pgdg_key_url='https://www.postgresql.org/media/keys/ACCC4CF8.asc'
+
+    if [ -e $pgdg_list ]; then
+      echo "Unable to install PostgreSQL Apt Repository"
+      echo
+      echo "The file ${pgdg_list} already exists."
+      echo
+      echo "Contact engage@citusdata.com with information about your system for help."
+      exit 1
+    fi
+
+    echo -n "Installing ${pgdg_list}... "
+
+    # create an apt config file for the PGDG repository
+    echo "${pgdg_source_path}" > $pgdg_list
+    echo "done."
+
+    echo -n "Installing ca-certificates... "
+    apt-get install -y --no-install-recommends ca-certificates &> /dev/null
+    echo "done."
+
+    echo -n "Importing PostgreSQL gpg key... "
+    # import the gpg key
+    curl -L "${pgdg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
+    echo "done."
   fi
 }
 
@@ -79,16 +126,45 @@ detect_os ()
   echo "Detected operating system as $os/$dist."
 }
 
+detect_codename ()
+{
+  if [ "${os}" = "debian" ]; then
+    case "${dist}" in
+      7)
+        codename='wheezy'
+        ;;
+      8)
+        codename='jessie'
+        ;;
+      wheezy)
+        codename="${dist}"
+        ;;
+      jessie)
+        codename="${dist}"
+        ;;
+      *)
+        unknown_os
+        ;;
+    esac
+  else
+    codename=${dist}
+  fi
+}
+
 main ()
 {
   detect_os
-  curl_check
+  detect_codename
 
   # Need to first run apt-get update so that apt-transport-https can be
   # installed
   echo -n "Running apt-get update... "
   apt-get update &> /dev/null
   echo "done."
+
+  arch_check
+  curl_check
+  pgdg_check
 
   # Install the debian-archive-keyring package on debian systems so that
   # apt-transport-https can be installed next
@@ -104,7 +180,7 @@ main ()
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_community.list"
 
-  echo -n "Installing $apt_source_path..."
+  echo -n "Installing $apt_source_path... "
 
   # create an apt config file for this repository
   curl -sSf "${apt_config_url}" > $apt_source_path
@@ -157,7 +233,7 @@ main ()
   echo "done."
 
   echo
-  echo "The repository is setup! You can now install packages."
+  echo "The repository is set up! You can now install packages."
 }
 
 main

--- a/community/rpm.sh
+++ b/community/rpm.sh
@@ -8,14 +8,38 @@ unknown_os ()
   exit 1
 }
 
+arch_check ()
+{
+  if [ "$(uname -m)" != 'x86_64' ]; then
+    echo "Unfortunately, the Citus repository does not contain packages for non-x86_64 architectures."
+    echo
+    echo "Please email engage@citusdata.com with any issues."
+    exit 1
+  fi
+}
+
 curl_check ()
 {
   echo "Checking for curl..."
   if command -v curl > /dev/null; then
     echo "Detected curl..."
   else
-    echo "Installing curl..."
+    echo -n "Installing curl... "
     yum install -d0 -e0 -y curl
+    echo "done."
+  fi
+}
+
+pgdg_check ()
+{
+  echo "Checking for postgresql95-server..."
+  if yum list -q postgresql95-server &> /dev/null; then
+    echo "Detected postgresql95-server..."
+  else
+    echo -n "Installing pgdg95 repo... "
+
+    yum install -d0 -e0 -y "${repo_url}"
+    echo "done."
   fi
 }
 
@@ -78,17 +102,64 @@ detect_os ()
   echo "Detected operating system as ${os}/${dist}."
 }
 
+detect_repo_url ()
+{
+  # set common defaults used by most flavors
+  family='redhat'
+  family_short='rhel'
+  pkg_dist="${dist}"
+  pkg_os="${os}"
+  pkg_version='2'
+
+  case "${os}" in
+    amzn)
+      # require at least a 2015 image
+      if [ "${dist}" -lt "2015" ]; then
+        unknown_os
+      fi
+
+      # use 2015.03 pgdg repo for all recent Amazon instances
+      pkg_dist=6
+      pkg_os='ami201503-'
+      ;;
+    ol)
+      pkg_os='oraclelinux'
+      ;;
+    fedora)
+      family='fedora'
+      family_short='fedora'
+      pkg_version='3'
+      ;;
+    centos)
+      # defaults are suitable
+      ;;
+    rhel|redhatenterpriseserver)
+      pkg_os='redhat'
+      ;;
+    *)
+      unknown_os
+      ;;
+  esac
+
+  repo_url="https://download.postgresql.org/pub/repos/yum/9.5/${family}"
+  repo_url+="/${family_short}-${pkg_dist}-x86_64"
+  repo_url+="/pgdg-${pkg_os}95-9.5-${pkg_version}.noarch.rpm"
+}
+
 main ()
 {
   detect_os
-  curl_check
+  detect_repo_url
 
+  arch_check
+  curl_check
+  pgdg_check
 
   yum_repo_config_url="https://repos.citusdata.com/community/config_file.repo?os=${os}&dist=${dist}&source=script"
 
   yum_repo_path=/etc/yum.repos.d/citusdata_community.repo
 
-  echo "Downloading repository file: ${yum_repo_config_url}"
+  echo -n "Downloading repository file: ${yum_repo_config_url}... "
 
   curl -sSf "${yum_repo_config_url}" > $yum_repo_path
   curl_exit_code=$?
@@ -131,8 +202,8 @@ main ()
     echo "done."
   fi
 
-  echo "Installing pygpgme to verify GPG signatures..."
-  yum install -y pygpgme --disablerepo='citusdata_community'
+  echo -n "Installing pygpgme to verify GPG signatures... "
+  yum install -d0 -e0 -y pygpgme --disablerepo='citusdata_community' &> /dev/null
   pypgpme_check=`rpm -qa | grep -qw pygpgme`
   if [ "$?" != "0" ]; then
     echo
@@ -145,9 +216,10 @@ main ()
     # set the repo_gpgcheck option to 0
     sed -i'' 's/repo_gpgcheck=1/repo_gpgcheck=0/' /etc/yum.repos.d/citusdata_community.repo
   fi
+  echo 'done.'
 
-  echo "Installing yum-utils..."
-  yum install -y yum-utils --disablerepo='citusdata_community'
+  echo -n "Installing yum-utils... "
+  yum install -d0 -e0 -y yum-utils --disablerepo='citusdata_community' &> /dev/null
   yum_utils_check=`rpm -qa | grep -qw yum-utils`
   if [ "$?" != "0" ]; then
     echo
@@ -155,12 +227,14 @@ main ()
     echo "The yum-utils package could not be installed. This means you may not be able to install source RPMs or use other yum features."
     echo
   fi
+  echo 'done.'
 
-  echo "Generating yum cache for citusdata_community..."
-  yum -q makecache -y --disablerepo='*' --enablerepo='citusdata_community'
+  echo -n "Generating yum cache for citusdata_community... "
+  yum -d0 -e0 -q makecache -y --disablerepo='*' --enablerepo='citusdata_community' &> /dev/null
+  echo 'done.'
 
   echo
-  echo "The repository is setup! You can now install packages."
+  echo "The repository is set up! You can now install packages."
 }
 
 main

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -8,14 +8,38 @@ unknown_os ()
   exit 1
 }
 
+arch_check ()
+{
+  if [ "$(uname -m)" != 'x86_64' ]; then
+    echo "Unfortunately, the Citus repository does not contain packages for non-x86_64 architectures."
+    echo
+    echo "Please email engage@citusdata.com with any issues."
+    exit 1
+  fi
+}
+
 curl_check ()
 {
   echo "Checking for curl..."
   if command -v curl > /dev/null; then
     echo "Detected curl..."
   else
-    echo "Installing curl..."
+    echo -n "Installing curl... "
     yum install -d0 -e0 -y curl
+    echo "done."
+  fi
+}
+
+pgdg_check ()
+{
+  echo "Checking for postgresql95-server..."
+  if yum list -q postgresql95-server &> /dev/null; then
+    echo "Detected postgresql95-server..."
+  else
+    echo -n "Installing pgdg95 repo... "
+
+    yum install -d0 -e0 -y "${repo_url}"
+    echo "done."
   fi
 }
 
@@ -108,17 +132,65 @@ detect_os ()
   echo "Detected operating system as ${os}/${dist}."
 }
 
+detect_repo_url ()
+{
+  # set common defaults used by most flavors
+  family='redhat'
+  family_short='rhel'
+  pkg_dist="${dist}"
+  pkg_os="${os}"
+  pkg_version='2'
+
+  case "${os}" in
+    amzn)
+      # require at least a 2015 image
+      if [ "${dist}" -lt "2015" ]; then
+        unknown_os
+      fi
+
+      # use 2015.03 pgdg repo for all recent Amazon instances
+      pkg_dist=6
+      pkg_os='ami201503-'
+      ;;
+    ol)
+      pkg_os='oraclelinux'
+      ;;
+    fedora)
+      family='fedora'
+      family_short='fedora'
+      pkg_version='3'
+      ;;
+    centos)
+      # defaults are suitable
+      ;;
+    rhel|redhatenterpriseserver)
+      pkg_os='redhat'
+      ;;
+    *)
+      unknown_os
+      ;;
+  esac
+
+  repo_url="https://download.postgresql.org/pub/repos/yum/9.5/${family}"
+  repo_url+="/${family_short}-${pkg_dist}-x86_64"
+  repo_url+="/pgdg-${pkg_os}95-9.5-${pkg_version}.noarch.rpm"
+}
+
 main ()
 {
   detect_os
+  detect_repo_url
+
+  arch_check
   curl_check
+  pgdg_check
 
   if [ -z "$unique_id" ]; then
     get_unique_id
   fi
 
   if [ -z "${CITUS_REPO_TOKEN}" ]; then
-    echo "Could not determine enterprise repository token."
+    echo "Could not determine enterprise-nightlies repository token."
     echo "Please set the CITUS_REPO_TOKEN environment variable."
     echo
     echo "Contact engage@citusdata.com if you continue to have problems."
@@ -130,7 +202,7 @@ main ()
 
   yum_repo_path=/etc/yum.repos.d/citusdata_enterprise-nightlies.repo
 
-  echo "Downloading repository file: ${yum_repo_config_url}"
+  echo -n "Downloading repository file: ${yum_repo_config_url}... "
 
   curl -sSf "${yum_repo_config_url}" > $yum_repo_path
   curl_exit_code=$?
@@ -173,8 +245,8 @@ main ()
     echo "done."
   fi
 
-  echo "Installing pygpgme to verify GPG signatures..."
-  yum install -y pygpgme --disablerepo='citusdata_enterprise-nightlies'
+  echo -n "Installing pygpgme to verify GPG signatures... "
+  yum install -d0 -e0 -y pygpgme --disablerepo='citusdata_enterprise-nightlies' &> /dev/null
   pypgpme_check=`rpm -qa | grep -qw pygpgme`
   if [ "$?" != "0" ]; then
     echo
@@ -187,9 +259,10 @@ main ()
     # set the repo_gpgcheck option to 0
     sed -i'' 's/repo_gpgcheck=1/repo_gpgcheck=0/' /etc/yum.repos.d/citusdata_enterprise-nightlies.repo
   fi
+  echo 'done.'
 
-  echo "Installing yum-utils..."
-  yum install -y yum-utils --disablerepo='citusdata_enterprise-nightlies'
+  echo -n "Installing yum-utils... "
+  yum install -d0 -e0 -y yum-utils --disablerepo='citusdata_enterprise-nightlies' &> /dev/null
   yum_utils_check=`rpm -qa | grep -qw yum-utils`
   if [ "$?" != "0" ]; then
     echo
@@ -197,12 +270,14 @@ main ()
     echo "The yum-utils package could not be installed. This means you may not be able to install source RPMs or use other yum features."
     echo
   fi
+  echo 'done.'
 
-  echo "Generating yum cache for citusdata_enterprise-nightlies..."
-  yum -q makecache -y --disablerepo='*' --enablerepo='citusdata_enterprise-nightlies'
+  echo -n "Generating yum cache for citusdata_enterprise-nightlies... "
+  yum -d0 -e0 -q makecache -y --disablerepo='*' --enablerepo='citusdata_enterprise-nightlies' &> /dev/null
+  echo 'done.'
 
   echo
-  echo "The repository is setup! You can now install packages."
+  echo "The repository is set up! You can now install packages."
 }
 
 main

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -8,14 +8,61 @@ unknown_os ()
   exit 1
 }
 
+arch_check ()
+{
+  if [ "$(uname -m)" != 'x86_64' ]; then
+    echo "Unfortunately, the Citus repository does not contain packages for non-x86_64 architectures."
+    echo
+    echo "Please email engage@citusdata.com with any issues."
+    exit 1
+  fi
+}
+
 curl_check ()
 {
   echo "Checking for curl..."
   if command -v curl > /dev/null; then
     echo "Detected curl..."
   else
-    echo "Installing curl..."
-    apt-get install -q -y curl
+    echo -n "Installing curl... "
+    apt-get install -y --no-install-recommends curl &> /dev/null
+    echo "done."
+  fi
+}
+
+pgdg_check ()
+{
+  echo "Checking for postgresql-9.5..."
+  if apt-cache show postgresql-9.5 &> /dev/null; then
+    echo "Detected postgresql-9.5..."
+  else
+    pgdg_list='/etc/apt/sources.list.d/pgdg.list'
+    pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"
+    pgdg_key_url='https://www.postgresql.org/media/keys/ACCC4CF8.asc'
+
+    if [ -e $pgdg_list ]; then
+      echo "Unable to install PostgreSQL Apt Repository"
+      echo
+      echo "The file ${pgdg_list} already exists."
+      echo
+      echo "Contact engage@citusdata.com with information about your system for help."
+      exit 1
+    fi
+
+    echo -n "Installing ${pgdg_list}... "
+
+    # create an apt config file for the PGDG repository
+    echo "${pgdg_source_path}" > $pgdg_list
+    echo "done."
+
+    echo -n "Installing ca-certificates... "
+    apt-get install -y --no-install-recommends ca-certificates &> /dev/null
+    echo "done."
+
+    echo -n "Importing PostgreSQL gpg key... "
+    # import the gpg key
+    curl -L "${pgdg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
+    echo "done."
   fi
 }
 
@@ -109,16 +156,45 @@ detect_os ()
   echo "Detected operating system as $os/$dist."
 }
 
+detect_codename ()
+{
+  if [ "${os}" = "debian" ]; then
+    case "${dist}" in
+      7)
+        codename='wheezy'
+        ;;
+      8)
+        codename='jessie'
+        ;;
+      wheezy)
+        codename="${dist}"
+        ;;
+      jessie)
+        codename="${dist}"
+        ;;
+      *)
+        unknown_os
+        ;;
+    esac
+  else
+    codename=${dist}
+  fi
+}
+
 main ()
 {
   detect_os
-  curl_check
+  detect_codename
 
   # Need to first run apt-get update so that apt-transport-https can be
   # installed
   echo -n "Running apt-get update... "
   apt-get update &> /dev/null
   echo "done."
+
+  arch_check
+  curl_check
+  pgdg_check
 
   # Install the debian-archive-keyring package on debian systems so that
   # apt-transport-https can be installed next
@@ -154,7 +230,7 @@ main ()
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_enterprise.list"
 
-  echo -n "Installing $apt_source_path..."
+  echo -n "Installing $apt_source_path... "
 
   # create an apt config file for this repository
   curl -sSf "${apt_config_url}" > $apt_source_path
@@ -207,7 +283,7 @@ main ()
   echo "done."
 
   echo
-  echo "The repository is setup! You can now install packages."
+  echo "The repository is set up! You can now install packages."
 }
 
 main

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -8,14 +8,38 @@ unknown_os ()
   exit 1
 }
 
+arch_check ()
+{
+  if [ "$(uname -m)" != 'x86_64' ]; then
+    echo "Unfortunately, the Citus repository does not contain packages for non-x86_64 architectures."
+    echo
+    echo "Please email engage@citusdata.com with any issues."
+    exit 1
+  fi
+}
+
 curl_check ()
 {
   echo "Checking for curl..."
   if command -v curl > /dev/null; then
     echo "Detected curl..."
   else
-    echo "Installing curl..."
+    echo -n "Installing curl... "
     yum install -d0 -e0 -y curl
+    echo "done."
+  fi
+}
+
+pgdg_check ()
+{
+  echo "Checking for postgresql95-server..."
+  if yum list -q postgresql95-server &> /dev/null; then
+    echo "Detected postgresql95-server..."
+  else
+    echo -n "Installing pgdg95 repo... "
+
+    yum install -d0 -e0 -y "${repo_url}"
+    echo "done."
   fi
 }
 
@@ -108,10 +132,58 @@ detect_os ()
   echo "Detected operating system as ${os}/${dist}."
 }
 
+detect_repo_url ()
+{
+  # set common defaults used by most flavors
+  family='redhat'
+  family_short='rhel'
+  pkg_dist="${dist}"
+  pkg_os="${os}"
+  pkg_version='2'
+
+  case "${os}" in
+    amzn)
+      # require at least a 2015 image
+      if [ "${dist}" -lt "2015" ]; then
+        unknown_os
+      fi
+
+      # use 2015.03 pgdg repo for all recent Amazon instances
+      pkg_dist=6
+      pkg_os='ami201503-'
+      ;;
+    ol)
+      pkg_os='oraclelinux'
+      ;;
+    fedora)
+      family='fedora'
+      family_short='fedora'
+      pkg_version='3'
+      ;;
+    centos)
+      # defaults are suitable
+      ;;
+    rhel|redhatenterpriseserver)
+      pkg_os='redhat'
+      ;;
+    *)
+      unknown_os
+      ;;
+  esac
+
+  repo_url="https://download.postgresql.org/pub/repos/yum/9.5/${family}"
+  repo_url+="/${family_short}-${pkg_dist}-x86_64"
+  repo_url+="/pgdg-${pkg_os}95-9.5-${pkg_version}.noarch.rpm"
+}
+
 main ()
 {
   detect_os
+  detect_repo_url
+
+  arch_check
   curl_check
+  pgdg_check
 
   if [ -z "$unique_id" ]; then
     get_unique_id
@@ -130,7 +202,7 @@ main ()
 
   yum_repo_path=/etc/yum.repos.d/citusdata_enterprise.repo
 
-  echo "Downloading repository file: ${yum_repo_config_url}"
+  echo -n "Downloading repository file: ${yum_repo_config_url}... "
 
   curl -sSf "${yum_repo_config_url}" > $yum_repo_path
   curl_exit_code=$?
@@ -173,8 +245,8 @@ main ()
     echo "done."
   fi
 
-  echo "Installing pygpgme to verify GPG signatures..."
-  yum install -y pygpgme --disablerepo='citusdata_enterprise'
+  echo -n "Installing pygpgme to verify GPG signatures... "
+  yum install -d0 -e0 -y pygpgme --disablerepo='citusdata_enterprise' &> /dev/null
   pypgpme_check=`rpm -qa | grep -qw pygpgme`
   if [ "$?" != "0" ]; then
     echo
@@ -187,9 +259,10 @@ main ()
     # set the repo_gpgcheck option to 0
     sed -i'' 's/repo_gpgcheck=1/repo_gpgcheck=0/' /etc/yum.repos.d/citusdata_enterprise.repo
   fi
+  echo 'done.'
 
-  echo "Installing yum-utils..."
-  yum install -y yum-utils --disablerepo='citusdata_enterprise'
+  echo -n "Installing yum-utils... "
+  yum install -d0 -e0 -y yum-utils --disablerepo='citusdata_enterprise' &> /dev/null
   yum_utils_check=`rpm -qa | grep -qw yum-utils`
   if [ "$?" != "0" ]; then
     echo
@@ -197,12 +270,14 @@ main ()
     echo "The yum-utils package could not be installed. This means you may not be able to install source RPMs or use other yum features."
     echo
   fi
+  echo 'done.'
 
-  echo "Generating yum cache for citusdata_enterprise..."
-  yum -q makecache -y --disablerepo='*' --enablerepo='citusdata_enterprise'
+  echo -n "Generating yum cache for citusdata_enterprise... "
+  yum -d0 -e0 -q makecache -y --disablerepo='*' --enablerepo='citusdata_enterprise' &> /dev/null
+  echo 'done.'
 
   echo
-  echo "The repository is setup! You can now install packages."
+  echo "The repository is set up! You can now install packages."
 }
 
 main


### PR DESCRIPTION
With this change the user will be able to immediately install postgresql-9.5-citus or citus_95 after running the Citus community installer for their Linux.

Fixes #8 

Notes
- Installers are still idempotent
- deb.sh now creates `/etc/apt/sources.list.d/pgdg.list` and will _overwrite_ it if it exists. Theoretically it might clobber a user file, but it seems unlikely
- Not sure what happens if the system had an older postgres version already installed, should I test this?
- RPM version has a check to deal with 32bit systems although IIRC we don't have a Citus package created for this yet. It's for future proofing.

@jasonmp85 could give these scripts one more test in your battery of Docker containers?
