### PR TITLE
Fix determine_email so it recognizes bots@citusdata.com for nightly package builds

### DIFF
--- a/dockerfiles/centos-6-pg10/scripts/determine_email
+++ b/dockerfiles/centos-6-pg10/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/centos-6-pg11/scripts/determine_email
+++ b/dockerfiles/centos-6-pg11/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/centos-6-pg12/scripts/determine_email
+++ b/dockerfiles/centos-6-pg12/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/centos-7-pg10/scripts/determine_email
+++ b/dockerfiles/centos-7-pg10/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/centos-7-pg11/scripts/determine_email
+++ b/dockerfiles/centos-7-pg11/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/centos-7-pg12/scripts/determine_email
+++ b/dockerfiles/centos-7-pg12/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/centos-8-pg10/scripts/determine_email
+++ b/dockerfiles/centos-8-pg10/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/centos-8-pg11/scripts/determine_email
+++ b/dockerfiles/centos-8-pg11/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/centos-8-pg12/scripts/determine_email
+++ b/dockerfiles/centos-8-pg12/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/debian-buster-all/scripts/determine_email
+++ b/dockerfiles/debian-buster-all/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/debian-jessie-all/scripts/determine_email
+++ b/dockerfiles/debian-jessie-all/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/debian-stretch-all/scripts/determine_email
+++ b/dockerfiles/debian-stretch-all/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/oraclelinux-6-pg10/scripts/determine_email
+++ b/dockerfiles/oraclelinux-6-pg10/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/oraclelinux-6-pg11/scripts/determine_email
+++ b/dockerfiles/oraclelinux-6-pg11/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/oraclelinux-6-pg12/scripts/determine_email
+++ b/dockerfiles/oraclelinux-6-pg12/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/oraclelinux-7-pg10/scripts/determine_email
+++ b/dockerfiles/oraclelinux-7-pg10/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/oraclelinux-7-pg11/scripts/determine_email
+++ b/dockerfiles/oraclelinux-7-pg11/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/oraclelinux-7-pg12/scripts/determine_email
+++ b/dockerfiles/oraclelinux-7-pg12/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/oraclelinux-8-pg10/scripts/determine_email
+++ b/dockerfiles/oraclelinux-8-pg10/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/oraclelinux-8-pg11/scripts/determine_email
+++ b/dockerfiles/oraclelinux-8-pg11/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/oraclelinux-8-pg12/scripts/determine_email
+++ b/dockerfiles/oraclelinux-8-pg12/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/ubuntu-bionic-all/scripts/determine_email
+++ b/dockerfiles/ubuntu-bionic-all/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/ubuntu-focal-all/scripts/determine_email
+++ b/dockerfiles/ubuntu-focal-all/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/dockerfiles/ubuntu-xenial-all/scripts/determine_email
+++ b/dockerfiles/ubuntu-xenial-all/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then

--- a/scripts/determine_email
+++ b/scripts/determine_email
@@ -11,8 +11,9 @@ failure=1
 # fallback to public email
 email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
 
-# find the first verified Microsoft email
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$")))) | first | .email // empty'
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
 citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
 
 if [ -n "${citusemail}" ]; then


### PR DESCRIPTION
Due to the last changes (#509 & #510 ) that we made in `determine_email`, that script wasn't able to fetch the email address of the bot account as its email address was ending with @citusdata.com.

Try to do an exact match for bots@citusdata.com email if can't find Microsoft email.

This was blocking cron job to create nightly packages because determine_email couldn't determine email of our bot account.