### PR TITLE
Bump Citus Debian to 6.2.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+citus (6.2.2.citus-1) stable; urgency=low
+
+  * Fixes a common cause of deadlocks when repairing tables with foreign keys
+
+ -- Burak Velioglu <velioglub@citusdata.com>  Wed, 07 Jun 2017 09:42:17 +0000
+
 citus (6.2.1.citus-1) stable; urgency=low
 
   * Relaxes version-check logic to avoid breaking non-distributed commands

--- a/pkgvars
+++ b/pkgvars
@@ -1,5 +1,5 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
-pkglatest=6.2.1.citus-1
+pkglatest=6.2.2.citus-1
 releasepg=9.5,9.6
 versioning=fancy


### PR DESCRIPTION
Changes to bump Citus Debian version to 6.2.2