### PR TITLE
Update PGXN postgresql version to match specs

### DIFF
--- a/META.json
+++ b/META.json
@@ -16,7 +16,7 @@
    "prereqs": {
       "runtime": {
          "requires": {
-            "PostgreSQL": "10.6"
+            "PostgreSQL": "10.0.0"
          }
       },
       "test": {


### PR DESCRIPTION
I used the official PG version numbers to create PGXN builds and failed.

Apparently PGXN needs a `.0` at the end. So this PR should fix our future PGXN releases