### PR TITLE
Bump Citus Debian to 6.2.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+citus (6.2.1.citus-1) stable; urgency=low
+
+  * Relaxes version-check logic to avoid breaking non-distributed commands
+
+ -- Jason Petersen <jason@citusdata.com>  Wed, 24 May 2017 22:36:07 +0000
+
 citus (6.2.0.citus-1) stable; urgency=low
 
   * Increases SQL subquery coverage by pushing down more kinds of queries

--- a/debian/postgresql-9.5-citus.lintian-overrides
+++ b/debian/postgresql-9.5-citus.lintian-overrides
@@ -1,1 +1,1 @@
-postgresql-9.5-citus binary: new-package-should-close-itp-bug
+new-package-should-close-itp-bug

--- a/debian/postgresql-9.6-citus.lintian-overrides
+++ b/debian/postgresql-9.6-citus.lintian-overrides
@@ -1,1 +1,1 @@
-postgresql-9.6-citus binary: new-package-should-close-itp-bug
+new-package-should-close-itp-bug

--- a/pkgvars
+++ b/pkgvars
@@ -1,5 +1,5 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
-pkglatest=6.2.0.citus-1
+pkglatest=6.2.1.citus-1
 releasepg=9.5,9.6
 versioning=fancy


### PR DESCRIPTION
Also stripped off the prefix in the lintian overrides as it turns out
they are unnecessary.