### PR TITLE
Change Enterprise package license to Commercial

### DIFF
--- a/citus-enterprise.spec
+++ b/citus-enterprise.spec
@@ -10,7 +10,7 @@ Provides:	citus_%{pgmajorversion}
 Conflicts:	citus_%{pgmajorversion}
 Version:	9.2.4.citus
 Release:	1%{dist}
-License:	AGPLv3
+License:	Commercial
 Group:		Applications/Databases
 Source0:       https://github.com/citusdata/citus-enterprise/archive/v9.2.4.tar.gz
 URL:		https://github.com/citusdata/citus-enterprise


### PR DESCRIPTION
We had a wrong `License` type set in an RPM spec.