### PR TITLE
Fix a logic error in gcc version check

### DIFF
--- a/pg-auto-failover-enterprise.spec
+++ b/pg-auto-failover-enterprise.spec
@@ -40,7 +40,7 @@ EXECUTABLE_SECURITY_CFLAGS="-fpie -Wl,-pie -Wl,-z,defs"
 
 currentgccver="$(gcc -dumpversion)"
 requiredgccver="4.8.2"
-if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | tail -n1)" = "$requiredgccver" ]; then
+if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | head -n1)" != "$requiredgccver" ]; then
     if [ -z "${UNENCRYPTED_PACKAGE:-}" ]; then
         echo ERROR: At least GCC version "$requiredgccver" is needed to build Microsoft packages
         exit 1


### PR DESCRIPTION
We shouldn't enter the if block if the gcc version is equal ot the requiredgccversion.