### PR TITLE
citus-enterprise/Include .bc files for columnar as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script: |
         if [ -z "${UNENCRYPTED_PACKAGE:-}" ]; then
         citus_package -p ${TARGET_PLATFORM} 'local' 'release'
         else
-        build_new_release # && build_new_nightly
+        build_new_release && build_new_nightly
         fi
 deploy:
   - provider: packagecloud


### PR DESCRIPTION
At 7e96183: Fix #547 for citus/enterprise
At 9081969: Revert 86b872b to enable nightly builds again

To explain what 7e96183 does:

* We need to add .bc files for columnar for Citus versions >= 10.0
* We need to do that conditionally, depending on if columnar directory exists
* Directly including `%{pginstdir}/lib/bitcode/columnar/*.bc` breaks builds for Citus versions < 10.0
* So we need to write that columnar path conditionally to a file list
* But this file can't be empty, otherwise build is again broken
* So include other installation files in that files list, and optionally include columnar dir