### PR TITLE
Bump Citus Redhat to 6.2.2

### DIFF
--- a/citus.spec
+++ b/citus.spec
@@ -7,11 +7,11 @@ Summary:	PostgreSQL-based distributed RDBMS
 Name:		%{sname}%{?pkginfix}_%{pgmajorversion}
 Provides:	%{sname}_%{pgmajorversion}
 Conflicts:	%{sname}_%{pgmajorversion}
-Version:	6.2.1.citus
+Version:	6.2.2.citus
 Release:	1%{dist}
 License:	AGPLv3
 Group:		Applications/Databases
-Source0:	https://github.com/citusdata/citus/archive/v6.2.1.tar.gz
+Source0:	https://github.com/citusdata/citus/archive/v6.2.2.tar.gz
 URL:		https://github.com/citusdata/citus
 BuildRequires:	postgresql%{pgmajorversion}-devel
 Requires:	postgresql%{pgmajorversion}-server
@@ -63,6 +63,9 @@ make %{?_smp_mflags}
 %{pginstdir}/share/extension/%{sname}.control
 
 %changelog
+* Wed Jun 7 2017 - Burak Velioglu <velioglub@citusdata.com> 6.2.2.citus-1
+- Update to Citus 6.2.2
+
 * Wed May 24 2017 - Jason Petersen <jason@citusdata.com> 6.2.1.citus-1
 - Update to Citus 6.2.1
 

--- a/pkgvars
+++ b/pkgvars
@@ -1,5 +1,5 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
-pkglatest=6.2.1.citus-1
+pkglatest=6.2.2.citus-1
 releasepg=9.5,9.6
 versioning=fancy


### PR DESCRIPTION
Changes to bump Citus Redhat version to 6.2.2