### PR TITLE
Fail in determine_name if any commands fails

### DIFF
--- a/dockerfiles/centos-7-pg10/scripts/determine_name
+++ b/dockerfiles/centos-7-pg10/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/centos-7-pg11/scripts/determine_name
+++ b/dockerfiles/centos-7-pg11/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/centos-7-pg12/scripts/determine_name
+++ b/dockerfiles/centos-7-pg12/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/centos-7-pg13/scripts/determine_name
+++ b/dockerfiles/centos-7-pg13/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/centos-7-pg14/scripts/determine_name
+++ b/dockerfiles/centos-7-pg14/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/centos-8-pg10/scripts/determine_name
+++ b/dockerfiles/centos-8-pg10/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/centos-8-pg11/scripts/determine_name
+++ b/dockerfiles/centos-8-pg11/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/centos-8-pg12/scripts/determine_name
+++ b/dockerfiles/centos-8-pg12/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/centos-8-pg13/scripts/determine_name
+++ b/dockerfiles/centos-8-pg13/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/centos-8-pg14/scripts/determine_name
+++ b/dockerfiles/centos-8-pg14/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/debian-bullseye-all/scripts/determine_name
+++ b/dockerfiles/debian-bullseye-all/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/debian-buster-all/scripts/determine_name
+++ b/dockerfiles/debian-buster-all/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/debian-stretch-all/scripts/determine_name
+++ b/dockerfiles/debian-stretch-all/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-6-pg10/scripts/determine_name
+++ b/dockerfiles/oraclelinux-6-pg10/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-6-pg11/scripts/determine_name
+++ b/dockerfiles/oraclelinux-6-pg11/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-6-pg12/scripts/determine_name
+++ b/dockerfiles/oraclelinux-6-pg12/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-6-pg14/scripts/determine_name
+++ b/dockerfiles/oraclelinux-6-pg14/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-7-pg10/scripts/determine_name
+++ b/dockerfiles/oraclelinux-7-pg10/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-7-pg11/scripts/determine_name
+++ b/dockerfiles/oraclelinux-7-pg11/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-7-pg12/scripts/determine_name
+++ b/dockerfiles/oraclelinux-7-pg12/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-7-pg13/scripts/determine_name
+++ b/dockerfiles/oraclelinux-7-pg13/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-7-pg14/scripts/determine_name
+++ b/dockerfiles/oraclelinux-7-pg14/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-8-pg10/scripts/determine_name
+++ b/dockerfiles/oraclelinux-8-pg10/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-8-pg11/scripts/determine_name
+++ b/dockerfiles/oraclelinux-8-pg11/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-8-pg12/scripts/determine_name
+++ b/dockerfiles/oraclelinux-8-pg12/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-8-pg13/scripts/determine_name
+++ b/dockerfiles/oraclelinux-8-pg13/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/oraclelinux-8-pg14/scripts/determine_name
+++ b/dockerfiles/oraclelinux-8-pg14/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/ubuntu-bionic-all/scripts/determine_name
+++ b/dockerfiles/ubuntu-bionic-all/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/dockerfiles/ubuntu-focal-all/scripts/determine_name
+++ b/dockerfiles/ubuntu-focal-all/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants

--- a/scripts/determine_name
+++ b/scripts/determine_name
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make bash behave
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 # constants


### PR DESCRIPTION
I didn't have `jq` installed and it would not fail because `-e` option wasn't set.