### PR TITLE
Update required gcc version from 4.8.0 to 4.8.2

### DIFF
--- a/citus-enterprise.spec
+++ b/citus-enterprise.spec
@@ -43,7 +43,7 @@ commands.
 SECURITY_CFLAGS="-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security"
 
 currentgccver="$(gcc -dumpversion)"
-requiredgccver="4.8.0"
+requiredgccver="4.8.2"
 if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | tail -n1)" = "$requiredgccver" ]; then
     if [ -z "${UNENCRYPTED_PACKAGE:-}" ]; then
         echo ERROR: At least GCC version "$requiredgccver" is needed to build Microsoft packages

--- a/debian/check-gcc-version.sh
+++ b/debian/check-gcc-version.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 currentgccver="$($(pg_config --cc) -dumpversion)"
-requiredgccver="4.8.0"
+requiredgccver="4.8.2"
 if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | tail -n1)" = "$requiredgccver" ]; then
     echo ERROR: At least GCC version "$requiredgccver" is needed
     exit 1


### PR DESCRIPTION
For security, microsoft recommends using gcc4.8.2+, hence required gcc
version is upgraded.