### PR TITLE
Re-enable package building for debian/strecth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - secure: "pZmrxStWj0vXaG/YAyJORvxfaKQHvr+O+66yjFF52gQTVd2zNb83Mn4zDLNqMwU3nkXEKYuFbpXKbDSMX9zNbE7W/w1ARSa8MVXnMVM3jbj+OCaBu7fyVrA0tvT3EZkMh943paTRcSyPSzd61P3CNOkcY1RycDHBbJtNrzSdUbdAy6//TWgNxC66dxSeHASRJIIs49caxQssMMSGRgC5aGH4KLU5eSdP3wnWDEHr+aLqaI2DF2W3lNMI0WJwtGN6cLEYzAsA3BkoPoYRFDd4jjTpolVdrFBXRaT1EIg0FXjsvjyFrQfQLBIqvSx42H5w4rCIYoKYYgRgCKDATLK8XxPbFsgPKLVSHFD6t9ebuYacYxS20oMakkqj5e98qMIWe2vkm+V9YNeADIlhYT+NsF9Kug2B6pLK+U+Hhj6TldFpP18snPXttRKzsg9QrGbnBUVq2wv60U7/3pWs+T3tpr9bIFyaUYbRRAwl/hv2hVkFiSdsiLB6tJphbILB7EDKBCu1iK9PC9tlYoGrqptRxj6bmlawOvcnEKRtoPNJ9eyrvHPDd8FmmW6xWbq89zJ97Ztl7VR8CzNePqvG9vwdtJigXovuXfzu4CHX+jOt3jvllB6rMprsK5r++qBzh1SS24sYqo/APtUfoYdkleWhC+tSuhbucZb2yGUCMo/ZhDo="
   matrix:
     - TARGET_PLATFORM=debian/jessie
+    - TARGET_PLATFORM=debian/stretch
     - TARGET_PLATFORM=ubuntu/bionic
     - TARGET_PLATFORM=ubuntu/xenial
     - TARGET_PLATFORM=ubuntu/trusty


### PR DESCRIPTION
We fixed debian/stretch image, can now build the package