### PR TITLE
Install libstdc++ from EPEL repos

### DIFF
--- a/dockerfiles/centos-6-pg10/Dockerfile
+++ b/dockerfiles/centos-6-pg10/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/centos-6-pg11/Dockerfile
+++ b/dockerfiles/centos-6-pg11/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/centos-6-pg12/Dockerfile
+++ b/dockerfiles/centos-6-pg12/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -53,7 +53,7 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
 # install devtoolset-8-gcc on distros where it is available
 RUN { \
         { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
-        || yum install -y devtoolset-8-gcc ; \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
     } \
     && yum clean all
 


### PR DESCRIPTION
We need stdc++ headers to build hll packages.


I tested these changes on CentOS 6,7,8 and they all can create packages after these changes