### PR TITLE
Fix conditinal branch rules before docker push

### DIFF
--- a/ci/push_images
+++ b/ci/push_images
@@ -12,7 +12,7 @@ badusage=64
 
 nprocs="${1:-1}"
 
-if [[ $(git rev-parse --abbrev-ref HEAD) != develop ]]; then
+if [[ $TRAVIS_PULL_REQUEST != "false" ]] || [[ $TRAVIS_BRANCH != "develop" ]] ; then
     echo "PR is not merged to develop, not pushing to DockerHub"
     exit 0;
 fi


### PR DESCRIPTION
For some reason we can not detect the git branch name properly. Using Travis envvars instead.

[Travis Docs](https://docs.travis-ci.com/user/environment-variables/) for environment variables: 
> TRAVIS_BRANCH:
> - for push builds, or builds not triggered by a pull request, this is the name of the branch.
> - for builds triggered by a pull request this is the name of the branch targeted by the pull request.
> - for builds triggered by a tag, this is the same as the name of the tag (TRAVIS_TAG).

> TRAVIS_PULL_REQUEST: The pull request number if the current job is a pull request, “false” if it’s not a pull request.
> 