### PR TITLE
Bump RPM URLs in nightly scripts to 9.6 versions

### DIFF
--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -32,9 +32,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-9.5..."
-  if apt-cache show postgresql-9.5 &> /dev/null; then
-    echo "Detected postgresql-9.5..."
+  echo "Checking for postgresql-9.6..."
+  if apt-cache show postgresql-9.6 &> /dev/null; then
+    echo "Detected postgresql-9.6..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/community-nightlies/rpm.sh
+++ b/community-nightlies/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql95-server..."
-  if yum list -q postgresql95-server &> /dev/null; then
-    echo "Detected postgresql95-server..."
+  echo "Checking for postgresql96-server..."
+  if yum list -q postgresql96-server &> /dev/null; then
+    echo "Detected postgresql96-server..."
   else
-    echo -n "Installing pgdg95 repo... "
+    echo -n "Installing pgdg96 repo... "
 
     yum install -d0 -e0 -y "${repo_url}"
     echo "done."
@@ -125,6 +125,7 @@ detect_repo_url ()
       # use 2015.03 pgdg repo for all recent Amazon instances
       pkg_dist=6
       pkg_os='ami201503-'
+      pkg_version='2'
       ;;
     ol)
       pkg_os='oraclelinux'
@@ -132,7 +133,6 @@ detect_repo_url ()
     fedora)
       family='fedora'
       family_short='fedora'
-      pkg_version='4'
       ;;
     centos)
       # defaults are suitable
@@ -145,9 +145,9 @@ detect_repo_url ()
       ;;
   esac
 
-  repo_url="https://download.postgresql.org/pub/repos/yum/9.5/${family}"
+  repo_url="https://download.postgresql.org/pub/repos/yum/9.6/${family}"
   repo_url+="/${family_short}-${pkg_dist}-x86_64"
-  repo_url+="/pgdg-${pkg_os}95-9.5-${pkg_version}.noarch.rpm"
+  repo_url+="/pgdg-${pkg_os}96-9.6-${pkg_version}.noarch.rpm"
 }
 
 main ()

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -32,9 +32,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-9.5..."
-  if apt-cache show postgresql-9.5 &> /dev/null; then
-    echo "Detected postgresql-9.5..."
+  echo "Checking for postgresql-9.6..."
+  if apt-cache show postgresql-9.6 &> /dev/null; then
+    echo "Detected postgresql-9.6..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql95-server..."
-  if yum list -q postgresql95-server &> /dev/null; then
-    echo "Detected postgresql95-server..."
+  echo "Checking for postgresql96-server..."
+  if yum list -q postgresql96-server &> /dev/null; then
+    echo "Detected postgresql96-server..."
   else
-    echo -n "Installing pgdg95 repo... "
+    echo -n "Installing pgdg96 repo... "
 
     yum install -d0 -e0 -y "${repo_url}"
     echo "done."
@@ -155,6 +155,7 @@ detect_repo_url ()
       # use 2015.03 pgdg repo for all recent Amazon instances
       pkg_dist=6
       pkg_os='ami201503-'
+      pkg_version='2'
       ;;
     ol)
       pkg_os='oraclelinux'
@@ -162,7 +163,6 @@ detect_repo_url ()
     fedora)
       family='fedora'
       family_short='fedora'
-      pkg_version='4'
       ;;
     centos)
       # defaults are suitable
@@ -175,9 +175,9 @@ detect_repo_url ()
       ;;
   esac
 
-  repo_url="https://download.postgresql.org/pub/repos/yum/9.5/${family}"
+  repo_url="https://download.postgresql.org/pub/repos/yum/9.6/${family}"
   repo_url+="/${family_short}-${pkg_dist}-x86_64"
-  repo_url+="/pgdg-${pkg_os}95-9.5-${pkg_version}.noarch.rpm"
+  repo_url+="/pgdg-${pkg_os}96-9.6-${pkg_version}.noarch.rpm"
 }
 
 main ()


### PR DESCRIPTION
Since we now have 9.6 nightlies, might as well give people access to PostgreSQL 9.6 when they add the nightly repositories.
