### PR TITLE
Add Debian Stretch to OS list; fix gpg problem

### DIFF
--- a/dockerfiles/debian-jessie-all/Dockerfile
+++ b/dockerfiles/debian-jessie-all/Dockerfile
@@ -1,6 +1,25 @@
 # vim:set ft=dockerfile:
 FROM debian:jessie
 
+# See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
+#
+# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
+RUN set -x \
+	&& apt-get update \
+	&& { \
+		which gpg \
+# prefer gnupg2, to match APT's Recommends
+		|| apt-get install -y --no-install-recommends gnupg2 \
+		|| apt-get install -y --no-install-recommends gnupg \
+	; } \
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+	&& { \
+		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
+		|| apt-get install -y --no-install-recommends dirmngr \
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
+
 # install build tools and PostgreSQL development files
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' > /etc/apt/sources.list.d/pgdg.list \

--- a/dockerfiles/debian-stretch-all/Dockerfile
+++ b/dockerfiles/debian-stretch-all/Dockerfile
@@ -1,6 +1,25 @@
 # vim:set ft=dockerfile:
 FROM debian:stretch
 
+# See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
+#
+# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
+RUN set -x \
+	&& apt-get update \
+	&& { \
+		which gpg \
+# prefer gnupg2, to match APT's Recommends
+		|| apt-get install -y --no-install-recommends gnupg2 \
+		|| apt-get install -y --no-install-recommends gnupg \
+	; } \
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+	&& { \
+		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
+		|| apt-get install -y --no-install-recommends dirmngr \
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
+
 # install build tools and PostgreSQL development files
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
@@ -33,9 +52,9 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && apt-get install -y postgresql-9.5-citus-6.0 postgresql-9.6-citus-6.0 \
-    && rm -rf /var/lib/apt/lists/*
+# RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
+#     && apt-get install -y postgresql-9.5-citus-6.0 postgresql-9.6-citus-6.0 \
+#     && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/dockerfiles/debian-wheezy-all/Dockerfile
+++ b/dockerfiles/debian-wheezy-all/Dockerfile
@@ -1,6 +1,25 @@
 # vim:set ft=dockerfile:
 FROM debian:wheezy
 
+# See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
+#
+# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
+RUN set -x \
+	&& apt-get update \
+	&& { \
+		which gpg \
+# prefer gnupg2, to match APT's Recommends
+		|| apt-get install -y --no-install-recommends gnupg2 \
+		|| apt-get install -y --no-install-recommends gnupg \
+	; } \
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+	&& { \
+		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
+		|| apt-get install -y --no-install-recommends dirmngr \
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
+
 # install build tools and PostgreSQL development files
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ wheezy-pgdg main' > /etc/apt/sources.list.d/pgdg.list \

--- a/dockerfiles/ubuntu-precise-all/Dockerfile
+++ b/dockerfiles/ubuntu-precise-all/Dockerfile
@@ -1,6 +1,25 @@
 # vim:set ft=dockerfile:
 FROM ubuntu:precise
 
+# See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
+#
+# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
+RUN set -x \
+	&& apt-get update \
+	&& { \
+		which gpg \
+# prefer gnupg2, to match APT's Recommends
+		|| apt-get install -y --no-install-recommends gnupg2 \
+		|| apt-get install -y --no-install-recommends gnupg \
+	; } \
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+	&& { \
+		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
+		|| apt-get install -y --no-install-recommends dirmngr \
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
+
 # install build tools and PostgreSQL development files
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main' > /etc/apt/sources.list.d/pgdg.list \

--- a/dockerfiles/ubuntu-trusty-all/Dockerfile
+++ b/dockerfiles/ubuntu-trusty-all/Dockerfile
@@ -1,6 +1,25 @@
 # vim:set ft=dockerfile:
 FROM ubuntu:trusty
 
+# See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
+#
+# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
+RUN set -x \
+	&& apt-get update \
+	&& { \
+		which gpg \
+# prefer gnupg2, to match APT's Recommends
+		|| apt-get install -y --no-install-recommends gnupg2 \
+		|| apt-get install -y --no-install-recommends gnupg \
+	; } \
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+	&& { \
+		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
+		|| apt-get install -y --no-install-recommends dirmngr \
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
+
 # install build tools and PostgreSQL development files
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main' > /etc/apt/sources.list.d/pgdg.list \

--- a/dockerfiles/ubuntu-xenial-all/Dockerfile
+++ b/dockerfiles/ubuntu-xenial-all/Dockerfile
@@ -1,6 +1,25 @@
 # vim:set ft=dockerfile:
 FROM ubuntu:xenial
 
+# See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
+#
+# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
+RUN set -x \
+	&& apt-get update \
+	&& { \
+		which gpg \
+# prefer gnupg2, to match APT's Recommends
+		|| apt-get install -y --no-install-recommends gnupg2 \
+		|| apt-get install -y --no-install-recommends gnupg \
+	; } \
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+	&& { \
+		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
+		|| apt-get install -y --no-install-recommends dirmngr \
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
+
 # install build tools and PostgreSQL development files
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' > /etc/apt/sources.list.d/pgdg.list \

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -1,6 +1,25 @@
 # vim:set ft=dockerfile:
 FROM %%os%%:%%release%%
 
+# See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
+#
+# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
+RUN set -x \
+	&& apt-get update \
+	&& { \
+		which gpg \
+# prefer gnupg2, to match APT's Recommends
+		|| apt-get install -y --no-install-recommends gnupg2 \
+		|| apt-get install -y --no-install-recommends gnupg \
+	; } \
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+	&& { \
+		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
+		|| apt-get install -y --no-install-recommends dirmngr \
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
+
 # install build tools and PostgreSQL development files
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main' > /etc/apt/sources.list.d/pgdg.list \


### PR DESCRIPTION
So this is pretty complex, but basically Debian Stretch no longer comes with gpg installed, which is now just a "Recommend" dependency of apt. The distinction between gpg and gpg2 is often obscured depending upon the OS flavor, and furthermore, gpg2 unbundles dirmngr, which is good to have for our build process.

The only reason all of this is necessary at all is our invocation of apt-key. For a little bit I mistakenly believed that using apt-key add with a local file rather than using a keyserver might avoid the need for dirmngr in particular, but after finding some discussion online I decided to go with this approach.

See: tianon/docker-brew-debian#49 and neurodebian/dockerfiles#3