### PR TITLE
Add gnupg2 to Debian builds

### DIFF
--- a/dockerfiles/debian-jessie-all/Dockerfile
+++ b/dockerfiles/debian-jessie-all/Dockerfile
@@ -2,7 +2,11 @@
 FROM debian:jessie
 
 # install build tools and PostgreSQL development files
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        dirmngr \
+        gnupg2 \
+    && apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -31,11 +35,6 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
 RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
-
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && apt-get install -y postgresql-9.5-citus-6.0 postgresql-9.6-citus-6.0 \
-    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/dockerfiles/debian-stretch-all/Dockerfile
+++ b/dockerfiles/debian-stretch-all/Dockerfile
@@ -2,7 +2,11 @@
 FROM debian:stretch
 
 # install build tools and PostgreSQL development files
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        dirmngr \
+        gnupg2 \
+    && apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -31,11 +35,6 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
 RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
-
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && apt-get install -y postgresql-9.5-citus-6.0 postgresql-9.6-citus-6.0 \
-    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/dockerfiles/debian-wheezy-all/Dockerfile
+++ b/dockerfiles/debian-wheezy-all/Dockerfile
@@ -2,7 +2,11 @@
 FROM debian:wheezy
 
 # install build tools and PostgreSQL development files
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        dirmngr \
+        gnupg2 \
+    && apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ wheezy-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -31,11 +35,6 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
 RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
-
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && apt-get install -y postgresql-9.5-citus-6.0 postgresql-9.6-citus-6.0 \
-    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/dockerfiles/ubuntu-precise-all/Dockerfile
+++ b/dockerfiles/ubuntu-precise-all/Dockerfile
@@ -2,7 +2,11 @@
 FROM ubuntu:precise
 
 # install build tools and PostgreSQL development files
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        dirmngr \
+        gnupg2 \
+    && apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -31,11 +35,6 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
 RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
-
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && apt-get install -y postgresql-9.5-citus-6.0 postgresql-9.6-citus-6.0 \
-    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/dockerfiles/ubuntu-trusty-all/Dockerfile
+++ b/dockerfiles/ubuntu-trusty-all/Dockerfile
@@ -2,7 +2,11 @@
 FROM ubuntu:trusty
 
 # install build tools and PostgreSQL development files
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        dirmngr \
+        gnupg2 \
+    && apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -31,11 +35,6 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
 RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
-
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && apt-get install -y postgresql-9.5-citus-6.0 postgresql-9.6-citus-6.0 \
-    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/dockerfiles/ubuntu-xenial-all/Dockerfile
+++ b/dockerfiles/ubuntu-xenial-all/Dockerfile
@@ -2,7 +2,11 @@
 FROM ubuntu:xenial
 
 # install build tools and PostgreSQL development files
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        dirmngr \
+        gnupg2 \
+    && apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -31,11 +35,6 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
 RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
-
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && apt-get install -y postgresql-9.5-citus-6.0 postgresql-9.6-citus-6.0 \
-    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -2,7 +2,11 @@
 FROM %%os%%:%%release%%
 
 # install build tools and PostgreSQL development files
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        dirmngr \
+        gnupg2 \
+    && apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -31,11 +35,6 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
 RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
-
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && apt-get install -y postgresql-9.5-citus-6.0 postgresql-9.6-citus-6.0 \
-    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /


### PR DESCRIPTION
Docker image of Debian Stretch does not come with gnupg, which is necessary for our operations. With this change we add it to our debian based Dockerfiles.

We are also removing the command which installs postgresql-9.5-citus-6.0 and postgresql-9.6-citus-6.0 packages to get headers. Because there is no citus packages for Debian Stretch yet thus, that command fails. Also it looks like everything works as expected even without that command. @jasonmp85 Did I miss anything about this?