### PR TITLE
Switch to 'fancy' versioning for Debian Enterprise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - export PATH="$(pwd)/tools/packaging:$PATH"
   - export PACKAGING_SECRET_KEY="$(openssl aes-256-cbc -K $encrypted_a39e3f1ee8ba_key -iv $encrypted_a39e3f1ee8ba_iv -in signing_key.asc.enc -d | base64)"
 install: true
-script: build_new_release && # build_new_nightly
+script: build_new_release # && build_new_nightly
 deploy:
   - provider: packagecloud
     username: "citusdata"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - export PATH="$(pwd)/tools/packaging:$PATH"
   - export PACKAGING_SECRET_KEY="$(openssl aes-256-cbc -K $encrypted_a39e3f1ee8ba_key -iv $encrypted_a39e3f1ee8ba_iv -in signing_key.asc.enc -d | base64)"
 install: true
-script: build_new_release && build_new_nightly
+script: build_new_release && # build_new_nightly
 deploy:
   - provider: packagecloud
     username: "citusdata"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+citus-enterprise (6.0.1.citus-3) stable; urgency=low
+
+  * First build using new versioning practices
+
+ -- Burak Yucesoy <burak@citusdata.com>  Fri, 10 Feb 2017 17:10:22 +0000
+
+citus-enterprise (6.0.1.citus-2) stable; urgency=low
+
+  * Transitional package to guide users to new package name
+
+ -- Burak Yucesoy <burak@citusdata.com>  Fri, 10 Feb 2017 17:05:34 +0000
+
 citus-enterprise (6.0.1.citus-1) stable; urgency=low
 
   * Fixes a bug causing failures during pg_upgrade

--- a/debian/control.in
+++ b/debian/control.in
@@ -3,7 +3,7 @@ Section: database
 Priority: optional
 Maintainer: Citus Data <packaging@citusdata.com>
 Uploaders: Jason Petersen <jason@citusdata.com>
-Build-Depends: debhelper (>= 9), autotools-dev, postgresql-server-dev-all (>= 158~)
+Build-Depends: debhelper (>= 9), autotools-dev, postgresql-server-dev-all (>= 158~), libedit-dev, libpam0g-dev, libselinux1-dev, libxslt1-dev, libssl-dev
 Standards-Version: 3.9.7
 Homepage: https://github.com/citusdata/citus-enterprise
 XS-Testsuite: autopkgtest
@@ -11,8 +11,9 @@ XS-Testsuite: autopkgtest
 Package: postgresql-PGVERSION-citus-enterprise
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-PGVERSION
+Provides: postgresql-PGVERSION-citus
 Conflicts: postgresql-PGVERSION-citus
-Replaces: postgresql-PGVERSION-citus
+Replaces: postgresql-PGVERSION-citus-enterprise (<< 6.0.1.citus-2~)
 Description: sharding and distributed joins for PostgreSQL
  Citus is a distributed database implemented as a PostgreSQL extension. It
  provides functions to easily split a PostgreSQL table into shards to be

--- a/pkgvars
+++ b/pkgvars
@@ -1,5 +1,6 @@
 pkgname=citus-enterprise
 pkgdesc='Citus Enterprise'
-pkglatest=6.0.1.citus-1
+pkglatest=6.0.1.citus-3
 releasepg=9.5,9.6
 nightlyref=enterprise-master
+versioning=fancy


### PR DESCRIPTION
Similar to community edition, we switch 'fancy' versioning in enterprise
repos.

Merging will release postgresql-9.5-citus-enterprise-6.0 and
postgresql-9.5-citus-enterprise-6.0. The version will be 6.0.1.citus-3 and
existing Citus users can easily upgrade with an apt-get dist-upgrade command
(so long as we remember to add the 6.0.1.citus-2 transitional package to our
repository). All sub-sequent 'fancy' version packages will conflict with one
another, ensuring two versions cannot be installed at the same time