### PR TITLE
Switch to 'fancy' versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - export PATH="$(pwd)/tools/packaging:$PATH"
   - export PACKAGING_SECRET_KEY="$(openssl aes-256-cbc -K $encrypted_a39e3f1ee8ba_key -iv $encrypted_a39e3f1ee8ba_iv -in signing_key.asc.enc -d | base64)"
 install: true
-script: build_new_release && build_new_nightly
+script: build_new_release # && build_new_nightly
 deploy:
   - provider: packagecloud
     username: "citusdata"

--- a/citus.spec
+++ b/citus.spec
@@ -4,9 +4,12 @@
 %global sname citus
 
 Summary:	PostgreSQL-based distributed RDBMS
-Name:		%{sname}_%{pgmajorversion}
+Name:		%{sname}%{?pkginfix}_%{pgmajorversion}
+Provides:	%{sname}_%{pgmajorversion}
+Conflicts:	%{sname}_%{pgmajorversion}
+Obsoletes:	%{sname}_%{pgmajorversion} <= 6.0.1.citus-1%{dist}
 Version:	6.0.1.citus
-Release:	1%{dist}
+Release:	2%{dist}
 License:	AGPLv3
 Group:		Applications/Databases
 Source0:	https://github.com/citusdata/citus/archive/v6.0.1.tar.gz
@@ -61,6 +64,9 @@ make %{?_smp_mflags}
 %{pginstdir}/share/extension/%{sname}.control
 
 %changelog
+* Wed Feb 8 2017 - Jason Petersen <jason@citusdata.com> 6.0.1.citus-2
+- Transitional package to guide users to new package name
+
 * Wed Nov 30 2016 - Burak Yucesoy <burak@citusdata.com> 6.0.1.citus-1
 - Update to Citus 6.0.1
 

--- a/pkgvars
+++ b/pkgvars
@@ -1,4 +1,5 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
-pkglatest=6.0.1.citus-1
+pkglatest=6.0.1.citus-2
 releasepg=9.5,9.6
+versioning=fancy

--- a/rpmlintrc
+++ b/rpmlintrc
@@ -2,6 +2,8 @@ addFilter("E: binary-or-shlib-defines-rpath .*");
 addFilter("W: devel-file-in-non-devel-package .*");
 addFilter("W: incoherent-version-in-changelog .*el7");
 addFilter("W: no-soname .*");
+addFilter("W: self-obsoletion .*");
+addFilter("W: useless-provides .*");
 addFilter("W: non-standard-dir-in-usr .*");
 addFilter("W: shared-lib-calls-exit .*");
 addFilter("W: spelling-error .*(itus|datasets|parallelizes|sharding)");


### PR DESCRIPTION
I'm not 100% sure whether a self-conflicting package is best in the RPM world, but despite the warning everything seems to work well.

Merging this will release `citus60_95` and `citus60_96`. The version will be `6.0.1.citus-2` and existing Citus users will be auto-upgraded. This and all subsequent 'fancy' version packages will conflict with one another, ensuring two versions cannot be installed at the same time.