### PR TITLE
Check that GCC used to compile has a bigger version than 4.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ env:
     - secure: "pZmrxStWj0vXaG/YAyJORvxfaKQHvr+O+66yjFF52gQTVd2zNb83Mn4zDLNqMwU3nkXEKYuFbpXKbDSMX9zNbE7W/w1ARSa8MVXnMVM3jbj+OCaBu7fyVrA0tvT3EZkMh943paTRcSyPSzd61P3CNOkcY1RycDHBbJtNrzSdUbdAy6//TWgNxC66dxSeHASRJIIs49caxQssMMSGRgC5aGH4KLU5eSdP3wnWDEHr+aLqaI2DF2W3lNMI0WJwtGN6cLEYzAsA3BkoPoYRFDd4jjTpolVdrFBXRaT1EIg0FXjsvjyFrQfQLBIqvSx42H5w4rCIYoKYYgRgCKDATLK8XxPbFsgPKLVSHFD6t9ebuYacYxS20oMakkqj5e98qMIWe2vkm+V9YNeADIlhYT+NsF9Kug2B6pLK+U+Hhj6TldFpP18snPXttRKzsg9QrGbnBUVq2wv60U7/3pWs+T3tpr9bIFyaUYbRRAwl/hv2hVkFiSdsiLB6tJphbILB7EDKBCu1iK9PC9tlYoGrqptRxj6bmlawOvcnEKRtoPNJ9eyrvHPDd8FmmW6xWbq89zJ97Ztl7VR8CzNePqvG9vwdtJigXovuXfzu4CHX+jOt3jvllB6rMprsK5r++qBzh1SS24sYqo/APtUfoYdkleWhC+tSuhbucZb2yGUCMo/ZhDo="
   matrix:
     - TARGET_PLATFORM=el/6
-    - TARGET_PLATFORM=ol/6
+    # Removed for now because it has no gcc4.8+ (which is required for security
+    # compliance)
+    # - TARGET_PLATFORM=ol/6
     - TARGET_PLATFORM=el/7
     - TARGET_PLATFORM=ol/7
     - TARGET_PLATFORM=el/8

--- a/citus-enterprise.spec
+++ b/citus-enterprise.spec
@@ -37,7 +37,15 @@ commands.
 %setup -q -n %{sname}-%{version}
 
 %build
-%configure PG_CONFIG=%{pginstdir}/bin/pg_config --with-extra-version="%{?conf_extra_version}"
+
+currentgccver="$(gcc -dumpversion)"
+requiredgccver="4.8.0"
+if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | tail -n1)" = "$requiredgccver" ]; then
+    echo ERROR: At least GCC version "$requiredgccver" is needed
+    exit 1
+fi
+
+%configure PG_CONFIG=%{pginstdir}/bin/pg_config --with-extra-version="%{?conf_extra_version}" CC=$(command -v gcc)
 make %{?_smp_mflags}
 
 %install

--- a/debian/check-gcc-version.sh
+++ b/debian/check-gcc-version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+currentgccver="$($(pg_config --cc) -dumpversion)"
+requiredgccver="4.8.0"
+if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | tail -n1)" = "$requiredgccver" ]; then
+    echo ERROR: At least GCC version "$requiredgccver" is needed
+    exit 1
+fi
+

--- a/debian/rules
+++ b/debian/rules
@@ -12,6 +12,7 @@ override_dh_auto_test:
 	# nothing to do here, see debian/tests/* instead
 
 override_dh_auto_configure:
+	debian/check-gcc-version.sh
 	+pg_buildext configure build-%v --with-extra-version="$${CONF_EXTRA_VERSION:-}" --without-libcurl
 
 override_dh_auto_install:


### PR DESCRIPTION
This is a check to ensure that Citus Enterprise is not built with a GCC version
lower than 4.8.0. This is mostly used as a way to ensure that el/6 and ol/6 are
not accidentily built before #424 is merged.