### PR TITLE
Set version of virtual package too

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -10,7 +10,7 @@ Homepage: https://github.com/citusdata/pg_auto_failover
 Package: pg-auto-failover-cli
 Architecture: any
 Depends: ${shlibs:Depends},${misc:Depends}
-Provides: pg-auto-failover-cli
+Provides: pg-auto-failover-cli (= ${binary:Version})
 Conflicts: pg-auto-failover-cli
 Recommends: postgresql-10-auto-failover | postgresql-11-auto-failover | postgresql-12-auto-failover
 Description: Command line interface and service to manage pg auto failover Clusters


### PR DESCRIPTION
When trying to install the packages in a docker container after merging
https://github.com/citusdata/packaging/pull/482 it didn't work.
This was because no package provided the correct version of
`pg-auto-failover-cli`. This sets the version of the virtual package too, so this
error does not occur.

For some reason my own environment didn't complain about this.