### PR TITLE
Skip pushing pg13 docker image for el/ol 6

### DIFF
--- a/ci/push_images
+++ b/ci/push_images
@@ -31,6 +31,12 @@ while read -r line; do
         # redhat variants need an image for each PostgreSQL version
         IFS=' '
         for pgversion in ${pgversions}; do
+            if { [[ "${os}" = 'centos' ]] || [[ "${os}" = 'oraclelinux' ]]; } && \
+                 [[ "${release}" = '6' ]] && [[ "${pgversion}" = '13' ]]; then
+                # CentOS and OracleLinux 6 doesn't have pg13 packages yet.
+                # So skip building docker images for them.
+                continue
+            fi
             pgshort=${pgversion//./}
             tag="${os}-${release}-pg${pgshort}"
             args+="push citus/packaging:${tag}\n"


### PR DESCRIPTION
Completes the changes that we missed in #532 / 4b2929fbeda21e7bdf14a1dbd81e6e1cf52bfd7f

This commit will be reverted when el/ol 6 have necessary pg13 packages

