### PR TITLE
Fix issues on travis with docker images

### DIFF
--- a/dockerfiles/centos-6-pg11/Dockerfile
+++ b/dockerfiles/centos-6-pg11/Dockerfile
@@ -48,10 +48,6 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
 
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
-    && yum clean all
-
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \

--- a/dockerfiles/centos-6-pg12/Dockerfile
+++ b/dockerfiles/centos-6-pg12/Dockerfile
@@ -48,10 +48,6 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
 
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
-    && yum clean all
-
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -48,10 +48,6 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
 
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
-    && yum clean all
-
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -48,10 +48,6 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
 
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
-    && yum clean all
-
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -48,10 +48,6 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
 
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
-    && yum clean all
-
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -48,10 +48,6 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
 
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
-    && yum clean all
-
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -29,6 +29,8 @@ RUN set -ex; \
 # uid                  PostgreSQL Debian Repository
     key='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8'; \
     export GNUPGHOME="$(mktemp -d)"; \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf; \
     gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
     gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/postgres.gpg; \
     command -v gpgconf > /dev/null && gpgconf --kill all; \

--- a/dockerfiles/debian-jessie-all/Dockerfile
+++ b/dockerfiles/debian-jessie-all/Dockerfile
@@ -29,6 +29,8 @@ RUN set -ex; \
 # uid                  PostgreSQL Debian Repository
     key='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8'; \
     export GNUPGHOME="$(mktemp -d)"; \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf; \
     gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
     gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/postgres.gpg; \
     command -v gpgconf > /dev/null && gpgconf --kill all; \

--- a/dockerfiles/debian-stretch-all/Dockerfile
+++ b/dockerfiles/debian-stretch-all/Dockerfile
@@ -29,6 +29,8 @@ RUN set -ex; \
 # uid                  PostgreSQL Debian Repository
     key='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8'; \
     export GNUPGHOME="$(mktemp -d)"; \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf; \
     gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
     gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/postgres.gpg; \
     command -v gpgconf > /dev/null && gpgconf --kill all; \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -48,10 +48,6 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
 
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
-    && yum clean all
-
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -48,10 +48,6 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
 
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
-    && yum clean all
-
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -48,10 +48,6 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
 
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
-    && yum clean all
-
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -48,10 +48,6 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
 
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
-    && yum clean all
-
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -48,10 +48,6 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
 
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
-    && yum clean all
-
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -48,10 +48,6 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
 
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
-    && yum clean all
-
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -29,6 +29,8 @@ RUN set -ex; \
 # uid                  PostgreSQL Debian Repository
     key='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8'; \
     export GNUPGHOME="$(mktemp -d)"; \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf; \
     gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
     gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/postgres.gpg; \
     command -v gpgconf > /dev/null && gpgconf --kill all; \

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -29,6 +29,8 @@ RUN set -ex; \
 # uid                  PostgreSQL Debian Repository
     key='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8'; \
     export GNUPGHOME="$(mktemp -d)"; \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf; \
     gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
     gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/postgres.gpg; \
     command -v gpgconf > /dev/null && gpgconf --kill all; \

--- a/dockerfiles/ubuntu-xenial-all/Dockerfile
+++ b/dockerfiles/ubuntu-xenial-all/Dockerfile
@@ -29,6 +29,8 @@ RUN set -ex; \
 # uid                  PostgreSQL Debian Repository
     key='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8'; \
     export GNUPGHOME="$(mktemp -d)"; \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf; \
     gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
     gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/postgres.gpg; \
     command -v gpgconf > /dev/null && gpgconf --kill all; \

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -29,6 +29,8 @@ RUN set -ex; \
 # uid                  PostgreSQL Debian Repository
     key='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8'; \
     export GNUPGHOME="$(mktemp -d)"; \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf; \
     gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
     gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/postgres.gpg; \
     command -v gpgconf > /dev/null && gpgconf --kill all; \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -48,10 +48,6 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
          -o /usr/bin/jq \
     && chmod +x /usr/bin/jq
 
-# install latest Citus release to get header files
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.rpm.sh | bash \
-    && yum clean all
-
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \


### PR DESCRIPTION
1. Don't install citus packages anymore. They were only needed for the
   shard_rebalancer, which is now part of citus.
2. Put the ipv6 fix for gpg in the temporary gpg home directory too.