### PR TITLE
Bump expected PostgreSQL version to 9.6

### DIFF
--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -32,9 +32,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-9.5..."
-  if apt-cache show postgresql-9.5 &> /dev/null; then
-    echo "Detected postgresql-9.5..."
+  echo "Checking for postgresql-9.6..."
+  if apt-cache show postgresql-9.6 &> /dev/null; then
+    echo "Detected postgresql-9.6..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/community-nightlies/rpm.sh
+++ b/community-nightlies/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql95-server..."
-  if yum list -q postgresql95-server &> /dev/null; then
-    echo "Detected postgresql95-server..."
+  echo "Checking for postgresql96-server..."
+  if yum list -q postgresql96-server &> /dev/null; then
+    echo "Detected postgresql96-server..."
   else
-    echo -n "Installing pgdg95 repo... "
+    echo -n "Installing pgdg96 repo... "
 
     yum install -d0 -e0 -y "${repo_url}"
     echo "done."
@@ -113,7 +113,7 @@ detect_repo_url ()
   family_short='rhel'
   pkg_dist="${dist}"
   pkg_os="${os}"
-  pkg_version='2'
+  pkg_version='3'
 
   case "${os}" in
     amzn)
@@ -132,7 +132,6 @@ detect_repo_url ()
     fedora)
       family='fedora'
       family_short='fedora'
-      pkg_version='3'
       ;;
     centos)
       # defaults are suitable
@@ -145,9 +144,9 @@ detect_repo_url ()
       ;;
   esac
 
-  repo_url="https://download.postgresql.org/pub/repos/yum/9.5/${family}"
+  repo_url="https://download.postgresql.org/pub/repos/yum/9.6/${family}"
   repo_url+="/${family_short}-${pkg_dist}-x86_64"
-  repo_url+="/pgdg-${pkg_os}95-9.5-${pkg_version}.noarch.rpm"
+  repo_url+="/pgdg-${pkg_os}96-9.6-${pkg_version}.noarch.rpm"
 }
 
 main ()

--- a/community-nightlies/rpm.sh
+++ b/community-nightlies/rpm.sh
@@ -49,8 +49,12 @@ detect_os ()
   if [[ ( -z "${os}" ) && ( -z "${dist}" ) ]]; then
     if [ -e /etc/os-release ]; then
       . /etc/os-release
-      dist=`echo ${VERSION_ID} | awk -F '.' '{ print $1 }'`
       os=${ID}
+      if [ "${os}" = "poky" ]; then
+        dist=`echo ${VERSION_ID}`
+      else
+        dist=`echo ${VERSION_ID} | awk -F '.' '{ print $1 }'`
+      fi
 
     elif [ `which lsb_release 2>/dev/null` ]; then
       # get major version (e.g. '5' or '6')

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -32,9 +32,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-9.5..."
-  if apt-cache show postgresql-9.5 &> /dev/null; then
-    echo "Detected postgresql-9.5..."
+  echo "Checking for postgresql-9.6..."
+  if apt-cache show postgresql-9.6 &> /dev/null; then
+    echo "Detected postgresql-9.6..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/community/rpm.sh
+++ b/community/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql95-server..."
-  if yum list -q postgresql95-server &> /dev/null; then
-    echo "Detected postgresql95-server..."
+  echo "Checking for postgresql96-server..."
+  if yum list -q postgresql96-server &> /dev/null; then
+    echo "Detected postgresql96-server..."
   else
-    echo -n "Installing pgdg95 repo... "
+    echo -n "Installing pgdg96 repo... "
 
     yum install -d0 -e0 -y "${repo_url}"
     echo "done."
@@ -113,7 +113,7 @@ detect_repo_url ()
   family_short='rhel'
   pkg_dist="${dist}"
   pkg_os="${os}"
-  pkg_version='2'
+  pkg_version='3'
 
   case "${os}" in
     amzn)
@@ -132,7 +132,6 @@ detect_repo_url ()
     fedora)
       family='fedora'
       family_short='fedora'
-      pkg_version='3'
       ;;
     centos)
       # defaults are suitable
@@ -145,9 +144,9 @@ detect_repo_url ()
       ;;
   esac
 
-  repo_url="https://download.postgresql.org/pub/repos/yum/9.5/${family}"
+  repo_url="https://download.postgresql.org/pub/repos/yum/9.6/${family}"
   repo_url+="/${family_short}-${pkg_dist}-x86_64"
-  repo_url+="/pgdg-${pkg_os}95-9.5-${pkg_version}.noarch.rpm"
+  repo_url+="/pgdg-${pkg_os}96-9.6-${pkg_version}.noarch.rpm"
 }
 
 main ()

--- a/community/rpm.sh
+++ b/community/rpm.sh
@@ -49,8 +49,12 @@ detect_os ()
   if [[ ( -z "${os}" ) && ( -z "${dist}" ) ]]; then
     if [ -e /etc/os-release ]; then
       . /etc/os-release
-      dist=`echo ${VERSION_ID} | awk -F '.' '{ print $1 }'`
       os=${ID}
+      if [ "${os}" = "poky" ]; then
+        dist=`echo ${VERSION_ID}`
+      else
+        dist=`echo ${VERSION_ID} | awk -F '.' '{ print $1 }'`
+      fi
 
     elif [ `which lsb_release 2>/dev/null` ]; then
       # get major version (e.g. '5' or '6')

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -32,9 +32,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-9.5..."
-  if apt-cache show postgresql-9.5 &> /dev/null; then
-    echo "Detected postgresql-9.5..."
+  echo "Checking for postgresql-9.6..."
+  if apt-cache show postgresql-9.6 &> /dev/null; then
+    echo "Detected postgresql-9.6..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -79,8 +79,12 @@ detect_os ()
   if [[ ( -z "${os}" ) && ( -z "${dist}" ) ]]; then
     if [ -e /etc/os-release ]; then
       . /etc/os-release
-      dist=`echo ${VERSION_ID} | awk -F '.' '{ print $1 }'`
       os=${ID}
+      if [ "${os}" = "poky" ]; then
+        dist=`echo ${VERSION_ID}`
+      else
+        dist=`echo ${VERSION_ID} | awk -F '.' '{ print $1 }'`
+      fi
 
     elif [ `which lsb_release 2>/dev/null` ]; then
       # get major version (e.g. '5' or '6')

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql95-server..."
-  if yum list -q postgresql95-server &> /dev/null; then
-    echo "Detected postgresql95-server..."
+  echo "Checking for postgresql96-server..."
+  if yum list -q postgresql96-server &> /dev/null; then
+    echo "Detected postgresql96-server..."
   else
-    echo -n "Installing pgdg95 repo... "
+    echo -n "Installing pgdg96 repo... "
 
     yum install -d0 -e0 -y "${repo_url}"
     echo "done."
@@ -143,7 +143,7 @@ detect_repo_url ()
   family_short='rhel'
   pkg_dist="${dist}"
   pkg_os="${os}"
-  pkg_version='2'
+  pkg_version='3'
 
   case "${os}" in
     amzn)
@@ -162,7 +162,6 @@ detect_repo_url ()
     fedora)
       family='fedora'
       family_short='fedora'
-      pkg_version='3'
       ;;
     centos)
       # defaults are suitable
@@ -175,9 +174,9 @@ detect_repo_url ()
       ;;
   esac
 
-  repo_url="https://download.postgresql.org/pub/repos/yum/9.5/${family}"
+  repo_url="https://download.postgresql.org/pub/repos/yum/9.6/${family}"
   repo_url+="/${family_short}-${pkg_dist}-x86_64"
-  repo_url+="/pgdg-${pkg_os}95-9.5-${pkg_version}.noarch.rpm"
+  repo_url+="/pgdg-${pkg_os}96-9.6-${pkg_version}.noarch.rpm"
 }
 
 main ()

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -32,9 +32,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-9.5..."
-  if apt-cache show postgresql-9.5 &> /dev/null; then
-    echo "Detected postgresql-9.5..."
+  echo "Checking for postgresql-9.6..."
+  if apt-cache show postgresql-9.6 &> /dev/null; then
+    echo "Detected postgresql-9.6..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -79,8 +79,12 @@ detect_os ()
   if [[ ( -z "${os}" ) && ( -z "${dist}" ) ]]; then
     if [ -e /etc/os-release ]; then
       . /etc/os-release
-      dist=`echo ${VERSION_ID} | awk -F '.' '{ print $1 }'`
       os=${ID}
+      if [ "${os}" = "poky" ]; then
+        dist=`echo ${VERSION_ID}`
+      else
+        dist=`echo ${VERSION_ID} | awk -F '.' '{ print $1 }'`
+      fi
 
     elif [ `which lsb_release 2>/dev/null` ]; then
       # get major version (e.g. '5' or '6')

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql95-server..."
-  if yum list -q postgresql95-server &> /dev/null; then
-    echo "Detected postgresql95-server..."
+  echo "Checking for postgresql96-server..."
+  if yum list -q postgresql96-server &> /dev/null; then
+    echo "Detected postgresql96-server..."
   else
-    echo -n "Installing pgdg95 repo... "
+    echo -n "Installing pgdg96 repo... "
 
     yum install -d0 -e0 -y "${repo_url}"
     echo "done."
@@ -143,7 +143,7 @@ detect_repo_url ()
   family_short='rhel'
   pkg_dist="${dist}"
   pkg_os="${os}"
-  pkg_version='2'
+  pkg_version='3'
 
   case "${os}" in
     amzn)
@@ -162,7 +162,6 @@ detect_repo_url ()
     fedora)
       family='fedora'
       family_short='fedora'
-      pkg_version='3'
       ;;
     centos)
       # defaults are suitable
@@ -175,9 +174,9 @@ detect_repo_url ()
       ;;
   esac
 
-  repo_url="https://download.postgresql.org/pub/repos/yum/9.5/${family}"
+  repo_url="https://download.postgresql.org/pub/repos/yum/9.6/${family}"
   repo_url+="/${family_short}-${pkg_dist}-x86_64"
-  repo_url+="/pgdg-${pkg_os}95-9.5-${pkg_version}.noarch.rpm"
+  repo_url+="/pgdg-${pkg_os}96-9.6-${pkg_version}.noarch.rpm"
 }
 
 main ()


### PR DESCRIPTION
This also (implicitly) removes support for the sunset Fedora 22 distro, as PostgreSQL itself no longer supports that distro. As it was the only
distro with a package release other than '3', that block was simplified somewhat by the change.
