### PR TITLE
Update gcc version from 4.8.0 to 4.8.2

### DIFF
--- a/debian/check-gcc-version.sh
+++ b/debian/check-gcc-version.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 currentgccver="$($(pg_config --cc) -dumpversion)"
-requiredgccver="4.8.0"
+requiredgccver="4.8.2"
 if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | tail -n1)" = "$requiredgccver" ]; then
     echo ERROR: At least GCC version "$requiredgccver" is needed
     exit 1

--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,9 @@ override_dh_auto_clean:
 	+make -C $(shell pwd)/src/bin/pg_autoctl clean
 	+pg_buildext clean $(shell pwd)/src/monitor build-%v
 
+override_dh_auto_configure:
+	debian/check-gcc-version.sh
+
 override_dh_auto_test:
 	# nothing to do here, see debian/tests/* instead
 

--- a/pg-auto-failover-enterprise.spec
+++ b/pg-auto-failover-enterprise.spec
@@ -39,7 +39,7 @@ SHARED_LIB_SECURITY_CFLAGS="-fpic"
 EXECUTABLE_SECURITY_CFLAGS="-fpie -Wl,-pie -Wl,-z,defs"
 
 currentgccver="$(gcc -dumpversion)"
-requiredgccver="4.8.0"
+requiredgccver="4.8.2"
 if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | tail -n1)" = "$requiredgccver" ]; then
     if [ -z "${UNENCRYPTED_PACKAGE:-}" ]; then
         echo ERROR: At least GCC version "$requiredgccver" is needed to build Microsoft packages


### PR DESCRIPTION
Related to #517 

What other branches do we use packaging pg_auto_failover or citus community/enterprise so that I can update them as well