### PR TITLE
Introduce Citus 9.3.0 package for ubuntu/focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
     - TARGET_PLATFORM=debian/jessie
     - TARGET_PLATFORM=ubuntu/bionic
     - TARGET_PLATFORM=ubuntu/xenial
+    - TARGET_PLATFORM=ubuntu/focal
 before_install:
   - git clone -b v0.7.15 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
     - TARGET_PLATFORM=el/7
     - TARGET_PLATFORM=ol/7
     - TARGET_PLATFORM=el/8
+    #  Below commented out, because packagecloud does not support ol/8 packages yet.
+    #- TARGET_PLATFORM=ol/8
     - TARGET_PLATFORM=debian/buster
     - TARGET_PLATFORM=debian/stretch
     - TARGET_PLATFORM=debian/jessie

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,18 @@ env:
     # Docker Hub URL to trigger new nightly image
     - secure: "A3mqytw2Tq/jSBYgBgMrP3sSHXhkRXMeHmsVlsrzrzgnQskJ62c+QbGMomHY71y8JSJWEWsmCCLBuayF9TwMVnbiELGQFSxX2Aw7sy3wNunk6rNKs166od3K0d9YctIBrqcBm25YUOby4FlYAluxipix4gqq8JayPkP4n3x+it9hyCGZL6WYhreEfIkmH2sISbjGZJ5PggsymlAQdBepvQRuBQTNysNFySw9ENme1tqgf3eiG/m9bvghkVphJwrkfFyC+LauhQGopjq5rXTR2yvB7zlj4LYAP65qtRQrkYOax0w5qpy4StxgsP5Q8JnW8qk+JM5lwLE8worMcYt8I6epclWOl4jkhCraIGm4XGOFzdcs/W2fBYeI9UFJBaPgt9RoxsSs8m6ER6ivDyaFkZ72gMwViogZnf5VABXoZ8tgaxYHfaT89OW2/X4x9V6ONv7jWy3xvdNUYqiDqHeWZSjMC+1JqhCEgMu23sL1u+gMXbCYSFq2dIh4pVRyK2H/StTHDP4teHlA2+OCFkfL/eQ2K0QunjPZxPU2+/V+zlUNWI4pEMV92JVQtjMZMcrDCS1DATXaasHpgphCexFEDqQwwKQoMh5j17nUBHjYxKqle5akakd/ShSi3F02uE3FGbIMSaYSreXdSjbzK8bkFU6q5rn0Fem0w20pcVyYPV8="
   matrix:
-    - TARGET_PLATFORM=el/6
-    - TARGET_PLATFORM=ol/6
-    - TARGET_PLATFORM=el/7
-    - TARGET_PLATFORM=ol/7
-    - TARGET_PLATFORM=el/8
+    #- TARGET_PLATFORM=el/6
+    #- TARGET_PLATFORM=ol/6
+    #- TARGET_PLATFORM=el/7
+    #- TARGET_PLATFORM=ol/7
+    #- TARGET_PLATFORM=el/8
     #  Below commented out, because packagecloud does not support ol/8 packages yet.
     #- TARGET_PLATFORM=ol/8
-    - TARGET_PLATFORM=debian/buster
-    - TARGET_PLATFORM=debian/stretch
-    - TARGET_PLATFORM=debian/jessie
-    - TARGET_PLATFORM=ubuntu/bionic
-    - TARGET_PLATFORM=ubuntu/xenial
+    #- TARGET_PLATFORM=debian/buster
+    #- TARGET_PLATFORM=debian/stretch
+    #- TARGET_PLATFORM=debian/jessie
+    #- TARGET_PLATFORM=ubuntu/bionic
+    #- TARGET_PLATFORM=ubuntu/xenial
     - TARGET_PLATFORM=ubuntu/focal
 before_install:
   - git clone -b v0.7.17 --depth 1 https://github.com/citusdata/tools.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - TARGET_PLATFORM=ubuntu/xenial
     - TARGET_PLATFORM=ubuntu/focal
 before_install:
-  - git clone -b v0.7.15 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.7.17 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - export PACKAGING_SECRET_KEY="$(openssl aes-256-cbc -K $encrypted_a39e3f1ee8ba_key -iv $encrypted_a39e3f1ee8ba_iv -in signing_key.asc.enc -d | base64)"
 install: true


### PR DESCRIPTION
This pr aims to:
* Add ol/8 to build matrix as commented out
* Add ubuntu/focal to build matrix
* Use v0.7.17 of tools for ubuntu/focal support
* Trigger packaging only for ubuntu/focal as we missed it for 9.3.0 by commenting out the other items in the build matrix (This last commit should be reverted in the next release)