### PR TITLE
Changes for debian packages to be hosted on microsoft infrastructure

### DIFF
--- a/debian/citus-setup
+++ b/debian/citus-setup
@@ -93,7 +93,6 @@ done
 if ! gpg --output "/dev/null" \
         --batch --no-tty --yes --quiet \
         --passphrase "$CITUS_LICENSE_KEY" \
-        --pinentry loopback \
         --homedir "$temp_gnupghome" \
         --decrypt "$(head -n 1 "$secret_files_list").gpg" 2> /dev/null; then
     echo "ERROR: Invalid license key supplied"
@@ -110,7 +109,6 @@ while read -r path_unencrypted; do
     gpg --output "$path_unencrypted" \
         --batch --no-tty --yes --quiet \
         --passphrase "$CITUS_LICENSE_KEY" \
-        --pinentry loopback \
         --homedir "$temp_gnupghome" \
         --decrypt "$path_encrypted"
 

--- a/debian/citus-setup
+++ b/debian/citus-setup
@@ -1,0 +1,123 @@
+#!/bin/sh
+
+set -eu
+
+pg_version=
+libdir="/usr/lib/postgresql/$pg_version/lib"
+secret_files_list="$libdir/citus_secret_files.metadata"
+
+# Make sure the script is being run as root
+if [ "$(id -u)" -ne "0" ]; then
+    echo "ERROR: citus-enterprise-pg-$pg_version-setup needs to be run as root"
+    echo "HINT: try running \"sudo citus-enterprise-pg-$pg_version-setup\" instead"
+    exit 1
+fi
+
+
+eula_text="
+Your use of this software is subject to the terms and conditions of the license
+agreement by which you acquired this software. If you are a volume license
+customer, use of this software is subject to your volume license agreement.
+You may not use this software if you have not validly acquired a license for
+the software from Microsoft or its licensed distributors.
+
+Do you accept these terms? y/N"
+
+CITUS_ACCEPT_LICENSE="${CITUS_ACCEPT_LICENSE:-}"
+while [ -z "$CITUS_ACCEPT_LICENSE" ]; do
+    echo "$eula_text"
+    read -r CITUS_ACCEPT_LICENSE
+done
+
+case "$CITUS_ACCEPT_LICENSE" in
+    y|Y|Yes|YES|yes );;
+    * )
+        echo "ERROR: Terms of the software must be accepted"
+        exit 1
+esac
+
+
+ssl_warning_text="
+Since Citus is a distributed database, data is sent over the network between
+nodes. It is YOUR RESPONSIBILITY as an operator to ensure that this traffic is
+secure.
+
+Since Citus version X.Y (released YYYY-MM-DD) the traffic between the different
+nodes in the cluster is encrypted for NEW installations. This is done by using
+TLS with self-signed certificates. This means that this does NOT protect
+against Man-In-The-Middle attacks. This only protects against passive
+eavesdropping on the network.
+
+This automatic TLS setup of self-signed certificates and TLS is not done in the
+following cases:
+1. The Citus clusters was originally created with a Citus version before X.Y.
+   Even when the cluster is later upgraded to a version after X.Y.
+2. The ssl or ssl_ciphers Postgres configuration option is set to something
+   other than the default.
+
+In these cases it is assumed the operator has set up appropriate security
+themselves.
+
+So, with the default settings Citus clusters are not safe from
+Man-In-The-Middle attacks. To secure the traffic completely you need to follow
+the practices outlined here:
+https://citus.com/some-page-on-secure-setup
+
+Please confirm that you have read this and understand that you should set up
+TLS yourself to send traffic between nodes securely:
+y/N?"
+
+CITUS_ACCEPT_ENCRYPTION_WARNING="${CITUS_ACCEPT_ENCRYPTION_WARNING:-}"
+while [ -z "$CITUS_ACCEPT_ENCRYPTION_WARNING" ]; do
+    echo "$ssl_warning_text"
+    read -r CITUS_ACCEPT_ENCRYPTION_WARNING
+done
+
+case "$CITUS_ACCEPT_ENCRYPTION_WARNING" in
+    y|Y|Yes|YES|yes );;
+    * )
+        echo "ERROR: Warning about encrypted traffic must be accepted before installing"
+        exit 1
+esac
+
+# create a temporary directory for gpg to use so it doesn't output warnings
+temp_gnupghome="$(mktemp -d)"
+CITUS_LICENSE_KEY="${CITUS_LICENSE_KEY:-}"
+while [ -z "$CITUS_LICENSE_KEY" ]; do
+    echo ''
+    echo 'Please enter license key:'
+    read -r CITUS_LICENSE_KEY
+done
+
+# Try to decrypt the first file in the list to check if the key is correct
+if ! gpg --output "/dev/null" \
+        --batch --no-tty --yes --quiet \
+        --passphrase "$CITUS_LICENSE_KEY" \
+        --pinentry loopback \
+        --homedir "$temp_gnupghome" \
+        --decrypt "$(head -n 1 "$secret_files_list").gpg" 2> /dev/null; then
+    echo "ERROR: Invalid license key supplied"
+    exit 1
+fi
+
+echo "License key is valid"
+echo "Installing..."
+
+# Decrypt all the encrypted files
+while read -r path_unencrypted; do
+    path_encrypted="$path_unencrypted.gpg"
+    # decrypt the encrypted file
+    gpg --output "$path_unencrypted" \
+        --batch --no-tty --yes --quiet \
+        --passphrase "$CITUS_LICENSE_KEY" \
+        --pinentry loopback \
+        --homedir "$temp_gnupghome" \
+        --decrypt "$path_encrypted"
+
+    # restore permissions and ownership
+    chmod --reference "$path_encrypted" "$path_unencrypted"
+    chown --reference "$path_encrypted" "$path_unencrypted"
+done < "$secret_files_list"
+
+# remove the temporary gpg directory
+rm -rf "$temp_gnupghome"

--- a/debian/citus-setup
+++ b/debian/citus-setup
@@ -42,16 +42,16 @@ Since Citus is a distributed database, data is sent over the network between
 nodes. It is YOUR RESPONSIBILITY as an operator to ensure that this traffic is
 secure.
 
-Since Citus version X.Y (released YYYY-MM-DD) the traffic between the different
-nodes in the cluster is encrypted for NEW installations. This is done by using
-TLS with self-signed certificates. This means that this does NOT protect
-against Man-In-The-Middle attacks. This only protects against passive
+Since Citus version 8.1.0 (released 2018-12-17) the traffic between the
+different nodes in the cluster is encrypted for NEW installations. This is done
+by using TLS with self-signed certificates. This means that this does NOT
+protect against Man-In-The-Middle attacks. This only protects against passive
 eavesdropping on the network.
 
-This automatic TLS setup of self-signed certificates and TLS is not done in the
+This automatic TLS setup of self-signed certificates and TLS is NOT DONE in the
 following cases:
-1. The Citus clusters was originally created with a Citus version before X.Y.
-   Even when the cluster is later upgraded to a version after X.Y.
+1. The Citus clusters was originally created with a Citus version before 8.1.0.
+   Even when the cluster is later upgraded to version 8.1.0 or higher.
 2. The ssl or ssl_ciphers Postgres configuration option is set to something
    other than the default.
 

--- a/debian/encrypt_files.sh
+++ b/debian/encrypt_files.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -euo pipefail
+
+PACKAGE_ENCRYPTION_KEY="${PACKAGE_ENCRYPTION_KEY:-}"
+if [ -z "$PACKAGE_ENCRYPTION_KEY" ]; then
+    echo "ERROR: The PACKAGE_ENCRYPTION_KEY environment variable needs to be set"
+    exit 1
+fi
+
+
+for dir in debian/postgresql-*; do
+    # skip postgresql-xxxx.log files
+    if [ ! -d "$dir" ]; then
+        continue;
+    fi;
+
+    # Get PG version from directory name
+    # shellcheck disable=SC2001
+    pg_version=$(echo "$dir" | sed 's@^debian/postgresql-\([0-9]\+\)-.\+$@\1@g')
+
+    # Copy over postinst and prerm file, but replace "pg_version=" with 
+    # e.g. "pg_version=12"
+    pg_version_regex="s/^pg_version=\$/pg_version=$pg_version/g"
+
+    debdir="$dir/DEBIAN"
+    for script in prerm postinst; do
+        sed "$pg_version_regex" "debian/$script" > "$debdir/$script";
+        cat "$debdir/$script"
+        chmod +x "$debdir/$script"
+    done
+
+
+    bindir="$dir/usr/bin"
+    mkdir -p "$bindir"
+    setup="$bindir/citus-enterprise-pg-$pg_version-setup"
+    sed "$pg_version_regex" "debian/citus-setup" > "$setup";
+    cat "$setup"
+    chmod +x "$setup"
+
+
+    # libdir contains files that we want to encrypt
+    libdir="$dir/usr/lib/postgresql/$pg_version/lib"
+    mkdir -p "$libdir"
+
+    # create files REMOVE IN FINAL VERSION
+    mkdir -p "$libdir/bitcode"
+    echo "hello1" > "$libdir/citus1.txt";
+    echo "hello2" > "$libdir/citus2.txt";
+    echo "hello3" > "$libdir/bitcode/citus3.txt";
+    echo "hello4" > "$libdir/citus4.txtt";
+
+    # REMOVE .txt from final version
+    # List all files to be encrypted and store it in the libdir as secret_files_list
+    secret_files_list="$libdir/citus_secret_files.metadata"
+    find "$dir" -iname "*.so" -o -iname "*.bc" -o -iname "*.control" -o -iname "*.txt" | sed -e "s@^$dir@@g" > "$secret_files_list"
+    cat "$secret_files_list"
+
+    while read -r unencrypted_file; do
+        path_unencrypted="$dir$unencrypted_file"
+        path_encrypted="$path_unencrypted.gpg"
+
+        # encrypt the files using password
+        gpg --symmetric \
+            --batch \
+            --no-tty \
+            --yes \
+            --passphrase-fd 0 \
+            --output "$path_encrypted" \
+            "$path_unencrypted" \
+            <<< "$PACKAGE_ENCRYPTION_KEY"
+
+        # keep permissions and ownership the same, so we can restore it later
+        # when decrypting
+        chmod --reference "$path_unencrypted" "$path_encrypted"
+        chown --reference "$path_unencrypted" "$path_encrypted"
+
+        # remove the unencrypted file from the package
+        rm "$path_unencrypted"
+    done < "$secret_files_list"
+done
+
+

--- a/debian/encrypt_files.sh
+++ b/debian/encrypt_files.sh
@@ -52,10 +52,15 @@ for dir in debian/postgresql-*; do
         path_encrypted="$path_unencrypted.gpg"
 
         # encrypt the files using password
+        # --s2k-* options are there to make sure decrypting/encrypting doesn't
+        # take minutes
         gpg --symmetric \
             --batch \
             --no-tty \
             --yes \
+            --s2k-mode 3 \
+            --s2k-count 1000000 \
+            --s2k-digest-algo SHA512 \
             --passphrase-fd 0 \
             --output "$path_encrypted" \
             "$path_unencrypted" \

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eu
+
+pg_version=
+installation_message="
++--------------------------------------------------------------+
+Please run 'sudo citus-enterprise-pg-$pg_version-setup'
+to complete the setup of Citus Enterprise
++--------------------------------------------------------------+
+"
+echo "$installation_message"
+

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eux
+
+pg_version=
+
+libdir="/usr/lib/postgresql/$pg_version/lib"
+
+secret_files_list="$libdir/citus_secret_files.metadata"
+
+# Cleanup all de decrypted files since these are not managed by the package
+# manager and would be left around otherwise
+while read -r path_unencrypted; do
+    rm -f "$path_unencrypted"
+done < "$secret_files_list"

--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,6 @@ override_dh_auto_configure:
 
 override_dh_auto_install:
 	+pg_buildext install build-%v postgresql-%v-citus-enterprise
-	dh_installdeb
 	debian/encrypt_files.sh
 
 %:

--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ override_dh_auto_test:
 	# nothing to do here, see debian/tests/* instead
 
 override_dh_auto_configure:
-	+pg_buildext configure build-%v --with-extra-version="$${CONF_EXTRA_VERSION:-}"
+	+pg_buildext configure build-%v --with-extra-version="$${CONF_EXTRA_VERSION:-}" --without-libcurl
 
 override_dh_auto_install:
 	+pg_buildext install build-%v postgresql-%v-citus-enterprise

--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,8 @@ override_dh_auto_configure:
 
 override_dh_auto_install:
 	+pg_buildext install build-%v postgresql-%v-citus-enterprise
+	dh_installdeb
+	debian/encrypt_files.sh
 
 %:
 	dh $@


### PR DESCRIPTION
Things this does:
1. Encrypt the `.so`, `.bc` and `.control` files, so the package is effectively
   unusable without decrypting them
2. Adds a `citus-enterprise-pg-$PGVERSION-setup` script that needs to be run
   after install for the installation to complete
3. Add a postinst script, telling the user to run the required script
4. Add a prerm script to cleanup the files that the
5. Disable libcurl integration, so statistics collection is compiled out

The `citus-enterprise-pg-$PGVERSION-setup` does three things:
1. Require the user to accept software terms
2. Require the user to acknowledge the risks of unencrypted traffic
3. Require the user to enter the licence key they received during purchase of
   the product