### PR TITLE
[Debian] Release pg_auto_failover-enterprise 1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,5 @@ deploy:
     skip_cleanup: true
     local-dir: "pkgs/releases"
     on:
-      branch: "debian-ha"
+      branch: "debian-pgautofailover-enterprise"
       condition: -d "pkgs/releases"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+pg-auto-failover-enterprise (1.0.2) testing; urgency=low
+
+  * First release of pg-auto-failover-enterprise
+
+ -- Nils Dijk <nils@citusdata.com>  Mon, 6 May 2019 16:00:00 +0200
+
+
 citus-ha (2.1.0) testing; urgency=low
  
   * Fix: wait until postgres is ready after pg_ctl start before connecting

--- a/debian/control.in
+++ b/debian/control.in
@@ -1,26 +1,28 @@
-Source: citus-ha
+Source: pg-auto-failover-enterprise
 Section: database
 Priority: optional
 Maintainer: Citus Data <packaging@citusdata.com>
-Uploaders: Burak Velioglu <velioglub@citusdata.com>
+Uploaders: Nils Dijk <nils@citusdata.com>
 Build-Depends: debhelper (>= 9), autotools-dev, flex, postgresql-server-dev-all (>= 158~), libedit-dev, libpam0g-dev, libselinux1-dev, libxslt1-dev
 Standards-Version: 3.9.7
 Homepage: https://github.com/citusdata/citus-ha
 
-Package: citus-ha
+Package: pg-auto-failover-cli-enterprise
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
-Provides: citus-ha
-Conflicts: citus-ha
-Recommends: postgresql-10-citus-ha | postgresql-11-citus-ha
+Depends: ${shlibs:Depends},${misc:Depends}
+Provides: pg-auto-failover-cli
+Conflicts: pg-auto-failover-cli
+Recommends: postgresql-10-auto-failover-enterprise | postgresql-11-auto-failover-enterprise
 Suggests: postgresql-11-citus-8.1 | postgresql-10-citus-8.1 | postgresql-10-citus-enterprise-8.1 | postgresql-11-citus-enterprise-8.1
-Description: Citus high availability CLI
- This CLI is used to manage HA installations of a Citus cluster.
+Description: Command line interface and service to manage pg auto failover Clusters
+ This CLI is used to manage pg_auto_failover installations to provide High
+ Availability to Postgres.
 
-Package: postgresql-PGVERSION-citus-ha
+Package: postgresql-PGVERSION-auto-failover-enterprise
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-PGVERSION, citus-ha
-Provides: postgresql-PGVERSION-citus-ha
-Conflicts: postgresql-PGVERSION-citus-ha
-Description: Citus high availability support
- This extension implements a set of functions for HA on Citus clusters.
+Depends: ${shlibs:Depends},${misc:Depends}, postgresql-PGVERSION, pg-auto-failover-cli-enterprise
+Provides: postgresql-PGVERSION-auto-failover
+Conflicts: postgresql-PGVERSION-auto-failover
+Description: Postgres high availability support
+ This extension implements a set of functions to provide High Availability to
+ Postgres.

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-HANAME := $(lastword $(shell grep "Package: citus-ha" debian/control))
+CLINAME := $(lastword $(shell grep "Package: pg-auto-failover-cli-enterprise" debian/control))
 
 include /usr/share/postgresql-common/pgxs_debian_control.mk
 clean: debian/control
@@ -8,21 +8,21 @@ clean: debian/control
 .PHONY: debian/control
 
 override_dh_auto_build:
-	+make -C $(shell pwd)/src/bin/citusha
+	+make -C $(shell pwd)/src/bin/pg_autoctl
 	+pg_buildext build $(shell pwd)/src/monitor build-%v
 
 override_dh_auto_clean:
-	+make -C $(shell pwd)/src/bin/citusha clean
+	+make -C $(shell pwd)/src/bin/pg_autoctl clean
 	+pg_buildext clean $(shell pwd)/src/monitor build-%v
 
 override_dh_auto_test:
 	# nothing to do here, see debian/tests/* instead
 
 override_dh_auto_install:
-	+make -C $(shell pwd)/src/bin/citusha install \
-		DESTDIR=$(CURDIR)/debian/${HANAME} \
+	+make -C $(shell pwd)/src/bin/pg_autoctl install \
+		DESTDIR=$(CURDIR)/debian/${CLINAME} \
 		BINDIR=/usr/bin
-	+pg_buildext install $(shell pwd)/src/monitor build-%v postgresql-%v-citus-ha
+	+pg_buildext install $(shell pwd)/src/monitor build-%v postgresql-%v-auto-failover-enterprise
 
 %:
 	dh $@

--- a/pkgvars
+++ b/pkgvars
@@ -1,6 +1,6 @@
-pkgname=citus-ha
+pkgname=auto-failover-enterprise
 hubproj=citus-ha
-pkgdesc='Citus HA'
-pkglatest=2.1.0
+pkgdesc='Postgres extension for automated failover and high-availability'
+pkglatest=1.0.2
 releasepg=10,11
 versioning=fancy


### PR DESCRIPTION
First release of enterprise.
Source branch is debian-ha, but moved around as we change the release artifact.