### PR TITLE
Clean up enterprise install scripts

### DIFF
--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -216,11 +216,14 @@ main ()
     exit 1
   fi
 
-  echo "Found host ID: ${CITUS_REPO_HOST_ID}"
-  gpg_key_install_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise-nightlies/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
-  apt_config_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise-nightlies/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+  # escape any colons in repo token (they separate it from empty password)
+  CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
-  gpg_key_url=`curl -L "${gpg_key_install_url}"`
+  echo "Found host ID: ${CITUS_REPO_HOST_ID}"
+  gpg_key_install_url="https://repos.citusdata.com/enterprise-nightlies/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
+  apt_config_url="https://repos.citusdata.com/enterprise-nightlies/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+
+  gpg_key_url=`curl -L -u "${CITUS_REPO_TOKEN}:" "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then
     echo "Unable to retrieve GPG key URL from: ${gpg_key_url}."
     echo "Please contact engage@citusdata.com"
@@ -233,7 +236,7 @@ main ()
   echo -n "Installing $apt_source_path... "
 
   # create an apt config file for this repository
-  curl -sSf "${apt_config_url}" > $apt_source_path
+  curl -sSf -u "${CITUS_REPO_TOKEN}:" "${apt_config_url}" > $apt_source_path
   curl_exit_code=$?
 
   if [ "$curl_exit_code" = "22" ]; then

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -220,10 +220,10 @@ main ()
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
-  gpg_key_install_url="https://repos.citusdata.com/enterprise-nightlies/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
-  apt_config_url="https://repos.citusdata.com/enterprise-nightlies/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+  gpg_key_install_url="https://repos.citusdata.com/enterprise-nightlies/gpg_key_url.list?os=${os}&dist=${dist}"
+  apt_config_url="https://repos.citusdata.com/enterprise-nightlies/config_file.list?os=${os}&dist=${dist}&source=script"
 
-  gpg_key_url=`curl -L -u "${CITUS_REPO_TOKEN}:" "${gpg_key_install_url}"`
+  gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then
     echo "Unable to retrieve GPG key URL from: ${gpg_key_url}."
     echo "Please contact engage@citusdata.com"
@@ -236,7 +236,7 @@ main ()
   echo -n "Installing $apt_source_path... "
 
   # create an apt config file for this repository
-  curl -sSf -u "${CITUS_REPO_TOKEN}:" "${apt_config_url}" > $apt_source_path
+  curl -GsSf -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${apt_config_url}" > $apt_source_path
   curl_exit_code=$?
 
   if [ "$curl_exit_code" = "22" ]; then

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -77,22 +77,22 @@ install_debian_keyring ()
 
 get_unique_id ()
 {
-  echo "A unique ID was not specified, using the machine's hostname..."
+  echo "A host ID was not specified, using the machine's hostname..."
 
-  unique_id=`hostname -f 2>/dev/null`
-  if [ "$unique_id" = "" ]; then
-    unique_id=`hostname 2>/dev/null`
-    if [ "$unique_id" = "" ]; then
-      unique_id=$HOSTNAME
+  CITUS_REPO_HOST_ID=`hostname -f 2>/dev/null`
+  if [ "$CITUS_REPO_HOST_ID" = "" ]; then
+    CITUS_REPO_HOST_ID=`hostname 2>/dev/null`
+    if [ "$CITUS_REPO_HOST_ID" = "" ]; then
+      CITUS_REPO_HOST_ID=$HOSTNAME
     fi
   fi
 
-  if [ "$unique_id" = "" -o "$unique_id" = "(none)" ]; then
-    echo "This script tries to use your machine's hostname as a unique ID by"
+  if [ "$CITUS_REPO_HOST_ID" = "" -o "$CITUS_REPO_HOST_ID" = "(none)" ]; then
+    echo "This script tries to use your machine's hostname as a host ID by"
     echo "default, however, this script was not able to determine your "
     echo "hostname!"
     echo
-    echo "You can override this by setting 'unique_id' to any unique "
+    echo "You can override this by setting 'CITUS_REPO_HOST_ID' to any unique "
     echo "identifier (hostname, shasum of hostname, "
     echo "etc) prior to running this script."
     echo
@@ -204,7 +204,7 @@ main ()
   apt-get install -y apt-transport-https &> /dev/null
   echo "done."
 
-  if [ -z "$unique_id" ]; then
+  if [ -z "$CITUS_REPO_HOST_ID" ]; then
     get_unique_id
   fi
 
@@ -216,9 +216,9 @@ main ()
     exit 1
   fi
 
-  echo "Found unique id: ${unique_id}"
-  gpg_key_install_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise-nightlies/gpg_key_url.list?os=${os}&dist=${dist}&name=${unique_id}"
-  apt_config_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise-nightlies/config_file.list?os=${os}&dist=${dist}&name=${unique_id}&source=script"
+  echo "Found host ID: ${CITUS_REPO_HOST_ID}"
+  gpg_key_install_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise-nightlies/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
+  apt_config_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise-nightlies/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
 
   gpg_key_url=`curl -L "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -45,22 +45,22 @@ pgdg_check ()
 
 get_unique_id ()
 {
-  echo "A unique ID was not specified, using the machine's hostname..."
+  echo "A host ID was not specified, using the machine's hostname..."
 
-  unique_id=`hostname -f 2>/dev/null`
-  if [ "$unique_id" = "" ]; then
-    unique_id=`hostname 2>/dev/null`
-    if [ "$unique_id" = "" ]; then
-      unique_id=$HOSTNAME
+  CITUS_REPO_HOST_ID=`hostname -f 2>/dev/null`
+  if [ "$CITUS_REPO_HOST_ID" = "" ]; then
+    CITUS_REPO_HOST_ID=`hostname 2>/dev/null`
+    if [ "$CITUS_REPO_HOST_ID" = "" ]; then
+      CITUS_REPO_HOST_ID=$HOSTNAME
     fi
   fi
 
-  if [ "$unique_id" = "" -o "$unique_id" = "(none)" ]; then
-    echo "This script tries to use your machine's hostname as a unique ID by"
+  if [ "$CITUS_REPO_HOST_ID" = "" -o "$CITUS_REPO_HOST_ID" = "(none)" ]; then
+    echo "This script tries to use your machine's hostname as a host ID by"
     echo "default, however, this script was not able to determine your "
     echo "hostname!"
     echo
-    echo "You can override this by setting 'unique_id' to any unique "
+    echo "You can override this by setting 'CITUS_REPO_HOST_ID' to any unique "
     echo "identifier (hostname, shasum of hostname, "
     echo "etc) prior to running this script."
     echo
@@ -185,7 +185,7 @@ main ()
   curl_check
   pgdg_check
 
-  if [ -z "$unique_id" ]; then
+  if [ -z "$CITUS_REPO_HOST_ID" ]; then
     get_unique_id
   fi
 
@@ -197,8 +197,8 @@ main ()
     exit 1
   fi
 
-  yum_repo_config_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise-nightlies/config_file.repo?os=${os}&dist=${dist}&name=${unique_id}&source=script"
-  echo "Found unique id: ${unique_id}"
+  yum_repo_config_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise-nightlies/config_file.repo?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+  echo "Found host ID: ${CITUS_REPO_HOST_ID}"
 
   yum_repo_path=/etc/yum.repos.d/citusdata_enterprise-nightlies.repo
 

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -197,14 +197,17 @@ main ()
     exit 1
   fi
 
-  yum_repo_config_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise-nightlies/config_file.repo?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+  # escape any colons in repo token (they separate it from empty password)
+  CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
+
+  yum_repo_config_url="https://repos.citusdata.com/enterprise-nightlies/config_file.repo?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
 
   yum_repo_path=/etc/yum.repos.d/citusdata_enterprise-nightlies.repo
 
   echo -n "Downloading repository file: ${yum_repo_config_url}... "
 
-  curl -sSf "${yum_repo_config_url}" > $yum_repo_path
+  curl -sSf -u "${CITUS_REPO_TOKEN}:" "${yum_repo_config_url}" > $yum_repo_path
   curl_exit_code=$?
 
   if [ "$curl_exit_code" = "22" ]; then

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -200,14 +200,14 @@ main ()
   # escape any colons in repo token (they separate it from empty password)
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
-  yum_repo_config_url="https://repos.citusdata.com/enterprise-nightlies/config_file.repo?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+  yum_repo_config_url="https://repos.citusdata.com/enterprise-nightlies/config_file.repo?os=${os}&dist=${dist}&source=script"
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
 
   yum_repo_path=/etc/yum.repos.d/citusdata_enterprise-nightlies.repo
 
   echo -n "Downloading repository file: ${yum_repo_config_url}... "
 
-  curl -sSf -u "${CITUS_REPO_TOKEN}:" "${yum_repo_config_url}" > $yum_repo_path
+  curl -GsSf -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${yum_repo_config_url}" > $yum_repo_path
   curl_exit_code=$?
 
   if [ "$curl_exit_code" = "22" ]; then

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -220,10 +220,10 @@ main ()
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
-  gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
-  apt_config_url="https://repos.citusdata.com/enterprise/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+  gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}"
+  apt_config_url="https://repos.citusdata.com/enterprise/config_file.list?os=${os}&dist=${dist}&source=script"
 
-  gpg_key_url=`curl -L -u "${CITUS_REPO_TOKEN}:" "${gpg_key_install_url}"`
+  gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then
     echo "Unable to retrieve GPG key URL from: ${gpg_key_url}."
     echo "Please contact engage@citusdata.com"
@@ -236,7 +236,7 @@ main ()
   echo -n "Installing $apt_source_path... "
 
   # create an apt config file for this repository
-  curl -sSf -u "${CITUS_REPO_TOKEN}:" "${apt_config_url}" > $apt_source_path
+  curl -GsSf -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${apt_config_url}" > $apt_source_path
   curl_exit_code=$?
 
   if [ "$curl_exit_code" = "22" ]; then

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -77,22 +77,22 @@ install_debian_keyring ()
 
 get_unique_id ()
 {
-  echo "A unique ID was not specified, using the machine's hostname..."
+  echo "A host ID was not specified, using the machine's hostname..."
 
-  unique_id=`hostname -f 2>/dev/null`
-  if [ "$unique_id" = "" ]; then
-    unique_id=`hostname 2>/dev/null`
-    if [ "$unique_id" = "" ]; then
-      unique_id=$HOSTNAME
+  CITUS_REPO_HOST_ID=`hostname -f 2>/dev/null`
+  if [ "$CITUS_REPO_HOST_ID" = "" ]; then
+    CITUS_REPO_HOST_ID=`hostname 2>/dev/null`
+    if [ "$CITUS_REPO_HOST_ID" = "" ]; then
+      CITUS_REPO_HOST_ID=$HOSTNAME
     fi
   fi
 
-  if [ "$unique_id" = "" -o "$unique_id" = "(none)" ]; then
-    echo "This script tries to use your machine's hostname as a unique ID by"
+  if [ "$CITUS_REPO_HOST_ID" = "" -o "$CITUS_REPO_HOST_ID" = "(none)" ]; then
+    echo "This script tries to use your machine's hostname as a host ID by"
     echo "default, however, this script was not able to determine your "
     echo "hostname!"
     echo
-    echo "You can override this by setting 'unique_id' to any unique "
+    echo "You can override this by setting 'CITUS_REPO_HOST_ID' to any unique "
     echo "identifier (hostname, shasum of hostname, "
     echo "etc) prior to running this script."
     echo
@@ -204,7 +204,7 @@ main ()
   apt-get install -y apt-transport-https &> /dev/null
   echo "done."
 
-  if [ -z "$unique_id" ]; then
+  if [ -z "$CITUS_REPO_HOST_ID" ]; then
     get_unique_id
   fi
 
@@ -216,9 +216,9 @@ main ()
     exit 1
   fi
 
-  echo "Found unique id: ${unique_id}"
-  gpg_key_install_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}&name=${unique_id}"
-  apt_config_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise/config_file.list?os=${os}&dist=${dist}&name=${unique_id}&source=script"
+  echo "Found host ID: ${CITUS_REPO_HOST_ID}"
+  gpg_key_install_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
+  apt_config_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
 
   gpg_key_url=`curl -L "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -216,11 +216,14 @@ main ()
     exit 1
   fi
 
-  echo "Found host ID: ${CITUS_REPO_HOST_ID}"
-  gpg_key_install_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
-  apt_config_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+  # escape any colons in repo token (they separate it from empty password)
+  CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
-  gpg_key_url=`curl -L "${gpg_key_install_url}"`
+  echo "Found host ID: ${CITUS_REPO_HOST_ID}"
+  gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
+  apt_config_url="https://repos.citusdata.com/enterprise/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+
+  gpg_key_url=`curl -L -u "${CITUS_REPO_TOKEN}:" "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then
     echo "Unable to retrieve GPG key URL from: ${gpg_key_url}."
     echo "Please contact engage@citusdata.com"
@@ -233,7 +236,7 @@ main ()
   echo -n "Installing $apt_source_path... "
 
   # create an apt config file for this repository
-  curl -sSf "${apt_config_url}" > $apt_source_path
+  curl -sSf -u "${CITUS_REPO_TOKEN}:" "${apt_config_url}" > $apt_source_path
   curl_exit_code=$?
 
   if [ "$curl_exit_code" = "22" ]; then

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -200,14 +200,14 @@ main ()
   # escape any colons in repo token (they separate it from empty password)
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
-  yum_repo_config_url="https://repos.citusdata.com/enterprise/config_file.repo?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+  yum_repo_config_url="https://repos.citusdata.com/enterprise/config_file.repo?os=${os}&dist=${dist}&source=script"
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
 
   yum_repo_path=/etc/yum.repos.d/citusdata_enterprise.repo
 
   echo -n "Downloading repository file: ${yum_repo_config_url}... "
 
-  curl -sSf -u "${CITUS_REPO_TOKEN}:" "${yum_repo_config_url}" > $yum_repo_path
+  curl -GsSf -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${yum_repo_config_url}" > $yum_repo_path
   curl_exit_code=$?
 
   if [ "$curl_exit_code" = "22" ]; then

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -197,14 +197,17 @@ main ()
     exit 1
   fi
 
-  yum_repo_config_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise/config_file.repo?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+  # escape any colons in repo token (they separate it from empty password)
+  CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
+
+  yum_repo_config_url="https://repos.citusdata.com/enterprise/config_file.repo?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
 
   yum_repo_path=/etc/yum.repos.d/citusdata_enterprise.repo
 
   echo -n "Downloading repository file: ${yum_repo_config_url}... "
 
-  curl -sSf "${yum_repo_config_url}" > $yum_repo_path
+  curl -sSf -u "${CITUS_REPO_TOKEN}:" "${yum_repo_config_url}" > $yum_repo_path
   curl_exit_code=$?
 
   if [ "$curl_exit_code" = "22" ]; then

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -45,22 +45,22 @@ pgdg_check ()
 
 get_unique_id ()
 {
-  echo "A unique ID was not specified, using the machine's hostname..."
+  echo "A host ID was not specified, using the machine's hostname..."
 
-  unique_id=`hostname -f 2>/dev/null`
-  if [ "$unique_id" = "" ]; then
-    unique_id=`hostname 2>/dev/null`
-    if [ "$unique_id" = "" ]; then
-      unique_id=$HOSTNAME
+  CITUS_REPO_HOST_ID=`hostname -f 2>/dev/null`
+  if [ "$CITUS_REPO_HOST_ID" = "" ]; then
+    CITUS_REPO_HOST_ID=`hostname 2>/dev/null`
+    if [ "$CITUS_REPO_HOST_ID" = "" ]; then
+      CITUS_REPO_HOST_ID=$HOSTNAME
     fi
   fi
 
-  if [ "$unique_id" = "" -o "$unique_id" = "(none)" ]; then
-    echo "This script tries to use your machine's hostname as a unique ID by"
+  if [ "$CITUS_REPO_HOST_ID" = "" -o "$CITUS_REPO_HOST_ID" = "(none)" ]; then
+    echo "This script tries to use your machine's hostname as a host ID by"
     echo "default, however, this script was not able to determine your "
     echo "hostname!"
     echo
-    echo "You can override this by setting 'unique_id' to any unique "
+    echo "You can override this by setting 'CITUS_REPO_HOST_ID' to any unique "
     echo "identifier (hostname, shasum of hostname, "
     echo "etc) prior to running this script."
     echo
@@ -185,7 +185,7 @@ main ()
   curl_check
   pgdg_check
 
-  if [ -z "$unique_id" ]; then
+  if [ -z "$CITUS_REPO_HOST_ID" ]; then
     get_unique_id
   fi
 
@@ -197,8 +197,8 @@ main ()
     exit 1
   fi
 
-  yum_repo_config_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise/config_file.repo?os=${os}&dist=${dist}&name=${unique_id}&source=script"
-  echo "Found unique id: ${unique_id}"
+  yum_repo_config_url="https://${CITUS_REPO_TOKEN}:@repos.citusdata.com/enterprise/config_file.repo?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+  echo "Found host ID: ${CITUS_REPO_HOST_ID}"
 
   yum_repo_path=/etc/yum.repos.d/citusdata_enterprise.repo
 


### PR DESCRIPTION
Handles a few issues:
- Renames `unique_id` to `CITUS_REPO_HOST_ID` to be clearer about what it's used for
- Ensures master token will not be echoed, passing it as a user parameter instead
- Ensures master tokens containing colons are handled (unlikely, but fixed anyhow)
- Allows host IDs which contain spaces, other non-URL-safe characters

Everything should be good to go re: enterprise install scripts after this is merged.
