### PR TITLE
Bump RPM URLs to latest release

### DIFF
--- a/community-nightlies/rpm.sh
+++ b/community-nightlies/rpm.sh
@@ -109,7 +109,7 @@ detect_repo_url ()
   family_short='rhel'
   pkg_dist="${dist}"
   pkg_os="${os}"
-  pkg_version='2'
+  pkg_version='3'
 
   case "${os}" in
     amzn)
@@ -128,7 +128,7 @@ detect_repo_url ()
     fedora)
       family='fedora'
       family_short='fedora'
-      pkg_version='3'
+      pkg_version='4'
       ;;
     centos)
       # defaults are suitable

--- a/community/rpm.sh
+++ b/community/rpm.sh
@@ -109,7 +109,7 @@ detect_repo_url ()
   family_short='rhel'
   pkg_dist="${dist}"
   pkg_os="${os}"
-  pkg_version='2'
+  pkg_version='3'
 
   case "${os}" in
     amzn)
@@ -128,7 +128,7 @@ detect_repo_url ()
     fedora)
       family='fedora'
       family_short='fedora'
-      pkg_version='3'
+      pkg_version='4'
       ;;
     centos)
       # defaults are suitable

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -139,7 +139,7 @@ detect_repo_url ()
   family_short='rhel'
   pkg_dist="${dist}"
   pkg_os="${os}"
-  pkg_version='2'
+  pkg_version='3'
 
   case "${os}" in
     amzn)
@@ -158,7 +158,7 @@ detect_repo_url ()
     fedora)
       family='fedora'
       family_short='fedora'
-      pkg_version='3'
+      pkg_version='4'
       ;;
     centos)
       # defaults are suitable

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -139,7 +139,7 @@ detect_repo_url ()
   family_short='rhel'
   pkg_dist="${dist}"
   pkg_os="${os}"
-  pkg_version='2'
+  pkg_version='3'
 
   case "${os}" in
     amzn)
@@ -158,7 +158,7 @@ detect_repo_url ()
     fedora)
       family='fedora'
       family_short='fedora'
-      pkg_version='3'
+      pkg_version='4'
       ;;
     centos)
       # defaults are suitable


### PR DESCRIPTION
They've been modified in the past month, might as well have the latest versions in case the old
ones are summarily yanked (possible).
