### PR TITLE
Bump Redhat Citus Enterprise to 6.1.1

### DIFF
--- a/citus-enterprise.spec
+++ b/citus-enterprise.spec
@@ -7,11 +7,11 @@ Summary:	PostgreSQL-based distributed RDBMS
 Name:		%{sname}%{?pkginfix}_%{pgmajorversion}
 Provides:	citus_%{pgmajorversion}
 Conflicts:	citus_%{pgmajorversion}
-Version:	6.1.0.citus
+Version:	6.1.1.citus
 Release:	1%{dist}
 License:	AGPLv3
 Group:		Applications/Databases
-Source0:	https://github.com/citusdata/citus-enterprise/archive/v6.1.0.tar.gz
+Source0:	https://github.com/citusdata/citus-enterprise/archive/v6.1.1.tar.gz
 URL:		https://github.com/citusdata/citus-enterprise
 BuildRequires:	postgresql%{pgmajorversion}-devel
 Requires:	postgresql%{pgmajorversion}-server
@@ -63,6 +63,9 @@ make %{?_smp_mflags}
 %{pginstdir}/share/extension/citus.control
 
 %changelog
+* Wed May 10 2017 - Metin Doslu <metin@citusdata.com> 6.1.1.citus-1
+- Update to Citus Enterprise 6.1.1
+
 * Fri Feb 10 2017 - Jason Petersen <jason@citusdata.com> 6.1.0.citus-1
 - Update to Citus Enterprise 6.1.0
 

--- a/pkgvars
+++ b/pkgvars
@@ -1,6 +1,6 @@
 pkgname=citus-enterprise
 pkgdesc='Citus Enterprise'
-pkglatest=6.1.0.citus-1
+pkglatest=6.1.1.citus-1
 releasepg=9.5,9.6
 nightlyref=enterprise-master
 versioning=fancy


### PR DESCRIPTION
Produces 6.1.1 release.