### PR TITLE
Use GCC8 on CentOS when available

### DIFF
--- a/dockerfiles/centos-6-pg11/Dockerfile
+++ b/dockerfiles/centos-6-pg11/Dockerfile
@@ -39,6 +39,13 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
     && yum clean all
 
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc ; \
+    } \
+    && yum clean all
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-6-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-6-pg11/scripts/fetch_and_build_rpm
@@ -183,6 +183,14 @@ case "${1}" in
         ;;
 esac
 
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
 rpmbuild --define "_sourcedir ${rpmbuilddir}" \
 --define "_specdir ${rpmbuilddir}" \
 --define "_builddir ${rpmbuilddir}" \

--- a/dockerfiles/centos-6-pg12/Dockerfile
+++ b/dockerfiles/centos-6-pg12/Dockerfile
@@ -39,6 +39,13 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
     && yum clean all
 
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc ; \
+    } \
+    && yum clean all
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-6-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-6-pg12/scripts/fetch_and_build_rpm
@@ -183,6 +183,14 @@ case "${1}" in
         ;;
 esac
 
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
 rpmbuild --define "_sourcedir ${rpmbuilddir}" \
 --define "_specdir ${rpmbuilddir}" \
 --define "_builddir ${rpmbuilddir}" \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -44,6 +44,13 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
     && yum clean all
 
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc ; \
+    } \
+    && yum clean all
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-7-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg11/scripts/fetch_and_build_rpm
@@ -183,6 +183,14 @@ case "${1}" in
         ;;
 esac
 
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
 rpmbuild --define "_sourcedir ${rpmbuilddir}" \
 --define "_specdir ${rpmbuilddir}" \
 --define "_builddir ${rpmbuilddir}" \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -44,6 +44,13 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
     && yum clean all
 
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc ; \
+    } \
+    && yum clean all
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-7-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg12/scripts/fetch_and_build_rpm
@@ -183,6 +183,14 @@ case "${1}" in
         ;;
 esac
 
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
 rpmbuild --define "_sourcedir ${rpmbuilddir}" \
 --define "_specdir ${rpmbuilddir}" \
 --define "_builddir ${rpmbuilddir}" \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -43,6 +43,13 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
     && yum clean all
 
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc ; \
+    } \
+    && yum clean all
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-8-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg11/scripts/fetch_and_build_rpm
@@ -183,6 +183,14 @@ case "${1}" in
         ;;
 esac
 
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
 rpmbuild --define "_sourcedir ${rpmbuilddir}" \
 --define "_specdir ${rpmbuilddir}" \
 --define "_builddir ${rpmbuilddir}" \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -45,6 +45,13 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
     && yum clean all
 
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc ; \
+    } \
+    && yum clean all
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-8-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg12/scripts/fetch_and_build_rpm
@@ -183,6 +183,14 @@ case "${1}" in
         ;;
 esac
 
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
 rpmbuild --define "_sourcedir ${rpmbuilddir}" \
 --define "_specdir ${rpmbuilddir}" \
 --define "_builddir ${rpmbuilddir}" \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -38,6 +38,13 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
     && yum clean all
 
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc ; \
+    } \
+    && yum clean all
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-6-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg11/scripts/fetch_and_build_rpm
@@ -183,6 +183,14 @@ case "${1}" in
         ;;
 esac
 
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
 rpmbuild --define "_sourcedir ${rpmbuilddir}" \
 --define "_specdir ${rpmbuilddir}" \
 --define "_builddir ${rpmbuilddir}" \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -36,6 +36,13 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
     && yum clean all
 
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc ; \
+    } \
+    && yum clean all
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-6-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg12/scripts/fetch_and_build_rpm
@@ -183,6 +183,14 @@ case "${1}" in
         ;;
 esac
 
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
 rpmbuild --define "_sourcedir ${rpmbuilddir}" \
 --define "_specdir ${rpmbuilddir}" \
 --define "_builddir ${rpmbuilddir}" \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -53,6 +53,13 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
     && yum clean all
 
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc ; \
+    } \
+    && yum clean all
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-7-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg11/scripts/fetch_and_build_rpm
@@ -183,6 +183,14 @@ case "${1}" in
         ;;
 esac
 
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
 rpmbuild --define "_sourcedir ${rpmbuilddir}" \
 --define "_specdir ${rpmbuilddir}" \
 --define "_builddir ${rpmbuilddir}" \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -54,6 +54,13 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
     && yum clean all
 
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc ; \
+    } \
+    && yum clean all
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-7-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg12/scripts/fetch_and_build_rpm
@@ -183,6 +183,14 @@ case "${1}" in
         ;;
 esac
 
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
 rpmbuild --define "_sourcedir ${rpmbuilddir}" \
 --define "_specdir ${rpmbuilddir}" \
 --define "_builddir ${rpmbuilddir}" \

--- a/scripts/fetch_and_build_rpm
+++ b/scripts/fetch_and_build_rpm
@@ -183,6 +183,14 @@ case "${1}" in
         ;;
 esac
 
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
 rpmbuild --define "_sourcedir ${rpmbuilddir}" \
 --define "_specdir ${rpmbuilddir}" \
 --define "_builddir ${rpmbuilddir}" \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -39,6 +39,13 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
     && yum clean all
 
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc ; \
+    } \
+    && yum clean all
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 


### PR DESCRIPTION
For security compliance we cannot use a GCC lower than 4.8. The default GCC on
centos6 and oraclelinux6 are GCC 4.4, so these don't comply.
This tries to add the GCC8 to the image using the devtoolset-8-gcc packge. This
is not available everywhere.