### PR TITLE
Update deb and rpm scripts to use PG13

### DIFF
--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -56,9 +56,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-12..."
-  if apt-cache show postgresql-12 &> /dev/null; then
-    echo "Detected postgresql-12..."
+  echo "Checking for postgresql-13..."
+  if apt-cache show postgresql-13 &> /dev/null; then
+    echo "Detected postgresql-13..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -65,12 +65,7 @@ pgdg_check ()
     pgdg_key_url='https://www.postgresql.org/media/keys/ACCC4CF8.asc'
 
     if [ -e $pgdg_list ]; then
-      echo "Unable to install PostgreSQL Apt Repository"
-      echo
-      echo "The file ${pgdg_list} already exists."
-      echo
-      echo "Contact us via https://www.citusdata.com/about/contact_us with information about your system for help."
-      exit 1
+      echo "Overriding ${pgdg_list}"
     fi
 
     echo -n "Installing ${pgdg_list}... "

--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -87,6 +87,16 @@ pgdg_check ()
     # import the gpg key
     curl -L "${pgdg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
     echo "done."
+
+    echo -n "Running apt-get update... "
+    apt-get update &> /dev/null
+    echo "done."
+
+    if ! apt-cache show postgresql-13 &> /dev/null; then
+      echo "PGDG repositories don't have postgresql-13 package for your operating system"
+      echo "Cannot install Citus, exiting."
+      exit 1
+    fi
   fi
 }
 

--- a/community-nightlies/rpm.sh
+++ b/community-nightlies/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql12-server..."
-  if yum list -q postgresql12-server &> /dev/null; then
-    echo "Detected postgresql12-server..."
+  echo "Checking for postgresql13-server..."
+  if yum list -q postgresql13-server &> /dev/null; then
+    echo "Detected postgresql13-server..."
   else
-    echo -n "Installing pgdg12 repo... "
+    echo -n "Installing pgdg13 repo... "
 
     if [ "${dist}" = "8" ]; then
       dnf -qy module disable postgresql

--- a/community-nightlies/rpm.sh
+++ b/community-nightlies/rpm.sh
@@ -43,6 +43,13 @@ pgdg_check ()
     fi
 
     yum install -d0 -e0 -y "${repo_url}"
+
+    if ! yum info -q postgresql13-server &> /dev/null; then
+      echo "PGDG repositories don't have postgresql13-server package for your operating system"
+      echo "Cannot install Citus, exiting."
+      exit 1
+    fi
+
     echo "done."
   fi
 }

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -56,9 +56,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-12..."
-  if apt-cache show postgresql-12 &> /dev/null; then
-    echo "Detected postgresql-12..."
+  echo "Checking for postgresql-13..."
+  if apt-cache show postgresql-13 &> /dev/null; then
+    echo "Detected postgresql-13..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -65,12 +65,7 @@ pgdg_check ()
     pgdg_key_url='https://www.postgresql.org/media/keys/ACCC4CF8.asc'
 
     if [ -e $pgdg_list ]; then
-      echo "Unable to install PostgreSQL Apt Repository"
-      echo
-      echo "The file ${pgdg_list} already exists."
-      echo
-      echo "Contact us via https://www.citusdata.com/about/contact_us with information about your system for help."
-      exit 1
+      echo "Overriding ${pgdg_list}"
     fi
 
     echo -n "Installing ${pgdg_list}... "

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -87,6 +87,16 @@ pgdg_check ()
     # import the gpg key
     curl -L "${pgdg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
     echo "done."
+
+    echo -n "Running apt-get update... "
+    apt-get update &> /dev/null
+    echo "done."
+
+    if ! apt-cache show postgresql-13 &> /dev/null; then
+      echo "PGDG repositories don't have postgresql-13 package for your operating system"
+      echo "Cannot install Citus, exiting."
+      exit 1
+    fi
   fi
 }
 

--- a/community/rpm.sh
+++ b/community/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql12-server..."
-  if yum list -q postgresql12-server &> /dev/null; then
-    echo "Detected postgresql12-server..."
+  echo "Checking for postgresql13-server..."
+  if yum list -q postgresql13-server &> /dev/null; then
+    echo "Detected postgresql13-server..."
   else
-    echo -n "Installing pgdg12 repo... "
+    echo -n "Installing pgdg13 repo... "
 
     if [ "${dist}" = "8" ]; then
       dnf -qy module disable postgresql

--- a/community/rpm.sh
+++ b/community/rpm.sh
@@ -43,6 +43,13 @@ pgdg_check ()
     fi
 
     yum install -d0 -e0 -y "${repo_url}"
+
+    if ! yum info -q postgresql13-server &> /dev/null; then
+      echo "PGDG repositories don't have postgresql13-server package for your operating system"
+      echo "Cannot install Citus, exiting."
+      exit 1
+    fi
+
     echo "done."
   fi
 }

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -56,9 +56,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-12..."
-  if apt-cache show postgresql-12 &> /dev/null; then
-    echo "Detected postgresql-12..."
+  echo "Checking for postgresql-13..."
+  if apt-cache show postgresql-13 &> /dev/null; then
+    echo "Detected postgresql-13..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -65,12 +65,7 @@ pgdg_check ()
     pgdg_key_url='https://www.postgresql.org/media/keys/ACCC4CF8.asc'
 
     if [ -e $pgdg_list ]; then
-      echo "Unable to install PostgreSQL Apt Repository"
-      echo
-      echo "The file ${pgdg_list} already exists."
-      echo
-      echo "Contact us via https://www.citusdata.com/about/contact_us with information about your system for help."
-      exit 1
+      echo "Overriding ${pgdg_list}"
     fi
 
     echo -n "Installing ${pgdg_list}... "

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -87,6 +87,16 @@ pgdg_check ()
     # import the gpg key
     curl -L "${pgdg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
     echo "done."
+
+    echo -n "Running apt-get update... "
+    apt-get update &> /dev/null
+    echo "done."
+
+    if ! apt-cache show postgresql-13 &> /dev/null; then
+      echo "PGDG repositories don't have postgresql-13 package for your operating system"
+      echo "Cannot install Citus, exiting."
+      exit 1
+    fi
   fi
 }
 

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql12-server..."
-  if yum list -q postgresql12-server &> /dev/null; then
-    echo "Detected postgresql12-server..."
+  echo "Checking for postgresql13-server..."
+  if yum list -q postgresql13-server &> /dev/null; then
+    echo "Detected postgresql13-server..."
   else
-    echo -n "Installing pgdg12 repo... "
+    echo -n "Installing pgdg13 repo... "
 
     if [ "${dist}" = "8" ]; then
       dnf -qy module disable postgresql

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -43,6 +43,13 @@ pgdg_check ()
     fi
 
     yum install -d0 -e0 -y "${repo_url}"
+
+    if ! yum info -q postgresql13-server &> /dev/null; then
+      echo "PGDG repositories don't have postgresql13-server package for your operating system"
+      echo "Cannot install Citus, exiting."
+      exit 1
+    fi
+
     echo "done."
   fi
 }

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -56,9 +56,9 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql-12..."
-  if apt-cache show postgresql-12 &> /dev/null; then
-    echo "Detected postgresql-12..."
+  echo "Checking for postgresql-13..."
+  if apt-cache show postgresql-13 &> /dev/null; then
+    echo "Detected postgresql-13..."
   else
     pgdg_list='/etc/apt/sources.list.d/pgdg.list'
     pgdg_source_path="deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main"

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -65,12 +65,7 @@ pgdg_check ()
     pgdg_key_url='https://www.postgresql.org/media/keys/ACCC4CF8.asc'
 
     if [ -e $pgdg_list ]; then
-      echo "Unable to install PostgreSQL Apt Repository"
-      echo
-      echo "The file ${pgdg_list} already exists."
-      echo
-      echo "Contact us via https://www.citusdata.com/about/contact_us with information about your system for help."
-      exit 1
+      echo "Overriding ${pgdg_list}"
     fi
 
     echo -n "Installing ${pgdg_list}... "

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -87,6 +87,16 @@ pgdg_check ()
     # import the gpg key
     curl -L "${pgdg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
     echo "done."
+
+    echo -n "Running apt-get update... "
+    apt-get update &> /dev/null
+    echo "done."
+
+    if ! apt-cache show postgresql-13 &> /dev/null; then
+      echo "PGDG repositories don't have postgresql-13 package for your operating system"
+      echo "Cannot install Citus, exiting."
+      exit 1
+    fi
   fi
 }
 

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -32,11 +32,11 @@ curl_check ()
 
 pgdg_check ()
 {
-  echo "Checking for postgresql12-server..."
-  if yum list -q postgresql12-server &> /dev/null; then
-    echo "Detected postgresql12-server..."
+  echo "Checking for postgresql13-server..."
+  if yum list -q postgresql13-server &> /dev/null; then
+    echo "Detected postgresql13-server..."
   else
-    echo -n "Installing pgdg12 repo... "
+    echo -n "Installing pgdg13 repo... "
     
     if [ "${dist}" = "8" ]; then
       dnf -qy module disable postgresql

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -43,6 +43,13 @@ pgdg_check ()
     fi
 
     yum install -d0 -e0 -y "${repo_url}"
+
+    if ! yum info -q postgresql13-server &> /dev/null; then
+      echo "PGDG repositories don't have postgresql13-server package for your operating system"
+      echo "Cannot install Citus, exiting."
+      exit 1
+    fi
+
     echo "done."
   fi
 }


### PR DESCRIPTION
Tested 9bfde1b5f5b667d74e26435ff3697586d25b78b1 on several distros for pg13, works fine.
For the distros that are not having pg13 packages, had some issues and fixed them in other commits
