### PR TITLE
Updated our patch to make pg_buildext parallel

### DIFF
--- a/dockerfiles/debian-buster-all/make_pg_buildext_parallel.patch
+++ b/dockerfiles/debian-buster-all/make_pg_buildext_parallel.patch
@@ -1,17 +1,17 @@
 --- /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-+++ /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-@@ -71,11 +71,13 @@
-     if [ "$opt" ]; then
-         cflags="$(echo $opt | sed -e "s:%v:$1:g")"
-     fi
++++ /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
+@@ -83,11 +83,13 @@
+ install() {
+     prepare_env $1
+     package=`echo $opt | sed -e "s:%v:$1:g"`
 +    procs="$(nproc)"
 +    mjobs="$(expr $procs + 1)"
  
      mkdir -p $vtarget
      # if a Makefile was created by configure, use it, else the top level Makefile
      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
--    make -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
-+    make -j${mjobs} -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
+-    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
++    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
  }
  
- install() {
+ clean() {

--- a/dockerfiles/debian-jessie-all/make_pg_buildext_parallel.patch
+++ b/dockerfiles/debian-jessie-all/make_pg_buildext_parallel.patch
@@ -1,17 +1,17 @@
 --- /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-+++ /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-@@ -71,11 +71,13 @@
-     if [ "$opt" ]; then
-         cflags="$(echo $opt | sed -e "s:%v:$1:g")"
-     fi
++++ /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
+@@ -83,11 +83,13 @@
+ install() {
+     prepare_env $1
+     package=`echo $opt | sed -e "s:%v:$1:g"`
 +    procs="$(nproc)"
 +    mjobs="$(expr $procs + 1)"
  
      mkdir -p $vtarget
      # if a Makefile was created by configure, use it, else the top level Makefile
      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
--    make -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
-+    make -j${mjobs} -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
+-    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
++    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
  }
  
- install() {
+ clean() {

--- a/dockerfiles/debian-stretch-all/make_pg_buildext_parallel.patch
+++ b/dockerfiles/debian-stretch-all/make_pg_buildext_parallel.patch
@@ -1,17 +1,17 @@
 --- /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-+++ /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-@@ -71,11 +71,13 @@
-     if [ "$opt" ]; then
-         cflags="$(echo $opt | sed -e "s:%v:$1:g")"
-     fi
++++ /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
+@@ -83,11 +83,13 @@
+ install() {
+     prepare_env $1
+     package=`echo $opt | sed -e "s:%v:$1:g"`
 +    procs="$(nproc)"
 +    mjobs="$(expr $procs + 1)"
  
      mkdir -p $vtarget
      # if a Makefile was created by configure, use it, else the top level Makefile
      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
--    make -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
-+    make -j${mjobs} -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
+-    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
++    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
  }
  
- install() {
+ clean() {

--- a/dockerfiles/ubuntu-bionic-all/make_pg_buildext_parallel.patch
+++ b/dockerfiles/ubuntu-bionic-all/make_pg_buildext_parallel.patch
@@ -1,17 +1,17 @@
 --- /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-+++ /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-@@ -71,11 +71,13 @@
-     if [ "$opt" ]; then
-         cflags="$(echo $opt | sed -e "s:%v:$1:g")"
-     fi
++++ /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
+@@ -83,11 +83,13 @@
+ install() {
+     prepare_env $1
+     package=`echo $opt | sed -e "s:%v:$1:g"`
 +    procs="$(nproc)"
 +    mjobs="$(expr $procs + 1)"
  
      mkdir -p $vtarget
      # if a Makefile was created by configure, use it, else the top level Makefile
      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
--    make -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
-+    make -j${mjobs} -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
+-    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
++    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
  }
  
- install() {
+ clean() {

--- a/dockerfiles/ubuntu-focal-all/make_pg_buildext_parallel.patch
+++ b/dockerfiles/ubuntu-focal-all/make_pg_buildext_parallel.patch
@@ -1,17 +1,17 @@
 --- /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-+++ /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-@@ -71,11 +71,13 @@
-     if [ "$opt" ]; then
-         cflags="$(echo $opt | sed -e "s:%v:$1:g")"
-     fi
++++ /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
+@@ -83,11 +83,13 @@
+ install() {
+     prepare_env $1
+     package=`echo $opt | sed -e "s:%v:$1:g"`
 +    procs="$(nproc)"
 +    mjobs="$(expr $procs + 1)"
  
      mkdir -p $vtarget
      # if a Makefile was created by configure, use it, else the top level Makefile
      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
--    make -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
-+    make -j${mjobs} -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
+-    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
++    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
  }
  
- install() {
+ clean() {

--- a/dockerfiles/ubuntu-xenial-all/make_pg_buildext_parallel.patch
+++ b/dockerfiles/ubuntu-xenial-all/make_pg_buildext_parallel.patch
@@ -1,17 +1,17 @@
 --- /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-+++ /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-@@ -71,11 +71,13 @@
-     if [ "$opt" ]; then
-         cflags="$(echo $opt | sed -e "s:%v:$1:g")"
-     fi
++++ /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
+@@ -83,11 +83,13 @@
+ install() {
+     prepare_env $1
+     package=`echo $opt | sed -e "s:%v:$1:g"`
 +    procs="$(nproc)"
 +    mjobs="$(expr $procs + 1)"
  
      mkdir -p $vtarget
      # if a Makefile was created by configure, use it, else the top level Makefile
      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
--    make -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
-+    make -j${mjobs} -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
+-    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
++    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
  }
  
- install() {
+ clean() {

--- a/make_pg_buildext_parallel.patch
+++ b/make_pg_buildext_parallel.patch
@@ -1,17 +1,17 @@
 --- /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-+++ /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-@@ -71,11 +71,13 @@
-     if [ "$opt" ]; then
-         cflags="$(echo $opt | sed -e "s:%v:$1:g")"
-     fi
++++ /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
+@@ -83,11 +83,13 @@
+ install() {
+     prepare_env $1
+     package=`echo $opt | sed -e "s:%v:$1:g"`
 +    procs="$(nproc)"
 +    mjobs="$(expr $procs + 1)"
  
      mkdir -p $vtarget
      # if a Makefile was created by configure, use it, else the top level Makefile
      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
--    make -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
-+    make -j${mjobs} -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS
+-    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
++    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
  }
  
- install() {
+ clean() {


### PR DESCRIPTION
Recent PostgreSQL versions (13.1, 12.5, 11.10 etc) updated pg_buildext
scripts. To unblock image creation we need to update the patch.