### PR TITLE
Use locale=C.utf8 in rpmdev-bumpspec for el/8 builds

### DIFF
--- a/dockerfiles/centos-6-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-6-pg10/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-6-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-6-pg11/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-6-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-6-pg12/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-7-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg10/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-7-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg11/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-7-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg12/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-8-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg10/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-8-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg11/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-8-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg12/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-6-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg10/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-6-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg11/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-6-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg12/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-7-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg10/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-7-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg11/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-7-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg12/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-8-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg10/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-8-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg11/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-8-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg12/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/scripts/fetch_and_build_rpm
+++ b/scripts/fetch_and_build_rpm
@@ -156,7 +156,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
 osname=$(awk '{print $1}' /etc/system-release)
 if [ "${osname}" == 'Oracle' ]; then
     locale='C'
-elif [ "${osname}" == 'Fedora' ]; then
+elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'


### PR DESCRIPTION
This was blocking nighly package builds for community/el/8 by throwing
below error:
rpmdev-bumpspec: error: 'ascii' codec can't decode byte ..