### PR TITLE
Update PGDG rpm repo paths

### DIFF
--- a/community-nightlies/rpm.sh
+++ b/community-nightlies/rpm.sh
@@ -155,7 +155,8 @@ finalize_zypper_repo ()
 
 detect_repo_url ()
 {
-  # set common defaults used by most flavors
+  # set common defaults used by all flavors
+  # Various repositories of different flavors are stored in EL (e.g. Centos and OL)
   family='redhat'
   family_short='EL'
   pkg_dist="${dist}"

--- a/community-nightlies/rpm.sh
+++ b/community-nightlies/rpm.sh
@@ -157,25 +157,11 @@ detect_repo_url ()
 {
   # set common defaults used by most flavors
   family='redhat'
-  family_short='rhel'
+  family_short='EL'
   pkg_dist="${dist}"
-  pkg_os="${os}"
-  pkg_version='2'
 
   case "${os}" in
-    ol)
-      pkg_os='oraclelinux'
-      ;;
-    fedora)
-      family='fedora'
-      family_short='fedora'
-      pkg_version='2'
-      ;;
-    centos)
-      # defaults are suitable
-      ;;
-    rhel|redhatenterpriseserver)
-      pkg_os='redhat'
+    ol|centos|rhel|redhatenterpriseserver)
       ;;
     *)
       unknown_os

--- a/community/rpm.sh
+++ b/community/rpm.sh
@@ -155,7 +155,8 @@ finalize_zypper_repo ()
 
 detect_repo_url ()
 {
-  # set common defaults used by most flavors
+  # set common defaults used by all flavors
+  # Various repositories of different flavors are stored in EL (e.g. Centos and OL)
   family='redhat'
   family_short='EL'
   pkg_dist="${dist}"

--- a/community/rpm.sh
+++ b/community/rpm.sh
@@ -159,23 +159,9 @@ detect_repo_url ()
   family='redhat'
   family_short='EL'
   pkg_dist="${dist}"
-  pkg_os="${os}"
-  pkg_version='2'
 
   case "${os}" in
-    ol)
-      pkg_os='oraclelinux'
-      ;;
-    fedora)
-      family='fedora'
-      family_short='fedora'
-      pkg_version='2'
-      ;;
-    centos)
-      # defaults are suitable
-      ;;
-    rhel|redhatenterpriseserver)
-      pkg_os='redhat'
+    ol|centos|rhel|redhatenterpriseserver)
       ;;
     *)
       unknown_os

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -187,25 +187,11 @@ detect_repo_url ()
 {
   # set common defaults used by most flavors
   family='redhat'
-  family_short='rhel'
+  family_short='EL'
   pkg_dist="${dist}"
-  pkg_os="${os}"
-  pkg_version='2'
 
   case "${os}" in
-    ol)
-      pkg_os='oraclelinux'
-      ;;
-    fedora)
-      family='fedora'
-      family_short='fedora'
-      pkg_version='2'
-      ;;
-    centos)
-      # defaults are suitable
-      ;;
-    rhel|redhatenterpriseserver)
-      pkg_os='redhat'
+    ol|centos|rhel|redhatenterpriseserver)
       ;;
     *)
       unknown_os
@@ -213,8 +199,8 @@ detect_repo_url ()
   esac
 
   repo_url="https://download.postgresql.org/pub/repos/yum/reporpms"
-  repo_url+="/${family}-${pkg_dist}-x86_64"
-  repo_url+="/pgdg-${family}-redhat-repo-latest.noarch.rpm"
+  repo_url+="/${family_short}-${pkg_dist}-x86_64"
+  repo_url+="/pgdg-${family}-repo-latest.noarch.rpm"
 }
 
 main ()

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -185,7 +185,8 @@ finalize_zypper_repo ()
 
 detect_repo_url ()
 {
-  # set common defaults used by most flavors
+  # set common defaults used by all flavors
+  # Various repositories of different flavors are stored in EL (e.g. Centos and OL)
   family='redhat'
   family_short='EL'
   pkg_dist="${dist}"

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -185,7 +185,8 @@ finalize_zypper_repo ()
 
 detect_repo_url ()
 {
-  # set common defaults used by most flavors
+  # set common defaults used by all flavors
+  # Various repositories of different flavors are stored in EL (e.g. Centos and OL)
   family='redhat'
   family_short='EL'
   pkg_dist="${dist}"

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -189,23 +189,9 @@ detect_repo_url ()
   family='redhat'
   family_short='EL'
   pkg_dist="${dist}"
-  pkg_os="${os}"
-  pkg_version='2'
 
   case "${os}" in
-    ol)
-      pkg_os='oraclelinux'
-      ;;
-    fedora)
-      family='fedora'
-      family_short='fedora'
-      pkg_version='2'
-      ;;
-    centos)
-      # defaults are suitable
-      ;;
-    rhel|redhatenterpriseserver)
-      pkg_os='redhat'
+    ol|centos|rhel|redhatenterpriseserver)
       ;;
     *)
       unknown_os
@@ -213,8 +199,8 @@ detect_repo_url ()
   esac
 
   repo_url="https://download.postgresql.org/pub/repos/yum/reporpms"
-  repo_url+="/${family}-${pkg_dist}-x86_64"
-  repo_url+="/pgdg-${family}-redhat-repo-latest.noarch.rpm"
+  repo_url+="/${family_short}-${pkg_dist}-x86_64"
+  repo_url+="/pgdg-${family}-repo-latest.noarch.rpm"
 }
 
 main ()


### PR DESCRIPTION
Recently PGDG rpm repository paths changed. I made the necessary changes to the `rpm.sh` files

- Removed fedora from the supported OS list 
- Removed unused variables

To test the script you can use the following to use the scripts in this branch:
```
curl https://raw.githubusercontent.com/citusdata/packaging/update-pgdg-rpm-paths/community/rpm.sh | sudo bash
```