### PR TITLE
Bump Citus Enterprise version to 9.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
     - TARGET_PLATFORM=debian/jessie
     - TARGET_PLATFORM=ubuntu/bionic
     - TARGET_PLATFORM=ubuntu/xenial
+    - TARGET_PLATFORM=ubuntu/focal
     # Packages on package cloud
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=el/6
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ol/6
@@ -37,6 +38,7 @@ env:
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=debian/jessie
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ubuntu/bionic
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ubuntu/xenial
+    - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ubuntu/focal
 before_install:
   - git clone -b v0.7.15 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ubuntu/xenial
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ubuntu/focal
 before_install:
-  - git clone -b v0.7.15 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.7.17 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - |
     if [ -z "${UNENCRYPTED_PACKAGE:-}" ]; then

--- a/citus-enterprise.spec
+++ b/citus-enterprise.spec
@@ -10,11 +10,11 @@ Summary:	PostgreSQL-based distributed RDBMS
 Name:		%{sname}%{?pkginfix}_%{pgmajorversion}
 Provides:	citus_%{pgmajorversion}
 Conflicts:	citus_%{pgmajorversion}
-Version:	9.2.4.citus
+Version:	9.3.0.citus
 Release:	1%{dist}
 License:	Commercial
 Group:		Applications/Databases
-Source0:	https://github.com/citusdata/citus-enterprise/archive/v9.2.4.tar.gz
+Source0:	https://github.com/citusdata/citus-enterprise/archive/v9.3.0.tar.gz
 URL:		https://github.com/citusdata/citus-enterprise
 BuildRequires:	postgresql%{pgmajorversion}-devel libcurl-devel
 Requires:	postgresql%{pgmajorversion}-server
@@ -341,6 +341,9 @@ done < "$secret_files_list"
 %endif
 
 %changelog
+* Wed May 27 2020 - Onur Tirtir <Onur.Tirtir@microsoft.com> 9.3.0.citus-1
+- Official 9.3.0 release of Citus Enterprise
+
 * Tue Mar 31 2020 - Jelte Fennema <Jelte.Fennema@microsoft.com> 9.2.4.citus-1
 - Update to Citus Enterprise 9.2.4
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,83 @@
+citus-enterprise (9.3.0.citus-1) stable; urgency=low
+
+  * Adds max_shared_pool_size to control number of connections across sessions
+
+  * Adds support for window functions on coordinator
+
+  * Improves shard pruning logic to understand OR-conditions
+
+  * Prevents using an extra connection for intermediate result multi-casts
+
+  * Adds propagation of CREATE ROLE and ALTER ROLE .. SET statements
+
+  * Adds update_distributed_table_colocation UDF to update colocation of tables
+
+  * Introduces a UDF to truncate local data after distributing a table
+
+  * Adds support for creating temp schemas in parallel
+
+  * Adds support for evaluation of nextval in the target list on coordinator
+
+  * Adds support for local execution of COPY/TRUNCATE/DROP/DDL commands
+
+  * Adds support for local execution of shard creation
+
+  * Uses local execution in a transaction block
+
+  * Adds support for querying distributed table sizes concurrently
+
+  * Allows master_copy_shard_placement to replicate placements to new nodes
+
+  * Allows table type to be used in target list
+
+  * Avoids having multiple maintenance daemons active for a single database
+
+  * Defers reference table replication to shard creation time
+
+  * Enables joins between local tables and reference tables in transaction blocks
+
+  * Ignores pruned target list entries in coordinator plan
+
+  * Improves SIGTERM handling of maintenance daemon
+
+  * Increases the default of citus.node_connection_timeout to 30 seconds
+
+  * Fixes a bug that occurs when creating remote tasks in local execution
+
+  * Fixes a bug that causes some DML queries containing aggregates to fail
+
+  * Fixes a bug that could cause failures in queries with subqueries or CTEs
+
+  * Fixes a bug that may cause some connection failures to throw errors
+
+  * Fixes a bug which caused queries with SRFs and function evalution to fail
+
+  * Fixes a bug with generated columns when executing COPY dist_table TO file
+
+  * Fixes a crash when using non-constant limit clauses
+
+  * Fixes a failure when composite types used in prepared statements
+
+  * Fixes a possible segfault when dropping dist. table in a transaction block
+
+  * Fixes a possible segfault when non-pushdownable aggs are solely used in HAVING
+
+  * Fixes a segfault when executing queries using GROUPING
+
+  * Fixes an error when using LEFT JOIN with GROUP BY on primary key
+
+  * Fixes an issue with distributing tables having generated cols not at the end
+
+  * Fixes automatic SSL permission issue when using "initdb --allow-group-access"
+
+  * Fixes errors which could occur when subqueries are parameters to aggregates
+
+  * Fixes possible issues by invalidating the plan cache in master_update_node
+
+  * Fixes timing issues which could be caused by changing system clock
+
+ -- Onur Tirtir <Onur.Tirtir@microsoft.com>  Wed, 27 May 2020 7:45:21 +0000
+
 citus-enterprise (9.2.4.citus-1) stable; urgency=low
 
   * Fixes a release problem in 9.2.3

--- a/pkgvars
+++ b/pkgvars
@@ -1,6 +1,6 @@
 pkgname=citus-enterprise
 pkgdesc='Citus Enterprise'
-pkglatest=9.2.4.citus-1
+pkglatest=9.3.0.citus-1
 releasepg=11,12
 nightlypg=11,12
 nightlyref=enterprise-master


### PR DESCRIPTION
This pr aims to:
* Bump Citus Enterprise version to 9.3.0
* Add Ubuntu/Focal to build matrix
* Use tools 0.7.17 to support package build for Ubuntu/Focal