### PR TITLE
Preserve UNENCRYPTED_PACKAGE envvar in debuild

### DIFF
--- a/dockerfiles/debian-buster-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-buster-all/scripts/fetch_and_build_deb
@@ -172,6 +172,6 @@ pg_buildext updatecontrol
 procs="$(nproc)"
 mjobs="$(expr $procs + 1)"
 
-DEB_BUILD_OPTIONS="parallel=${mjobs}" debuild --preserve-envvar CONF_EXTRA_VERSION --preserve-envvar PACKAGE_ENCRYPTION_KEY -uc -us -B --lintian-opts --profile debian --allow-root
+DEB_BUILD_OPTIONS="parallel=${mjobs}" debuild --preserve-envvar CONF_EXTRA_VERSION --preserve-envvar UNENCRYPTED_PACKAGE --preserve-envvar PACKAGE_ENCRYPTION_KEY -uc -us -B --lintian-opts --profile debian --allow-root
 
 cp ../*.deb /packages

--- a/dockerfiles/debian-jessie-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-jessie-all/scripts/fetch_and_build_deb
@@ -172,6 +172,6 @@ pg_buildext updatecontrol
 procs="$(nproc)"
 mjobs="$(expr $procs + 1)"
 
-DEB_BUILD_OPTIONS="parallel=${mjobs}" debuild --preserve-envvar CONF_EXTRA_VERSION --preserve-envvar PACKAGE_ENCRYPTION_KEY -uc -us -B --lintian-opts --profile debian --allow-root
+DEB_BUILD_OPTIONS="parallel=${mjobs}" debuild --preserve-envvar CONF_EXTRA_VERSION --preserve-envvar UNENCRYPTED_PACKAGE --preserve-envvar PACKAGE_ENCRYPTION_KEY -uc -us -B --lintian-opts --profile debian --allow-root
 
 cp ../*.deb /packages

--- a/dockerfiles/debian-stretch-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-stretch-all/scripts/fetch_and_build_deb
@@ -172,6 +172,6 @@ pg_buildext updatecontrol
 procs="$(nproc)"
 mjobs="$(expr $procs + 1)"
 
-DEB_BUILD_OPTIONS="parallel=${mjobs}" debuild --preserve-envvar CONF_EXTRA_VERSION --preserve-envvar PACKAGE_ENCRYPTION_KEY -uc -us -B --lintian-opts --profile debian --allow-root
+DEB_BUILD_OPTIONS="parallel=${mjobs}" debuild --preserve-envvar CONF_EXTRA_VERSION --preserve-envvar UNENCRYPTED_PACKAGE --preserve-envvar PACKAGE_ENCRYPTION_KEY -uc -us -B --lintian-opts --profile debian --allow-root
 
 cp ../*.deb /packages

--- a/dockerfiles/ubuntu-bionic-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-bionic-all/scripts/fetch_and_build_deb
@@ -172,6 +172,6 @@ pg_buildext updatecontrol
 procs="$(nproc)"
 mjobs="$(expr $procs + 1)"
 
-DEB_BUILD_OPTIONS="parallel=${mjobs}" debuild --preserve-envvar CONF_EXTRA_VERSION --preserve-envvar PACKAGE_ENCRYPTION_KEY -uc -us -B --lintian-opts --profile debian --allow-root
+DEB_BUILD_OPTIONS="parallel=${mjobs}" debuild --preserve-envvar CONF_EXTRA_VERSION --preserve-envvar UNENCRYPTED_PACKAGE --preserve-envvar PACKAGE_ENCRYPTION_KEY -uc -us -B --lintian-opts --profile debian --allow-root
 
 cp ../*.deb /packages

--- a/dockerfiles/ubuntu-xenial-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-xenial-all/scripts/fetch_and_build_deb
@@ -172,6 +172,6 @@ pg_buildext updatecontrol
 procs="$(nproc)"
 mjobs="$(expr $procs + 1)"
 
-DEB_BUILD_OPTIONS="parallel=${mjobs}" debuild --preserve-envvar CONF_EXTRA_VERSION --preserve-envvar PACKAGE_ENCRYPTION_KEY -uc -us -B --lintian-opts --profile debian --allow-root
+DEB_BUILD_OPTIONS="parallel=${mjobs}" debuild --preserve-envvar CONF_EXTRA_VERSION --preserve-envvar UNENCRYPTED_PACKAGE --preserve-envvar PACKAGE_ENCRYPTION_KEY -uc -us -B --lintian-opts --profile debian --allow-root
 
 cp ../*.deb /packages

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -172,6 +172,6 @@ pg_buildext updatecontrol
 procs="$(nproc)"
 mjobs="$(expr $procs + 1)"
 
-DEB_BUILD_OPTIONS="parallel=${mjobs}" debuild --preserve-envvar CONF_EXTRA_VERSION --preserve-envvar PACKAGE_ENCRYPTION_KEY -uc -us -B --lintian-opts --profile debian --allow-root
+DEB_BUILD_OPTIONS="parallel=${mjobs}" debuild --preserve-envvar CONF_EXTRA_VERSION --preserve-envvar UNENCRYPTED_PACKAGE --preserve-envvar PACKAGE_ENCRYPTION_KEY -uc -us -B --lintian-opts --profile debian --allow-root
 
 cp ../*.deb /packages


### PR DESCRIPTION
Forward ~MICROSOFT_PACKAGE~ UNENCRYPTED_PACKAGE environment variable to debuild. This is needed for
packages to handle Microsoft builds correctly.