### PR TITLE
Bump the version to 2.1.0

### DIFF
--- a/pkgvars
+++ b/pkgvars
@@ -1,5 +1,5 @@
 pkgname=topn
 hubproj=postgresql-topn
 pkgdesc='Counter Based Implementation for top-n Approximation'
-pkglatest=2.0.2.citus-1
+pkglatest=2.1.0.citus-1
 releasepg=9.5,9.6,10

--- a/topn.spec
+++ b/topn.spec
@@ -5,11 +5,11 @@
 
 Summary:	Counter Based Implementation for top-n Approximation
 Name:		%{sname}_%{pgmajorversion}
-Version:	2.0.2.citus
+Version:	2.1.0.citus
 Release:	1%{dist}
 License:	AGPLv3
 Group:		Applications/Databases
-Source0:	https://github.com/citusdata/postgresql-topn/archive/v2.0.2.tar.gz
+Source0:	https://github.com/citusdata/postgresql-topn/archive/v2.1.0.tar.gz
 URL:		https://github.com/citusdata/posgresql-topn
 BuildRequires:	postgresql%{pgmajorversion}-devel libxml2-devel
 BuildRequires:	libxslt-devel openssl-devel pam-devel readline-devel
@@ -47,6 +47,9 @@ PATH=%{pginstdir}/bin:$PATH
 %{pginstdir}/share/extension/topn.control
 
 %changelog
+* Mon Jul 09 2018 - Furkan Sahin <furkan@citusdata.com> 2.1.0.citus-1
+- Adds a return type for `topn` function
+
 * Thu Mar 29 2018 - Burak Velioglu <velioglub@citusdata.com> 2.0.2.citus-1
 - Fixes a bug for using with window functions
 


### PR DESCRIPTION
This PR bumps the topn packaging version from 2.0.2 to 2.1.0.