### PR TITLE
Install libstdc++ for hll packaging

### DIFF
--- a/dockerfiles/centos-6-pg10/Dockerfile
+++ b/dockerfiles/centos-6-pg10/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-relea
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/centos-6-pg11/Dockerfile
+++ b/dockerfiles/centos-6-pg11/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-relea
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/centos-6-pg12/Dockerfile
+++ b/dockerfiles/centos-6-pg12/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-relea
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-relea
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-relea
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-relea
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-relea
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "epel-release" ]] || yum install -y epel-release) \
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "epel-release" ]] || yum install -y epel-release) \
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "epel-release" ]] || yum install -y epel-release) \
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "epel-release" ]] || yum install -y epel-release) \
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "" ]] || yum install -y ) \
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "" ]] || yum install -y ) \
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "" ]] || yum install -y ) \
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "" ]] || yum install -y ) \
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "" ]] || yum install -y ) \
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "" ]] || yum install -y ) \
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "" ]] || yum install -y ) \
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-e
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-e
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-e
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -29,6 +29,7 @@ RUN ( [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-e
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -29,6 +29,7 @@ RUN ( [[ -z "%%extra-repositories%%" ]] || yum install -y %%extra-repositories%%
         hunspell-en \
         libcurl-devel \
         libicu-devel \
+        libstdc++-devel \
         libxml2-devel \
         libxslt-devel \
         openssl-devel \


### PR DESCRIPTION
I updated images for only rpm based distros that fail to build hll extension due to missing libstdc++ dependencies.