### PR TITLE
Revert pgxn 9.4.3

### DIFF
--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "citus",
    "abstract": "Scalable PostgreSQL for real-time workloads",
    "description": "Citus horizontally scales PostgreSQL across commodity servers using sharding and replication. Its query engine parallelizes incoming SQL queries across these servers to enable real-time responses on large datasets.",
-   "version": "9.4.3",
+   "version": "9.5.0",
    "maintainer": "\"Citus Data\" <packaging@citusdata.com>",
    "license": "agpl_3",
    "provides": {
@@ -10,7 +10,7 @@
          "abstract": "Citus Distributed Database",
          "file": "citus.so",
          "docfile": "README.md",
-         "version": "9.4.3"
+         "version": "9.5.0"
       }
    },
    "prereqs": {

--- a/pkgvars
+++ b/pkgvars
@@ -1,4 +1,4 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
 pkglatest=9.4.3
-releasepg=11,12
+releasepg=11,12,13

--- a/pkgvars
+++ b/pkgvars
@@ -1,4 +1,4 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
-pkglatest=9.4.3
+pkglatest=9.5.0
 releasepg=11,12,13


### PR DESCRIPTION
https://github.com/citusdata/packaging/pull/556 bumps pgxn to 9.4.3.
But in https://travis-ci.com/github/citusdata/packaging/builds/203814764, we see following error:
>PGXN already contains citus-9.4.3.zip!
The command "release_pgxn" exited with 0.

It's probably because pgxn doesn't accept artifacts for older versions and trying to make it work wouldn't add any value, so revert that pr