### PR TITLE
Fix compilation flags for microsoft packages

### DIFF
--- a/citus-enterprise.spec
+++ b/citus-enterprise.spec
@@ -45,7 +45,9 @@ if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | tail -n1)" 
     exit 1
 fi
 
-%configure PG_CONFIG=%{pginstdir}/bin/pg_config --with-extra-version="%{?conf_extra_version}" CC=$(command -v gcc)
+# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
+SECURITY_CFLAGS="-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security"
+%configure PG_CONFIG=%{pginstdir}/bin/pg_config --with-extra-version="%{?conf_extra_version}" CC=$(command -v gcc) CFLAGS="$SECURITY_CFLAGS"
 make %{?_smp_mflags}
 
 %install

--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,7 @@ override_dh_auto_test:
 
 override_dh_auto_configure:
 	debian/check-gcc-version.sh
-	+pg_buildext configure build-%v --with-extra-version="$${CONF_EXTRA_VERSION:-}" --without-libcurl
+	+pg_buildext configure build-%v "--with-extra-version='$${CONF_EXTRA_VERSION:-}' --without-libcurl"
 
 override_dh_auto_install:
 	+pg_buildext install build-%v postgresql-%v-citus-enterprise

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,8 @@
 include /usr/share/postgresql-common/pgxs_debian_control.mk
 
 override_dh_auto_build:
-	+pg_buildext build build-%v
+	# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
+	+pg_buildext build build-%v '-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security'
 
 override_dh_auto_clean:
 	+pg_buildext clean build-%v


### PR DESCRIPTION
--with-libcurl was ignored, because pg_extbuilder wants all the configure arguments in a single argument (which is weird)