### PR TITLE
Switch to 'fancy' versioning for Citus debs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - export PATH="$(pwd)/tools/packaging:$PATH"
   - export PACKAGING_SECRET_KEY="$(openssl aes-256-cbc -K $encrypted_a39e3f1ee8ba_key -iv $encrypted_a39e3f1ee8ba_iv -in signing_key.asc.enc -d | base64)"
 install: true
-script: build_new_release && build_new_nightly
+script: build_new_release # && build_new_nightly
 deploy:
   - provider: packagecloud
     username: "citusdata"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+citus (6.0.1.citus-3) stable; urgency=low
+
+  * First build using new versioning practices
+
+ -- Jason Petersen <jason@citusdata.com>  Wed, 8 Feb 2017 23:19:46 +0000
+
+citus (6.0.1.citus-2) stable; urgency=low
+
+  * Transitional package to guide users to new package name
+
+ -- Jason Petersen <jason@citusdata.com>  Mon, 6 Feb 2017 16:33:44 +0000
+
 citus (6.0.1.citus-1) stable; urgency=low
 
   * Fixes a bug causing failures during pg_upgrade

--- a/debian/control.in
+++ b/debian/control.in
@@ -11,6 +11,9 @@ XS-Testsuite: autopkgtest
 Package: postgresql-PGVERSION-citus
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-PGVERSION
+Provides: postgresql-PGVERSION-citus
+Conflicts: postgresql-PGVERSION-citus
+Replaces: postgresql-PGVERSION-citus (<< 6.0.1.citus-2~)
 Description: sharding and distributed joins for PostgreSQL
  Citus is a distributed database implemented as a PostgreSQL extension. It
  provides functions to easily split a PostgreSQL table into shards to be

--- a/debian/postgresql-9.5-citus.lintian-overrides
+++ b/debian/postgresql-9.5-citus.lintian-overrides
@@ -1,1 +1,1 @@
-postgresql-9.5-citus binary: new-package-should-close-itp-bug
+postgresql-9.5-citus-6.0 binary: new-package-should-close-itp-bug

--- a/debian/postgresql-9.6-citus.lintian-overrides
+++ b/debian/postgresql-9.6-citus.lintian-overrides
@@ -1,1 +1,1 @@
-postgresql-9.6-citus binary: new-package-should-close-itp-bug
+postgresql-9.6-citus-6.0 binary: new-package-should-close-itp-bug

--- a/pkgvars
+++ b/pkgvars
@@ -1,4 +1,5 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
-pkglatest=6.0.1.citus-1
+pkglatest=6.0.1.citus-3
 releasepg=9.5,9.6
+versioning=fancy


### PR DESCRIPTION
Merging will release `postgresql-9.5-citus-6.0`/`postgresql-9.5-citus-6.0`. The version will be `6.0.1.citus-3` and existing Citus users can easily upgrade with an `apt-get dist-upgrade` command (so long as we remember to add the `6.0.1.citus-2` transitional package to our repository). All subsequent 'fancy' version packages will conflict with one another, ensuring two versions cannot be installed at the same time.