### PR TITLE
Package missing PG10 Rebalancer 8.1.0

### DIFF
--- a/pkgvars
+++ b/pkgvars
@@ -2,5 +2,5 @@ pkgname=citus-rebalancer
 hubproj=shard_rebalancer
 pkgdesc='Shard Rebalancer'
 pkglatest=8.1.0.citus-1
-releasepg=11
+releasepg=10,11
 versioning=fancy


### PR DESCRIPTION
I did not realize missing the missing PG10 builds. This PR adds PG10 to the build matrix once again