### PR TITLE
Depend on the correct version of the cli

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -19,7 +19,7 @@ Description: Command line interface and service to manage pg auto failover Clust
 
 Package: postgresql-PGVERSION-auto-failover
 Architecture: any
-Depends: ${shlibs:Depends},${misc:Depends}, postgresql-PGVERSION, pg-auto-failover-cli
+Depends: ${shlibs:Depends},${misc:Depends}, postgresql-PGVERSION, pg-auto-failover-cli (= ${binary:Version})
 Provides: postgresql-PGVERSION-auto-failover
 Conflicts: postgresql-PGVERSION-auto-failover
 Description: Postgres high availability support


### PR DESCRIPTION
Without this the CLI and the extension might go out of sync, which you never
want.