### PR TITLE
Revert "Remove pg13 for 9.4.3 release"

### DIFF
--- a/pkgvars
+++ b/pkgvars
@@ -1,6 +1,6 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
 pkglatest=9.4.3.citus-1
-releasepg=11,12
-nightlypg=11,12
+releasepg=11,12,13
+nightlypg=11,12,13
 versioning=fancy


### PR DESCRIPTION
This reverts commit 4bab7f879528f96f968a406e1085509510d54370.

Let's open a draft pr not to forget this before 9.5.1 patch release 

Should be merged together with next release that has pg13 support (9.5.1 or 10.0.0), otherwise, builds will fail