### PR TITLE
Redhat ha 2.1.0

### DIFF
--- a/citus-ha.spec
+++ b/citus-ha.spec
@@ -8,11 +8,11 @@ Summary:	Auto-HA support for Citus
 Name:		%{sname}%{?pkginfix}_%{pgmajorversion}
 Provides:	%{sname}_%{pgmajorversion}
 Conflicts:	%{sname}_%{pgmajorversion}
-Version:	2.0.1
+Version:	2.1.0
 Release:	1%{dist}
-License:	AGPLv3
+License:	Proprietary
 Group:		Applications/Databases
-Source0:	https://github.com/citusdata/citus-ha/archive/v2.0.0.tar.gz
+Source0:	https://github.com/citusdata/citus-ha/archive/v2.1.0.tar.gz
 URL:		https://github.com/citusdata/citus-ha
 BuildRequires:	postgresql%{pgmajorversion}-devel postgresql%{pgmajorversion}-server libxml2-devel
 BuildRequires:	libxslt-devel openssl-devel pam-devel readline-devel
@@ -60,10 +60,9 @@ PATH=%{pginstdir}/bin:$PATH
 
 
 %changelog
-* Fri Mar 1 2019 - Nils Dijk <nils@citusdata.com> 2.0.1
-- Official release for 2.0.1
+* Thu Apr 18 2019 - Nils Dijk <nils@citusdata.com> 2.1.0
+- Official release for 2.1.0
 
-%changelog
 * Fri Feb 22 2019 - Nils Dijk <nils@citusdata.com> 2.0.0
 - Official release for 2.0.0
 

--- a/citus-ha.spec
+++ b/citus-ha.spec
@@ -8,7 +8,7 @@ Summary:	Auto-HA support for Citus
 Name:		%{sname}%{?pkginfix}_%{pgmajorversion}
 Provides:	%{sname}_%{pgmajorversion}
 Conflicts:	%{sname}_%{pgmajorversion}
-Version:	2.0.0
+Version:	2.0.1
 Release:	1%{dist}
 License:	AGPLv3
 Group:		Applications/Databases
@@ -33,8 +33,6 @@ make %{?_smp_mflags}
 %install
 PATH=%{pginstdir}/bin:$PATH
 %make_install
-%{__mkdir} -p %{buildroot}%{pginstdir}/bin
-%{__cp} /usr/pgsql-%{pgpackageversion}/bin/citusha %{buildroot}%{pginstdir}/bin/citusha
 # Install documentation with a better name:
 %{__mkdir} -p %{buildroot}%{pginstdir}/doc/extension
 %{__cp} README.md %{buildroot}%{pginstdir}/doc/extension/README-%{extname}.md
@@ -60,6 +58,10 @@ PATH=%{pginstdir}/bin:$PATH
   %endif
 %endif
 
+
+%changelog
+* Fri Mar 1 2019 - Nils Dijk <nils@citusdata.com> 2.0.1
+- Official release for 2.0.1
 
 %changelog
 * Fri Feb 22 2019 - Nils Dijk <nils@citusdata.com> 2.0.0

--- a/pkgvars
+++ b/pkgvars
@@ -1,6 +1,6 @@
 pkgname=citus-ha
 hubproj=citus-ha
 pkgdesc='Citus HA'
-pkglatest=2.0.1
+pkglatest=2.1.0
 releasepg=10,11
 versioning=fancy

--- a/pkgvars
+++ b/pkgvars
@@ -1,6 +1,6 @@
 pkgname=citus-ha
 hubproj=citus-ha
 pkgdesc='Citus HA'
-pkglatest=2.0.0
+pkglatest=2.0.1
 releasepg=10,11
 versioning=fancy


### PR DESCRIPTION
Builds require tag on repo, will restart after changelog commit is tagged and released.

redhat 2.0.1 commit is in there, never got released. Will be superseded by this release, but change in that commit is still needed on master, hence using that as a base.