### PR TITLE
Add travis to make sure dockerfiles build successfully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: required
+services: [ docker ]
+language: perl
+perl: "5.18"
+env:
+  matrix:
+    - TARGET_PLATFORM=centos,8
+    - TARGET_PLATFORM=centos,7
+    - TARGET_PLATFORM=centos,6
+    - TARGET_PLATFORM=debian,buster
+    - TARGET_PLATFORM=debian,jessie
+    - TARGET_PLATFORM=debian,stretch
+    - TARGET_PLATFORM=oraclelinux,7
+    - TARGET_PLATFORM=oraclelinux,6
+    - TARGET_PLATFORM=ubuntu,bionic
+    - TARGET_PLATFORM=ubuntu,xenial
+    - TARGET_PLATFORM=pgxn
+before_install:
+  - echo $TARGET_PLATFORM > os-list.csv
+install: true
+script:
+  - ./update_dockerfiles && git diff --exit-code dockerfiles
+  - git checkout -- dockerfiles && ./update_images

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ before_install:
   - echo $TARGET_PLATFORM > os-list.csv
 install: true
 script:
-  - ./update_dockerfiles && git diff --exit-code dockerfiles
+  #- ./update_dockerfiles && git diff --exit-code dockerfiles
   - git checkout -- dockerfiles && ./update_images

--- a/dockerfiles/centos-6-pg11/Dockerfile
+++ b/dockerfiles/centos-6-pg11/Dockerfile
@@ -26,7 +26,7 @@ RUN yum install -y centos-release-scl-rh epel-release \
         rpmlint \
         spectool \
         tar \
-    && yum install -y https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+    && yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && yum install -y postgresql11-server postgresql11-devel \
     && yum clean all
 

--- a/dockerfiles/centos-6-pg12/Dockerfile
+++ b/dockerfiles/centos-6-pg12/Dockerfile
@@ -26,7 +26,7 @@ RUN yum install -y centos-release-scl-rh epel-release \
         rpmlint \
         spectool \
         tar \
-    && yum install -y https://download.postgresql.org/pub/repos/yum/12/redhat/rhel-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+    && yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && yum install -y postgresql12-server  postgresql12-devel \
     && yum clean all
 

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -26,7 +26,7 @@ RUN yum install -y centos-release-scl-rh epel-release \
         rpmlint \
         spectool \
         tar \
-    && yum install -y https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+    && yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && yum install -y postgresql11-server postgresql11-devel \
     && yum clean all
 

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -26,7 +26,7 @@ RUN yum install -y centos-release-scl-rh epel-release \
         rpmlint \
         spectool \
         tar \
-    && yum install -y https://download.postgresql.org/pub/repos/yum/12/redhat/rhel-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+    && yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && yum install -y postgresql12-server postgresql12-devel \
     && yum clean all
 

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -24,7 +24,7 @@ RUN yum install -y epel-release \
         rpmlint \
         spectool \
         tar \
-    && yum install -y https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+    && yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && dnf -qy module disable postgresql \
     && yum install -y postgresql11-server postgresql11-devel \
     && yum clean all

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -7,6 +7,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 # https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
 RUN set -x \
 	&& apt-get update \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+	&& mkdir ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
 	&& { \
 		which gpg \
 # prefer gnupg2, to match APT's Recommends

--- a/dockerfiles/debian-jessie-all/Dockerfile
+++ b/dockerfiles/debian-jessie-all/Dockerfile
@@ -7,6 +7,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 # https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
 RUN set -x \
 	&& apt-get update \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+	&& mkdir ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
 	&& { \
 		which gpg \
 # prefer gnupg2, to match APT's Recommends

--- a/dockerfiles/debian-stretch-all/Dockerfile
+++ b/dockerfiles/debian-stretch-all/Dockerfile
@@ -7,6 +7,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 # https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
 RUN set -x \
 	&& apt-get update \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+	&& mkdir ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
 	&& { \
 		which gpg \
 # prefer gnupg2, to match APT's Recommends

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -25,7 +25,7 @@ RUN yum groupinstall -y 'Development Tools' \
         rpmlint \
         spectool \
         tar \
-    && yum install -y https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-6-x86_64/pgdg-oraclelinux11-11-2.noarch.rpm \
+    && yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && yum install -y  postgresql11-server postgresql11-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -36,7 +36,7 @@ RUN yum-config-manager --enable \
         rpmlint \
         spectool \
         tar \
-    && yum install -y https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-7-x86_64/pgdg-oraclelinux11-11-2.noarch.rpm \
+    && yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && yum install -y postgresql11-server postgresql11-devel \
     && yum clean all
 # install documentation generation libraries

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -7,6 +7,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 # https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
 RUN set -x \
 	&& apt-get update \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+	&& mkdir ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
 	&& { \
 		which gpg \
 # prefer gnupg2, to match APT's Recommends

--- a/dockerfiles/ubuntu-xenial-all/Dockerfile
+++ b/dockerfiles/ubuntu-xenial-all/Dockerfile
@@ -7,6 +7,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 # https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
 RUN set -x \
 	&& apt-get update \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+	&& mkdir ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
 	&& { \
 		which gpg \
 # prefer gnupg2, to match APT's Recommends

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -7,6 +7,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 # https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
 RUN set -x \
 	&& apt-get update \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+	&& mkdir ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
 	&& { \
 		which gpg \
 # prefer gnupg2, to match APT's Recommends

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -26,7 +26,7 @@ RUN yum install -y centos-release-scl-rh epel-release \
         rpmlint \
         spectool \
         tar \
-    && yum install -y https://%%rpm_url%% \
+    && yum install -y %%rpm_url%% \
     && yum install -y postgresql%%pgshort%%-devel \
     && yum clean all
 

--- a/update_dockerfiles
+++ b/update_dockerfiles
@@ -31,8 +31,7 @@ function update_rpm_dockerfile {
         exit $badusage
     fi
 
-    rpm=$(lftp -e 'cls -1; bye' "https://${rpms_url}" | egrep "$file_pattern" | sort -t'-' -k4 -nr | head -n1)
-    rpm_url=${rpms_url}${rpm}
+    rpm_url=https://download.postgresql.org/pub/repos/yum/reporpms/EL-$release-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 
     mkdir -p "${target_subdir}"
 


### PR DESCRIPTION
This checks 2 things:
1. The dockerfiles are all up to date (commented out, because it's currently failing, @hanefi is fixing the cause)
2. The dockerfiles can all build images

A future improvement would be to actually publish the updated docker images when merging into `develop`. But that requires some more work. This was an easy first step, that at least ensures some basic quality.