### PR TITLE
Add new "fancy" versioning mode

### DIFF
--- a/dockerfiles/centos-6-pg94/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-6-pg94/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/centos-6-pg95/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-6-pg95/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/centos-6-pg96/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-6-pg96/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/centos-7-pg94/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg94/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/centos-7-pg95/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg95/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/centos-7-pg96/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg96/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/debian-jessie-all/Dockerfile
+++ b/dockerfiles/debian-jessie-all/Dockerfile
@@ -17,8 +17,10 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
         libdistro-info-perl \
         libedit-dev \
         libfile-fcntllock-perl \
+        libkrb5-dev \
         libpam0g-dev \
         libselinux1-dev \
+        libssl-dev \
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \

--- a/dockerfiles/debian-jessie-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-jessie-all/scripts/fetch_and_build_deb
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -144,7 +145,12 @@ cd "${packagepath}"
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            suffix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+')
+            sed -i "/^Package:/ s/$/-${suffix}/" debian/control.in
+            sed -i "/postgresql-%v-${pkgname}/ s/$/-${suffix}/" debian/rules
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/debian-wheezy-all/Dockerfile
+++ b/dockerfiles/debian-wheezy-all/Dockerfile
@@ -17,8 +17,10 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
         libdistro-info-perl \
         libedit-dev \
         libfile-fcntllock-perl \
+        libkrb5-dev \
         libpam0g-dev \
         libselinux1-dev \
+        libssl-dev \
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \

--- a/dockerfiles/debian-wheezy-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-wheezy-all/scripts/fetch_and_build_deb
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -144,7 +145,12 @@ cd "${packagepath}"
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            suffix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+')
+            sed -i "/^Package:/ s/$/-${suffix}/" debian/control.in
+            sed -i "/postgresql-%v-${pkgname}/ s/$/-${suffix}/" debian/rules
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/fedora-23-pg94/scripts/fetch_and_build_rpm
+++ b/dockerfiles/fedora-23-pg94/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/fedora-23-pg95/scripts/fetch_and_build_rpm
+++ b/dockerfiles/fedora-23-pg95/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/fedora-23-pg96/scripts/fetch_and_build_rpm
+++ b/dockerfiles/fedora-23-pg96/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/fedora-24-pg94/scripts/fetch_and_build_rpm
+++ b/dockerfiles/fedora-24-pg94/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/fedora-24-pg95/scripts/fetch_and_build_rpm
+++ b/dockerfiles/fedora-24-pg95/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/fedora-24-pg96/scripts/fetch_and_build_rpm
+++ b/dockerfiles/fedora-24-pg96/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/oraclelinux-6-pg94/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg94/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/oraclelinux-6-pg95/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg95/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/oraclelinux-6-pg96/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg96/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/oraclelinux-7-pg94/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg94/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/oraclelinux-7-pg95/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg95/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/oraclelinux-7-pg96/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg96/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/ubuntu-precise-all/Dockerfile
+++ b/dockerfiles/ubuntu-precise-all/Dockerfile
@@ -17,8 +17,10 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
         libdistro-info-perl \
         libedit-dev \
         libfile-fcntllock-perl \
+        libkrb5-dev \
         libpam0g-dev \
         libselinux1-dev \
+        libssl-dev \
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \

--- a/dockerfiles/ubuntu-precise-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-precise-all/scripts/fetch_and_build_deb
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -144,7 +145,12 @@ cd "${packagepath}"
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            suffix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+')
+            sed -i "/^Package:/ s/$/-${suffix}/" debian/control.in
+            sed -i "/postgresql-%v-${pkgname}/ s/$/-${suffix}/" debian/rules
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/ubuntu-trusty-all/Dockerfile
+++ b/dockerfiles/ubuntu-trusty-all/Dockerfile
@@ -17,8 +17,10 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
         libdistro-info-perl \
         libedit-dev \
         libfile-fcntllock-perl \
+        libkrb5-dev \
         libpam0g-dev \
         libselinux1-dev \
+        libssl-dev \
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \

--- a/dockerfiles/ubuntu-trusty-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-trusty-all/scripts/fetch_and_build_deb
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -144,7 +145,12 @@ cd "${packagepath}"
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            suffix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+')
+            sed -i "/^Package:/ s/$/-${suffix}/" debian/control.in
+            sed -i "/postgresql-%v-${pkgname}/ s/$/-${suffix}/" debian/rules
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/dockerfiles/ubuntu-xenial-all/Dockerfile
+++ b/dockerfiles/ubuntu-xenial-all/Dockerfile
@@ -17,8 +17,10 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
         libdistro-info-perl \
         libedit-dev \
         libfile-fcntllock-perl \
+        libkrb5-dev \
         libpam0g-dev \
         libselinux1-dev \
+        libssl-dev \
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \

--- a/dockerfiles/ubuntu-xenial-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-xenial-all/scripts/fetch_and_build_deb
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -144,7 +145,12 @@ cd "${packagepath}"
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            suffix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+')
+            sed -i "/^Package:/ s/$/-${suffix}/" debian/control.in
+            sed -i "/postgresql-%v-${pkgname}/ s/$/-${suffix}/" debian/rules
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -144,7 +145,12 @@ cd "${packagepath}"
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            suffix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+')
+            sed -i "/^Package:/ s/$/-${suffix}/" debian/control.in
+            sed -i "/postgresql-%v-${pkgname}/ s/$/-${suffix}/" debian/rules
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/scripts/fetch_and_build_rpm
+++ b/scripts/fetch_and_build_rpm
@@ -56,6 +56,7 @@ hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.5,9.6}"
 nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -158,7 +159,11 @@ fi
 
 case "${1}" in
     release)
-        # nothing to do
+        # add minor/major version to package name if using fancy versioning
+        if [ "${versioning}" == 'fancy' ]; then
+            infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+            sed -i -E "1i %global pkginfix ${infix}" "${builddir}/${pkgname}.spec"
+        fi
         ;;
     nightly)
         msg="Nightly package. Built from ${nightlyref} "

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -17,8 +17,10 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
         libdistro-info-perl \
         libedit-dev \
         libfile-fcntllock-perl \
+        libkrb5-dev \
         libpam0g-dev \
         libselinux1-dev \
+        libssl-dev \
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \


### PR DESCRIPTION
If a package contains a _versioning_ variable set to _fancy_, then it will have the first two portions of its version 'baked into' its package name. For instance, Citus 6.1 would be `postgresql-9.6-citus` under the _simple_ mode, or `postgresql-9.6-citus-6.1` under _fancy_ mode. For an RPM, the version is infixed without a period, such as in `citus61_96`