### PR TITLE
Use locale=C.utf8 in rpmdev-bumpspec for ol/8 builds

### DIFF
--- a/dockerfiles/centos-6-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-6-pg10/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-6-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-6-pg11/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-6-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-6-pg12/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-6-pg13/Dockerfile
+++ b/dockerfiles/centos-6-pg13/Dockerfile
@@ -1,0 +1,80 @@
+# vim:set ft=dockerfile:
+FROM centos:6
+
+# FIXME: Hack around docker/docker#10180
+RUN ( yum install -y yum-plugin-ovl || yum install -y yum-plugin-ovl || touch /var/lib/rpm/* ) \
+    && yum clean all
+
+# Enable some other repos for some dependencies in OL/7 
+# see https://oracle-base.com/articles/linux/download-the-latest-oracle-linux-repo-file#oracle-linux-7-updated
+RUN [[ centos != oraclelinux ]] || [[ 6 != 7 ]] || ( \
+        pushd /etc/yum.repos.d/ \
+        && rm -f * \
+        && curl -O http://yum.oracle.com/public-yum-ol7.repo \
+        && popd \
+        && yum-config-manager --enable \
+            ol7_software_collections \
+            ol7_developer \
+            ol7_developer_EPEL \
+            ol7_optional_archive \
+        && yum clean all )
+
+# install build tools and PostgreSQL development files
+RUN ( [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-release centos-release-scl-rh) \
+    && yum groupinstall -y 'Development Tools' \
+    && yum install -y \
+        curl \
+        flex \
+        gcc-c++ \
+        hunspell-en \
+        libcurl-devel \
+        libicu-devel \
+        libxml2-devel \
+        libxslt-devel \
+        openssl-devel \
+        pam-devel \
+        readline-devel \
+        rpm-build \
+        rpmlint \
+        spectool \
+        tar \
+        llvm-toolset-7-clang llvm5.0 \
+    && yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+    && ( [[ 6 < 8 ]] || dnf -qy module disable postgresql ) \
+    && yum install -y postgresql13-server postgresql13-devel \
+    && yum clean all
+
+# install jq to process JSON API responses
+RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+         -o /usr/bin/jq \
+    && chmod +x /usr/bin/jq
+
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc ; \
+    } \
+    && yum clean all
+
+# install sphinx on distros with python3
+RUN { \
+        { yum search python3-pip 2>&1 | grep 'No matches found' ; } \
+        || { \
+            yum install -y python3-pip && \
+            pip3 install sphinx==1.8 \
+            ; \
+        } \
+    } \
+    && yum clean all
+
+
+RUN touch /rpmlintrc \
+    && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
+
+# set PostgreSQL version, place scripts on path, and declare output volume
+ENV PGVERSION=13 \
+    PATH=/scripts:$PATH
+COPY scripts /scripts
+VOLUME /packages
+
+ENTRYPOINT ["/scripts/fetch_and_build_rpm"]

--- a/dockerfiles/centos-6-pg13/scripts/determine_email
+++ b/dockerfiles/centos-6-pg13/scripts/determine_email
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# make bash behave
+set -uo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+# fallback to public email
+email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
+
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
+citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
+
+if [ -n "${citusemail}" ]; then
+    email="${citusemail}"
+fi
+
+if [ -z "${email}" ]; then
+    echo "$0: could not determine email" >&2
+    exit $failure
+fi
+
+echo "${email}"
+exit $success

--- a/dockerfiles/centos-6-pg13/scripts/determine_name
+++ b/dockerfiles/centos-6-pg13/scripts/determine_name
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# make bash behave
+set -uo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+fullname=$(curl -sf https://api.github.com/user | jq -r '.name // empty')
+
+if [ -z "${fullname}" ]; then
+    echo "$0: could not determine user name" >&2
+    exit $failure
+fi
+
+echo "${fullname}"
+exit $success

--- a/dockerfiles/centos-6-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-6-pg13/scripts/fetch_and_build_rpm
@@ -55,7 +55,7 @@ declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${releasepg:-11,12}"
+releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
 

--- a/dockerfiles/centos-7-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg10/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-7-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg11/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-7-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg12/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-7-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg13/scripts/fetch_and_build_rpm
@@ -55,7 +55,7 @@ declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${releasepg:-11,12}"
+releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
 

--- a/dockerfiles/centos-8-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg10/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-8-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg11/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-8-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg12/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/centos-8-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg13/scripts/fetch_and_build_rpm
@@ -55,7 +55,7 @@ declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${releasepg:-11,12}"
+releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
 

--- a/dockerfiles/oraclelinux-6-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg10/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-6-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg11/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-6-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg12/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-6-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg13/Dockerfile
@@ -1,0 +1,80 @@
+# vim:set ft=dockerfile:
+FROM oraclelinux:6
+
+# FIXME: Hack around docker/docker#10180
+RUN ( yum install -y yum-plugin-ovl || yum install -y yum-plugin-ovl || touch /var/lib/rpm/* ) \
+    && yum clean all
+
+# Enable some other repos for some dependencies in OL/7 
+# see https://oracle-base.com/articles/linux/download-the-latest-oracle-linux-repo-file#oracle-linux-7-updated
+RUN [[ oraclelinux != oraclelinux ]] || [[ 6 != 7 ]] || ( \
+        pushd /etc/yum.repos.d/ \
+        && rm -f * \
+        && curl -O http://yum.oracle.com/public-yum-ol7.repo \
+        && popd \
+        && yum-config-manager --enable \
+            ol7_software_collections \
+            ol7_developer \
+            ol7_developer_EPEL \
+            ol7_optional_archive \
+        && yum clean all )
+
+# install build tools and PostgreSQL development files
+RUN ( [[ -z "" ]] || yum install -y ) \
+    && yum groupinstall -y 'Development Tools' \
+    && yum install -y \
+        curl \
+        flex \
+        gcc-c++ \
+        hunspell-en \
+        libcurl-devel \
+        libicu-devel \
+        libxml2-devel \
+        libxslt-devel \
+        openssl-devel \
+        pam-devel \
+        readline-devel \
+        rpm-build \
+        rpmlint \
+        spectool \
+        tar \
+        llvm-toolset-7-clang llvm5.0 \
+    && yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+    && ( [[ 6 < 8 ]] || dnf -qy module disable postgresql ) \
+    && yum install -y postgresql13-server postgresql13-devel \
+    && yum clean all
+
+# install jq to process JSON API responses
+RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+         -o /usr/bin/jq \
+    && chmod +x /usr/bin/jq
+
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc ; \
+    } \
+    && yum clean all
+
+# install sphinx on distros with python3
+RUN { \
+        { yum search python3-pip 2>&1 | grep 'No matches found' ; } \
+        || { \
+            yum install -y python3-pip && \
+            pip3 install sphinx==1.8 \
+            ; \
+        } \
+    } \
+    && yum clean all
+
+
+RUN touch /rpmlintrc \
+    && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
+
+# set PostgreSQL version, place scripts on path, and declare output volume
+ENV PGVERSION=13 \
+    PATH=/scripts:$PATH
+COPY scripts /scripts
+VOLUME /packages
+
+ENTRYPOINT ["/scripts/fetch_and_build_rpm"]

--- a/dockerfiles/oraclelinux-6-pg13/scripts/determine_email
+++ b/dockerfiles/oraclelinux-6-pg13/scripts/determine_email
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# make bash behave
+set -uo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+# fallback to public email
+email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
+
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
+citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
+
+if [ -n "${citusemail}" ]; then
+    email="${citusemail}"
+fi
+
+if [ -z "${email}" ]; then
+    echo "$0: could not determine email" >&2
+    exit $failure
+fi
+
+echo "${email}"
+exit $success

--- a/dockerfiles/oraclelinux-6-pg13/scripts/determine_name
+++ b/dockerfiles/oraclelinux-6-pg13/scripts/determine_name
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# make bash behave
+set -uo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+fullname=$(curl -sf https://api.github.com/user | jq -r '.name // empty')
+
+if [ -z "${fullname}" ]; then
+    echo "$0: could not determine user name" >&2
+    exit $failure
+fi
+
+echo "${fullname}"
+exit $success

--- a/dockerfiles/oraclelinux-6-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg13/scripts/fetch_and_build_rpm
@@ -55,7 +55,7 @@ declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${releasepg:-11,12}"
+releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
 

--- a/dockerfiles/oraclelinux-7-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg10/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-7-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg11/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-7-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg12/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-7-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg13/scripts/fetch_and_build_rpm
@@ -55,7 +55,7 @@ declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${releasepg:-11,12}"
+releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
 

--- a/dockerfiles/oraclelinux-8-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg10/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-8-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg11/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-8-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg12/scripts/fetch_and_build_rpm
@@ -154,9 +154,7 @@ sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
     "${builddir}/${pkgname}.spec"
 
 osname=$(awk '{print $1}' /etc/system-release)
-if [ "${osname}" == 'Oracle' ]; then
-    locale='C'
-elif [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ]; then
+if [ "${osname}" == 'Fedora' ] || [ "${osname}" == 'CentOS' ] || [ "${osname}" == 'Oracle' ]; then
     locale='C.utf8'
 else
     locale='en_US.utf8'

--- a/dockerfiles/oraclelinux-8-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg13/scripts/fetch_and_build_rpm
@@ -55,7 +55,7 @@ declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${releasepg:-11,12}"
+releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
 


### PR DESCRIPTION
Fixes https://github.com/citusdata/packaging/issues/539
Similar pr: https://github.com/citusdata/packaging/pull/513

Not urgent for pg13, can be merged later since[ we already don't create ol/8 packages](https://github.com/citusdata/packaging/pull/520) as packagecloud doesn't support