### PR TITLE
Bump Citus Enterprise Debian to 6.2.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+citus-enterprise (6.2.1.citus-1) stable; urgency=low
+
+  * Relaxes version-check logic to avoid breaking non-distributed commands
+
+ -- Jason Petersen <jason@citusdata.com>  Wed, 24 May 2017 22:36:07 +0000
+
 citus-enterprise (6.2.0.citus-1) stable; urgency=low
 
   * Increases SQL subquery coverage by pushing down more kinds of queries

--- a/debian/postgresql-9.5-citus-enterprise.lintian-overrides
+++ b/debian/postgresql-9.5-citus-enterprise.lintian-overrides
@@ -1,2 +1,2 @@
-postgresql-9.5-citus-enterprise binary: new-package-should-close-itp-bug
-postgresql-9.5-citus-enterprise binary: package-has-long-file-name
+new-package-should-close-itp-bug
+package-has-long-file-name

--- a/debian/postgresql-9.6-citus-enterprise.lintian-overrides
+++ b/debian/postgresql-9.6-citus-enterprise.lintian-overrides
@@ -1,2 +1,2 @@
-postgresql-9.6-citus-enterprise binary: new-package-should-close-itp-bug
-postgresql-9.6-citus-enterprise binary: package-has-long-file-name
+new-package-should-close-itp-bug
+package-has-long-file-name

--- a/pkgvars
+++ b/pkgvars
@@ -1,6 +1,6 @@
 pkgname=citus-enterprise
 pkgdesc='Citus Enterprise'
-pkglatest=6.2.0.citus-1
+pkglatest=6.2.1.citus-1
 releasepg=9.5,9.6
 nightlyref=enterprise-master
 versioning=fancy


### PR DESCRIPTION
Also stripped off the prefix in the lintian overrides as it turns out
they are unnecessary.