### PR TITLE
Update deb and rpm scripts to use PG12

### DIFF
--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -163,6 +163,9 @@ detect_codename ()
       9)
         codename='stretch'
         ;;
+      10)
+        codename='buster'
+        ;;
       wheezy)
         codename="${dist}"
         ;;
@@ -170,6 +173,9 @@ detect_codename ()
         codename="${dist}"
         ;;
       stretch)
+        codename="${dist}"
+        ;;
+      buster)
         codename="${dist}"
         ;;
       *)

--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -56,9 +56,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-11..."
-  if apt-cache show postgresql-11 &> /dev/null; then
-    echo "Detected postgresql-11..."
+  echo "Checking for postgresql-12..."
+  if apt-cache show postgresql-12 &> /dev/null; then
+    echo "Detected postgresql-12..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/community-nightlies/rpm.sh
+++ b/community-nightlies/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql11-server..."
-  if yum list -q postgresql11-server &> /dev/null; then
-    echo "Detected postgresql11-server..."
+  echo "Checking for postgresql12-server..."
+  if yum list -q postgresql12-server &> /dev/null; then
+    echo "Detected postgresql12-server..."
   else
-    echo -n "Installing pgdg11 repo... "
+    echo -n "Installing pgdg12 repo... "
 
     yum install -d0 -e0 -y "${repo_url}"
     echo "done."
@@ -178,9 +178,9 @@ detect_repo_url ()
       ;;
   esac
 
-  repo_url="https://download.postgresql.org/pub/repos/yum/11/${family}"
+  repo_url="https://download.postgresql.org/pub/repos/yum/12/${family}"
   repo_url+="/${family_short}-${pkg_dist}-x86_64"
-  repo_url+="/pgdg-${pkg_os}11-11-${pkg_version}.noarch.rpm"
+  repo_url+="/pgdg-${pkg_os}12-12-${pkg_version}.noarch.rpm"
 }
 
 main ()

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -163,6 +163,9 @@ detect_codename ()
       9)
         codename='stretch'
         ;;
+      10)
+        codename='buster'
+        ;;
       wheezy)
         codename="${dist}"
         ;;
@@ -170,6 +173,9 @@ detect_codename ()
         codename="${dist}"
         ;;
       stretch)
+        codename="${dist}"
+        ;;
+      buster)
         codename="${dist}"
         ;;
       *)

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -56,9 +56,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-11..."
-  if apt-cache show postgresql-11 &> /dev/null; then
-    echo "Detected postgresql-11..."
+  echo "Checking for postgresql-12..."
+  if apt-cache show postgresql-12 &> /dev/null; then
+    echo "Detected postgresql-12..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/community/rpm.sh
+++ b/community/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql11-server..."
-  if yum list -q postgresql11-server &> /dev/null; then
-    echo "Detected postgresql11-server..."
+  echo "Checking for postgresql12-server..."
+  if yum list -q postgresql12-server &> /dev/null; then
+    echo "Detected postgresql12-server..."
   else
-    echo -n "Installing pgdg11 repo... "
+    echo -n "Installing pgdg12 repo... "
 
     yum install -d0 -e0 -y "${repo_url}"
     echo "done."
@@ -178,9 +178,9 @@ detect_repo_url ()
       ;;
   esac
 
-  repo_url="https://download.postgresql.org/pub/repos/yum/11/${family}"
+  repo_url="https://download.postgresql.org/pub/repos/yum/12/${family}"
   repo_url+="/${family_short}-${pkg_dist}-x86_64"
-  repo_url+="/pgdg-${pkg_os}11-11-${pkg_version}.noarch.rpm"
+  repo_url+="/pgdg-${pkg_os}12-12-${pkg_version}.noarch.rpm"
 }
 
 main ()

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -193,6 +193,9 @@ detect_codename ()
       9)
         codename='stretch'
         ;;
+      10)
+        codename='buster'
+        ;;
       wheezy)
         codename="${dist}"
         ;;
@@ -200,6 +203,9 @@ detect_codename ()
         codename="${dist}"
         ;;
       stretch)
+        codename="${dist}"
+        ;;
+      buster)
         codename="${dist}"
         ;;
       *)

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -56,9 +56,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-11..."
-  if apt-cache show postgresql-11 &> /dev/null; then
-    echo "Detected postgresql-11..."
+  echo "Checking for postgresql-12..."
+  if apt-cache show postgresql-12 &> /dev/null; then
+    echo "Detected postgresql-12..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql11-server..."
-  if yum list -q postgresql11-server &> /dev/null; then
-    echo "Detected postgresql11-server..."
+  echo "Checking for postgresql12-server..."
+  if yum list -q postgresql12-server &> /dev/null; then
+    echo "Detected postgresql12-server..."
   else
-    echo -n "Installing pgdg11 repo... "
+    echo -n "Installing pgdg12 repo... "
 
     yum install -d0 -e0 -y "${repo_url}"
     echo "done."
@@ -208,9 +208,9 @@ detect_repo_url ()
       ;;
   esac
 
-  repo_url="https://download.postgresql.org/pub/repos/yum/11/${family}"
+  repo_url="https://download.postgresql.org/pub/repos/yum/12/${family}"
   repo_url+="/${family_short}-${pkg_dist}-x86_64"
-  repo_url+="/pgdg-${pkg_os}11-11-${pkg_version}.noarch.rpm"
+  repo_url+="/pgdg-${pkg_os}12-12-${pkg_version}.noarch.rpm"
 }
 
 main ()

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -193,6 +193,9 @@ detect_codename ()
       9)
         codename='stretch'
         ;;
+      10)
+        codename='buster'
+        ;;
       wheezy)
         codename="${dist}"
         ;;
@@ -200,6 +203,9 @@ detect_codename ()
         codename="${dist}"
         ;;
       stretch)
+        codename="${dist}"
+        ;;
+      buster)
         codename="${dist}"
         ;;
       *)

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -56,9 +56,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-11..."
-  if apt-cache show postgresql-11 &> /dev/null; then
-    echo "Detected postgresql-11..."
+  echo "Checking for postgresql-12..."
+  if apt-cache show postgresql-12 &> /dev/null; then
+    echo "Detected postgresql-12..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql11-server..."
-  if yum list -q postgresql11-server &> /dev/null; then
-    echo "Detected postgresql11-server..."
+  echo "Checking for postgresql12-server..."
+  if yum list -q postgresql12-server &> /dev/null; then
+    echo "Detected postgresql12-server..."
   else
-    echo -n "Installing pgdg11 repo... "
+    echo -n "Installing pgdg12 repo... "
 
     yum install -d0 -e0 -y "${repo_url}"
     echo "done."
@@ -208,9 +208,9 @@ detect_repo_url ()
       ;;
   esac
 
-  repo_url="https://download.postgresql.org/pub/repos/yum/11/${family}"
+  repo_url="https://download.postgresql.org/pub/repos/yum/12/${family}"
   repo_url+="/${family_short}-${pkg_dist}-x86_64"
-  repo_url+="/pgdg-${pkg_os}11-11-${pkg_version}.noarch.rpm"
+  repo_url+="/pgdg-${pkg_os}12-12-${pkg_version}.noarch.rpm"
 }
 
 main ()


### PR DESCRIPTION
Update all the scripts to use PG12 repositories instead of 11.

We may need to do some testing in some repositories before landing the changes here.

- [x] ~We have not yet released all packages, so this PR should be blocked until we are able to test it properly~
	- The packaging of `9.0.1` is complete. I verified that the scripts in this branch works in all the new distros we started to support.
- [x] OL/EL 8 PGDG repositories have issues, ~we should wait until it gets fixed.~
	- The script works fine in the OL/EL 8. Once we start creating packages for these distros the changes here will hopefully work.
- [ ] CentOS 8 advises us to use `dnf` instead of `yum` to manage packages. We may consider doing that in these scripts as well
	- I am discarding this idea for now, as this means we will diverge from the package cloud scripts and we need to spend some more time on this to get it working.