### PR TITLE
Merge all enterprise packaging in a single branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,65 @@ env:
     # passphrase for packaging gpg secret key
     - secure: "pZmrxStWj0vXaG/YAyJORvxfaKQHvr+O+66yjFF52gQTVd2zNb83Mn4zDLNqMwU3nkXEKYuFbpXKbDSMX9zNbE7W/w1ARSa8MVXnMVM3jbj+OCaBu7fyVrA0tvT3EZkMh943paTRcSyPSzd61P3CNOkcY1RycDHBbJtNrzSdUbdAy6//TWgNxC66dxSeHASRJIIs49caxQssMMSGRgC5aGH4KLU5eSdP3wnWDEHr+aLqaI2DF2W3lNMI0WJwtGN6cLEYzAsA3BkoPoYRFDd4jjTpolVdrFBXRaT1EIg0FXjsvjyFrQfQLBIqvSx42H5w4rCIYoKYYgRgCKDATLK8XxPbFsgPKLVSHFD6t9ebuYacYxS20oMakkqj5e98qMIWe2vkm+V9YNeADIlhYT+NsF9Kug2B6pLK+U+Hhj6TldFpP18snPXttRKzsg9QrGbnBUVq2wv60U7/3pWs+T3tpr9bIFyaUYbRRAwl/hv2hVkFiSdsiLB6tJphbILB7EDKBCu1iK9PC9tlYoGrqptRxj6bmlawOvcnEKRtoPNJ9eyrvHPDd8FmmW6xWbq89zJ97Ztl7VR8CzNePqvG9vwdtJigXovuXfzu4CHX+jOt3jvllB6rMprsK5r++qBzh1SS24sYqo/APtUfoYdkleWhC+tSuhbucZb2yGUCMo/ZhDo="
   matrix:
+    # Packages on packages.microsoft.com
     - TARGET_PLATFORM=el/6
     # Removed for now because it has no gcc4.8+ (which is required for security
     # compliance)
     # - TARGET_PLATFORM=ol/6
     - TARGET_PLATFORM=el/7
-    - TARGET_PLATFORM=ol/7
+    # Removed for now since we don't have oracle linux repos on microsoft
+    # - TARGET_PLATFORM=ol/7
     - TARGET_PLATFORM=el/8
     - TARGET_PLATFORM=debian/buster
     - TARGET_PLATFORM=debian/stretch
     - TARGET_PLATFORM=debian/jessie
     - TARGET_PLATFORM=ubuntu/bionic
     - TARGET_PLATFORM=ubuntu/xenial
+    # Packages on package cloud
+    - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=el/6
+    - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ol/6
+    - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=el/7
+    - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ol/7
+    - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=el/8
+    - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=debian/buster
+    - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=debian/stretch
+    - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=debian/jessie
+    - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ubuntu/bionic
+    - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ubuntu/xenial
 before_install:
-  - export PACKAGE_ENCRYPTION_KEY=verysecret
-  - git clone -b v0.7.14 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.7.15 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
+  - |
+    if [ -z "${UNENCRYPTED_PACKAGE:-}" ]; then
+    export PACKAGE_ENCRYPTION_KEY=verysecret
+    else
+    export PACKAGING_SECRET_KEY="$(openssl aes-256-cbc -K $encrypted_a39e3f1ee8ba_key -iv $encrypted_a39e3f1ee8ba_iv -in signing_key.asc.enc -d | base64)"
+    fi
 install: true
-script: "export PACKAGE_ENCRYPTION_KEY=verysecret && citus_package -p ${TARGET_PLATFORM} 'local' 'release'"
+script: |
+        if [ -z "${UNENCRYPTED_PACKAGE:-}" ]; then
+        citus_package -p ${TARGET_PLATFORM} 'local' 'release'
+        else
+        build_new_release
+        fi
+deploy:
+  - provider: packagecloud
+    username: "citusdata"
+    repository: $PKG_REPOTYPE
+    token: $PACKAGECLOUD_API_TOKEN
+    dist: $TARGET_PLATFORM
+    skip_cleanup: true
+    local-dir: "pkgs/releases"
+    on:
+      branch: "all-enterprise"
+      condition: -d "pkgs/releases"
+  - provider: packagecloud
+    username: "citusdata"
+    repository: "$PKG_REPOTYPE-nightlies"
+    token: $PACKAGECLOUD_API_TOKEN
+    dist: $TARGET_PLATFORM
+    skip_cleanup: true
+    local-dir: "pkgs/nightlies"
+    on:
+      branch: "all-enterprise"
+      condition: -d "pkgs/nightlies"

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script: |
         if [ -z "${UNENCRYPTED_PACKAGE:-}" ]; then
         citus_package -p ${TARGET_PLATFORM} 'local' 'release'
         else
-        build_new_release
+        build_new_release && build_new_nightly
         fi
 deploy:
   - provider: packagecloud

--- a/citus-enterprise.spec
+++ b/citus-enterprise.spec
@@ -334,7 +334,7 @@ done < "$secret_files_list"
 %endif
 
 %changelog
-* Tue Mar 31 2020 -  <Jelte.Fennema@microsoft.com> 9.2.4.citus-1
+* Tue Mar 31 2020 - Jelte Fennema <Jelte.Fennema@microsoft.com> 9.2.4.citus-1
 - Update to Citus Enterprise 9.2.4
 
 * Wed Mar 25 2020 - Jelte Fennema <Jelte.Fennema@microsoft.com> 9.2.3.citus-1

--- a/citus-enterprise.spec
+++ b/citus-enterprise.spec
@@ -64,6 +64,7 @@ make %{?_smp_mflags}
 %{__cp} README.md %{buildroot}%{pginstdir}/doc/extension/README-%{sname}.md
 
 set -eu
+set +x
 
 if [ -n "${UNENCRYPTED_PACKAGE:-}" ]; then
     exit 0

--- a/citus-enterprise.spec
+++ b/citus-enterprise.spec
@@ -4,6 +4,7 @@
 %global sname citus-enterprise
 %global pname citus
 %global debug_package %{nil}
+%global unencrypted_package "%{getenv:UNENCRYPTED_PACKAGE}"
 
 Summary:	PostgreSQL-based distributed RDBMS
 Name:		%{sname}%{?pkginfix}_%{pgmajorversion}
@@ -38,15 +39,21 @@ commands.
 
 %build
 
+# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
+SECURITY_CFLAGS="-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security"
+
 currentgccver="$(gcc -dumpversion)"
 requiredgccver="4.8.0"
 if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | tail -n1)" = "$requiredgccver" ]; then
-    echo ERROR: At least GCC version "$requiredgccver" is needed
-    exit 1
+    if [ -z "${UNENCRYPTED_PACKAGE:-}" ]; then
+        echo ERROR: At least GCC version "$requiredgccver" is needed to build Microsoft packages
+        exit 1
+    else
+        echo WARNING: Using slower security flags because of outdated compiler
+        SECURITY_CFLAGS="-fstack-protector-all -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security"
+    fi
 fi
 
-# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
-SECURITY_CFLAGS="-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security"
 %configure PG_CONFIG=%{pginstdir}/bin/pg_config --with-extra-version="%{?conf_extra_version}" CC=$(command -v gcc) CFLAGS="$SECURITY_CFLAGS"
 make %{?_smp_mflags}
 
@@ -57,6 +64,11 @@ make %{?_smp_mflags}
 %{__cp} README.md %{buildroot}%{pginstdir}/doc/extension/README-%{sname}.md
 
 set -eu
+
+if [ -n "${UNENCRYPTED_PACKAGE:-}" ]; then
+    exit 0
+fi
+
 dir="%{buildroot}"
 libdir="$dir/%{pginstdir}/lib"
 mkdir -p "$libdir"
@@ -69,6 +81,7 @@ PACKAGE_ENCRYPTION_KEY="${PACKAGE_ENCRYPTION_KEY:-}"
 if [ -z "$PACKAGE_ENCRYPTION_KEY" ]; then
     echo "ERROR: The PACKAGE_ENCRYPTION_KEY environment variable needs to be set"
     echo "HINT: If trying to build packages locally, just set it to 'abc' or something"
+    echo "HINT: If you're trying to build unencrypted packages you should set the UNENCRYPTED_PACKAGE environment variable"
     exit 1
 fi
 
@@ -288,20 +301,35 @@ done < "$secret_files_list"
 %license LICENSE
 %endif
 %doc %{pginstdir}/doc/extension/README-%{sname}.md
-/usr/bin/citus-enterprise-pg-%{pgmajorversion}-setup
 %{pginstdir}/include/server/citus_*.h
 %{pginstdir}/include/server/distributed/*.h
-%{pginstdir}/lib/citus_secret_files.metadata
-%{pginstdir}/lib/citus.so.gpg
 %{pginstdir}/share/extension/citus-*.sql
-%{pginstdir}/share/extension/citus.control.gpg
-%ifarch ppc64 ppc64le
-  %else
-  %if 0%{?rhel} && 0%{?rhel} <= 6
-  %else
-    %{pginstdir}/lib/bitcode/%{pname}*.bc.gpg
-    %{pginstdir}/lib/bitcode/%{pname}/*.bc.gpg
-    %{pginstdir}/lib/bitcode/%{pname}/*/*.bc.gpg
+
+%if %{unencrypted_package} != ""
+  %{pginstdir}/lib/citus.so
+  %{pginstdir}/share/extension/citus.control
+  %ifarch ppc64 ppc64le
+    %else
+    %if 0%{?rhel} && 0%{?rhel} <= 6
+    %else
+      %{pginstdir}/lib/bitcode/%{pname}*.bc
+      %{pginstdir}/lib/bitcode/%{pname}/*.bc
+      %{pginstdir}/lib/bitcode/%{pname}/*/*.bc
+    %endif
+  %endif
+%else
+  /usr/bin/citus-enterprise-pg-%{pgmajorversion}-setup
+  %{pginstdir}/lib/citus_secret_files.metadata
+  %{pginstdir}/lib/citus.so.gpg
+  %{pginstdir}/share/extension/citus.control.gpg
+  %ifarch ppc64 ppc64le
+    %else
+    %if 0%{?rhel} && 0%{?rhel} <= 6
+    %else
+      %{pginstdir}/lib/bitcode/%{pname}*.bc.gpg
+      %{pginstdir}/lib/bitcode/%{pname}/*.bc.gpg
+      %{pginstdir}/lib/bitcode/%{pname}/*/*.bc.gpg
+    %endif
   %endif
 %endif
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ citus-enterprise (9.2.4.citus-1) stable; urgency=low
 
   * Fixes a release problem in 9.2.3
 
- --  <Jelte.Fennema@microsoft.com>  Tue, 31 Mar 2020 8:41:10 +0000
+ -- Jelte Fennema <Jelte.Fennema@microsoft.com>  Tue, 31 Mar 2020 8:41:10 +0000
 
 citus-enterprise (9.2.3.citus-1) stable; urgency=low
 

--- a/debian/encrypt_files.sh
+++ b/debian/encrypt_files.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ -n "${UNENCRYPTED_PACKAGE:-}" ]; then
+    exit 0
+fi
+
 PACKAGE_ENCRYPTION_KEY="${PACKAGE_ENCRYPTION_KEY:-}"
 if [ -z "$PACKAGE_ENCRYPTION_KEY" ]; then
     echo "ERROR: The PACKAGE_ENCRYPTION_KEY environment variable needs to be set"
     echo "HINT: If trying to build packages locally, just set it to 'abc' or something"
+    echo "HINT: If you're trying to build unencrypted packages you should set the UNENCRYPTED_PACKAGE environment variable"
     exit 1
 fi
 


### PR DESCRIPTION
We now have three branches to release Citus Enterpris, i.e `redhat-enterprise`, `debian-enterprise` and `microsoft-enterprise`. This merges them all in a single branch. It does require #440, otherwise no encrypted packages will ever be built for debian based distros.