### PR TITLE
citus-community/Include .bc files for columnar as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - sudo make -C tools install
   - export PACKAGING_SECRET_KEY="$(openssl aes-256-cbc -K $encrypted_a39e3f1ee8ba_key -iv $encrypted_a39e3f1ee8ba_iv -in signing_key.asc.enc -d | base64)"
 install: true
-script: build_new_release # && build_new_nightly
+script: build_new_release && build_new_nightly
 deploy:
   - provider: packagecloud
     username: "citusdata"

--- a/citus.spec
+++ b/citus.spec
@@ -43,10 +43,31 @@ make %{?_smp_mflags}
 # Install documentation with a better name:
 %{__mkdir} -p %{buildroot}%{pginstdir}/doc/extension
 %{__cp} README.md %{buildroot}%{pginstdir}/doc/extension/README-%{sname}.md
+# Set paths to be packaged other than LICENSE, README & CHANGELOG.md
+echo %{pginstdir}/include/server/citus_*.h >> installation_files.list
+echo %{pginstdir}/include/server/distributed/*.h >> installation_files.list
+echo %{pginstdir}/lib/%{sname}.so >> installation_files.list
+echo %{pginstdir}/share/extension/%{sname}-*.sql >> installation_files.list
+echo %{pginstdir}/share/extension/%{sname}.control >> installation_files.list
+%ifarch ppc64 ppc64le
+  %else
+  %if 0%{?rhel} && 0%{?rhel} <= 6
+  %else
+    echo %{pginstdir}/lib/bitcode/%{sname}/*.bc >> installation_files.list
+    echo %{pginstdir}/lib/bitcode/%{sname}*.bc >> installation_files.list
+    echo %{pginstdir}/lib/bitcode/%{sname}/*/*.bc >> installation_files.list
+    
+    # Columnar does not exist in Citus versions < 10.0
+    # At this point, we don't have %{pginstdir},
+    # so first check build directory for columnar.
+    [[ -d %{buildroot}%{pginstdir}/lib/bitcode/columnar/ ]] && echo %{pginstdir}/lib/bitcode/columnar/*.bc >> installation_files.list
+  %endif
+%endif
 
 %clean
 %{__rm} -rf %{buildroot}
 
+%files -f installation_files.list
 %files
 %defattr(-,root,root,-)
 %doc CHANGELOG.md
@@ -56,20 +77,6 @@ make %{?_smp_mflags}
 %license LICENSE
 %endif
 %doc %{pginstdir}/doc/extension/README-%{sname}.md
-%{pginstdir}/include/server/citus_*.h
-%{pginstdir}/include/server/distributed/*.h
-%{pginstdir}/lib/%{sname}.so
-%{pginstdir}/share/extension/%{sname}-*.sql
-%{pginstdir}/share/extension/%{sname}.control
-%ifarch ppc64 ppc64le
-  %else
-  %if 0%{?rhel} && 0%{?rhel} <= 6
-  %else
-    %{pginstdir}/lib/bitcode/%{sname}*.bc
-    %{pginstdir}/lib/bitcode/%{sname}/*.bc
-    %{pginstdir}/lib/bitcode/%{sname}/*/*.bc
-  %endif
-%endif
 
 %changelog
 * Tue Nov 24 2020 - Onur Tirtir <Onur.Tirtir@microsoft.com> 9.4.3.citus-1


### PR DESCRIPTION
At d2e7dfd: Fix #547 for citus/community
At a43803c: Revert 86b872b to enable nightly builds again

To explain what d2e7dfd does:
* We need to add .bc files for columnar for Citus versions >= 10.0
* We need to do that conditionally, depending on if columnar directory exists
* Directly including `%{pginstdir}/lib/bitcode/columnar/*.bc` breaks builds for Citus versions < 10.0
* So we need to write that columnar path conditionally to a file list
* But this file can't be empty, otherwise build is again broken
* So include other installation files in that files list, and optionally include columnar dir