### PR TITLE
Bump Redhat Citus Enterprise to 6.2.2

### DIFF
--- a/citus-enterprise.spec
+++ b/citus-enterprise.spec
@@ -7,11 +7,11 @@ Summary:	PostgreSQL-based distributed RDBMS
 Name:		%{sname}%{?pkginfix}_%{pgmajorversion}
 Provides:	citus_%{pgmajorversion}
 Conflicts:	citus_%{pgmajorversion}
-Version:	6.1.2.citus
+Version:	6.2.2.citus
 Release:	1%{dist}
 License:	AGPLv3
 Group:		Applications/Databases
-Source0:	https://github.com/citusdata/citus-enterprise/archive/v6.1.2.tar.gz
+Source0:	https://github.com/citusdata/citus-enterprise/archive/v6.2.2.tar.gz
 URL:		https://github.com/citusdata/citus-enterprise
 BuildRequires:	postgresql%{pgmajorversion}-devel
 Requires:	postgresql%{pgmajorversion}-server
@@ -63,6 +63,9 @@ make %{?_smp_mflags}
 %{pginstdir}/share/extension/citus.control
 
 %changelog
+* Thu Jun 8 2017 - Burak Velioglu <velioglub@citusdata.com> 6.2.2.citus-1
+- Update to Citus Enterprise 6.2.2
+
 * Wed May 31 2017 - Jason Petersen <jason@citusdata.com> 6.1.2.citus-1
 - Update to Citus Enterprise 6.1.2
 

--- a/pkgvars
+++ b/pkgvars
@@ -1,6 +1,6 @@
 pkgname=citus-enterprise
 pkgdesc='Citus Enterprise'
-pkglatest=6.1.2.citus-1
+pkglatest=6.2.2.citus-1
 releasepg=9.5,9.6
 nightlyref=enterprise-master
 versioning=fancy


### PR DESCRIPTION
Changes to bump Redhat Citus Enterprise version to 6.2.2