### PR TITLE
Pass security flags and check gcc version

### DIFF
--- a/citus.spec
+++ b/citus.spec
@@ -45,6 +45,11 @@ if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | tail -n1)" 
     fi
 fi
 
+gccgte8=$(expr `gcc -dumpversion | cut -f1 -d.` \>= 8)
+ifeq "$(gccgte8)" "1"
+    SECURITY_CFLAGS += -fstack-clash-protection
+endif
+
 %build
 %configure PG_CONFIG=%{pginstdir}/bin/pg_config --with-extra-version="%{?conf_extra_version}" CC=$(command -v gcc) CFLAGS="$SECURITY_CFLAGS"
 make %{?_smp_mflags}

--- a/debian/check-gcc-version.sh
+++ b/debian/check-gcc-version.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euxo pipefail
+
+currentgccver="$($(pg_config --cc) -dumpversion)"
+requiredgccver="4.8.2"
+if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | tail -n1)" = "$requiredgccver" ]; then
+    echo ERROR: At least GCC version "$requiredgccver" is needed
+    exit 1
+fi

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,8 @@
 include /usr/share/postgresql-common/pgxs_debian_control.mk
 
 override_dh_auto_build:
-	+pg_buildext build build-%v
+	# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
+	+pg_buildext build build-%v '$(CFLAGS) -fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security'
 
 override_dh_auto_clean:
 	+pg_buildext clean build-%v
@@ -12,6 +13,7 @@ override_dh_auto_test:
 	# nothing to do here, see debian/tests/* instead
 
 override_dh_auto_configure:
+	debian/check-gcc-version.sh
 	+pg_buildext configure build-%v --with-extra-version="$${CONF_EXTRA_VERSION:-}"
 
 override_dh_auto_install:

--- a/debian/rules
+++ b/debian/rules
@@ -2,9 +2,17 @@
 
 include /usr/share/postgresql-common/pgxs_debian_control.mk
 
+# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
+SECURITY_CFLAGS=-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security
+
+GCCVERSIONGTE8=$(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 8)
+ifeq "$(GCCVERSIONGTE8)" "1"
+    # if gcc version is greater than or equal to 8 we should also use this flag
+    SECURITY_CFLAGS += -fstack-clash-protection
+endif
+
 override_dh_auto_build:
-	# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
-	+pg_buildext build build-%v '$(CFLAGS) -fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security'
+	+pg_buildext build build-%v '$(CFLAGS) $(SECURITY_CFLAGS)'
 
 override_dh_auto_clean:
 	+pg_buildext clean build-%v


### PR DESCRIPTION
We were not passing security flags for citus community packages, which
we are for enterprise.

Also this adds the check for gcc version to make sure we are compliant
with security.