### PR TITLE
Bump debian TopN to 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ env:
     - secure: "pZmrxStWj0vXaG/YAyJORvxfaKQHvr+O+66yjFF52gQTVd2zNb83Mn4zDLNqMwU3nkXEKYuFbpXKbDSMX9zNbE7W/w1ARSa8MVXnMVM3jbj+OCaBu7fyVrA0tvT3EZkMh943paTRcSyPSzd61P3CNOkcY1RycDHBbJtNrzSdUbdAy6//TWgNxC66dxSeHASRJIIs49caxQssMMSGRgC5aGH4KLU5eSdP3wnWDEHr+aLqaI2DF2W3lNMI0WJwtGN6cLEYzAsA3BkoPoYRFDd4jjTpolVdrFBXRaT1EIg0FXjsvjyFrQfQLBIqvSx42H5w4rCIYoKYYgRgCKDATLK8XxPbFsgPKLVSHFD6t9ebuYacYxS20oMakkqj5e98qMIWe2vkm+V9YNeADIlhYT+NsF9Kug2B6pLK+U+Hhj6TldFpP18snPXttRKzsg9QrGbnBUVq2wv60U7/3pWs+T3tpr9bIFyaUYbRRAwl/hv2hVkFiSdsiLB6tJphbILB7EDKBCu1iK9PC9tlYoGrqptRxj6bmlawOvcnEKRtoPNJ9eyrvHPDd8FmmW6xWbq89zJ97Ztl7VR8CzNePqvG9vwdtJigXovuXfzu4CHX+jOt3jvllB6rMprsK5r++qBzh1SS24sYqo/APtUfoYdkleWhC+tSuhbucZb2yGUCMo/ZhDo="
   matrix:
     - TARGET_PLATFORM=debian/buster
-    - TARGET_PLATFORM=debian/stretch
     - TARGET_PLATFORM=debian/jessie
+    - TARGET_PLATFORM=debian/stretch
+    - TARGET_PLATFORM=ubuntu/focal
     - TARGET_PLATFORM=ubuntu/bionic
     - TARGET_PLATFORM=ubuntu/xenial
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - TARGET_PLATFORM=ubuntu/bionic
     - TARGET_PLATFORM=ubuntu/xenial
 before_install:
-  - git clone -b v0.7.13 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.7.21 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - export PACKAGING_SECRET_KEY="$(openssl aes-256-cbc -K $encrypted_a39e3f1ee8ba_key -iv $encrypted_a39e3f1ee8ba_iv -in signing_key.asc.enc -d | base64)"
 install: true

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+topn (2.3.1) stable; urgency=low
+
+  * Adds support for PostgreSQL 13
+  * Support parallel queries and aggregates
+
+ -- Hanefi Onaldi <Hanefi.Onaldi@microsoft.com>  Mon, 30 Nov 2020 14:35:00 +0300
+
 topn (2.3.0) stable; urgency=low
 
   * Adds support for PostgreSQL 12

--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ override_dh_auto_test:
 	# nothing to do here, see debian/tests/* instead
 
 override_dh_auto_install:
-	+pg_buildext install build-%v postgresql-%v-topn
+	+pg_buildext loop postgresql-%v-topn
 
 %:
 	dh $@

--- a/pkgvars
+++ b/pkgvars
@@ -1,4 +1,4 @@
 pkgname=postgresql-topn
 pkgdesc='Counter Based Implementation for top-n Approximation'
 pkglatest=2.3.0.citus-1
-releasepg=9.6,10,11,12
+releasepg=11,12,13

--- a/pkgvars
+++ b/pkgvars
@@ -1,4 +1,4 @@
 pkgname=postgresql-topn
 pkgdesc='Counter Based Implementation for top-n Approximation'
-pkglatest=2.3.0.citus-1
+pkglatest=2.3.1.citus-1
 releasepg=11,12,13


### PR DESCRIPTION
We need to fix several issues for a clean release. See #560 for a similar PR