### PR TITLE
Bump redhat TopN to 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,10 @@ env:
     # passphrase for packaging gpg secret key
     - secure: "pZmrxStWj0vXaG/YAyJORvxfaKQHvr+O+66yjFF52gQTVd2zNb83Mn4zDLNqMwU3nkXEKYuFbpXKbDSMX9zNbE7W/w1ARSa8MVXnMVM3jbj+OCaBu7fyVrA0tvT3EZkMh943paTRcSyPSzd61P3CNOkcY1RycDHBbJtNrzSdUbdAy6//TWgNxC66dxSeHASRJIIs49caxQssMMSGRgC5aGH4KLU5eSdP3wnWDEHr+aLqaI2DF2W3lNMI0WJwtGN6cLEYzAsA3BkoPoYRFDd4jjTpolVdrFBXRaT1EIg0FXjsvjyFrQfQLBIqvSx42H5w4rCIYoKYYgRgCKDATLK8XxPbFsgPKLVSHFD6t9ebuYacYxS20oMakkqj5e98qMIWe2vkm+V9YNeADIlhYT+NsF9Kug2B6pLK+U+Hhj6TldFpP18snPXttRKzsg9QrGbnBUVq2wv60U7/3pWs+T3tpr9bIFyaUYbRRAwl/hv2hVkFiSdsiLB6tJphbILB7EDKBCu1iK9PC9tlYoGrqptRxj6bmlawOvcnEKRtoPNJ9eyrvHPDd8FmmW6xWbq89zJ97Ztl7VR8CzNePqvG9vwdtJigXovuXfzu4CHX+jOt3jvllB6rMprsK5r++qBzh1SS24sYqo/APtUfoYdkleWhC+tSuhbucZb2yGUCMo/ZhDo="
   matrix:
+    - TARGET_PLATFORM=el/6
     - TARGET_PLATFORM=el/7
+    - TARGET_PLATFORM=el/8
+    - TARGET_PLATFORM=ol/6
     - TARGET_PLATFORM=ol/7
 before_install:
   - git clone -b v0.7.21 --depth 1 https://github.com/citusdata/tools.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - TARGET_PLATFORM=el/7
     - TARGET_PLATFORM=ol/7
 before_install:
-  - git clone -b v0.7.13 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.7.21 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - export PACKAGING_SECRET_KEY="$(openssl aes-256-cbc -K $encrypted_a39e3f1ee8ba_key -iv $encrypted_a39e3f1ee8ba_iv -in signing_key.asc.enc -d | base64)"
 install: true

--- a/pkgvars
+++ b/pkgvars
@@ -1,5 +1,5 @@
 pkgname=topn
 hubproj=postgresql-topn
 pkgdesc='Counter Based Implementation for top-n Approximation'
-pkglatest=2.3.0.citus-1
+pkglatest=2.3.1.citus-1
 releasepg=11,12,13

--- a/pkgvars
+++ b/pkgvars
@@ -2,4 +2,4 @@ pkgname=topn
 hubproj=postgresql-topn
 pkgdesc='Counter Based Implementation for top-n Approximation'
 pkglatest=2.3.0.citus-1
-releasepg=9.6,10,11,12
+releasepg=11,12,13

--- a/topn.spec
+++ b/topn.spec
@@ -5,11 +5,11 @@
 
 Summary:	Counter Based Implementation for top-n Approximation
 Name:		%{sname}_%{pgmajorversion}
-Version:	2.3.0.citus
+Version:	2.3.1.citus
 Release:	1%{dist}
 License:	AGPLv3
 Group:		Applications/Databases
-Source0:	https://github.com/citusdata/postgresql-topn/archive/v2.3.0.tar.gz
+Source0:	https://github.com/citusdata/postgresql-topn/archive/v2.3.1.tar.gz
 URL:		https://github.com/citusdata/posgresql-topn
 BuildRequires:	postgresql%{pgmajorversion}-devel libxml2-devel
 BuildRequires:	libxslt-devel openssl-devel pam-devel readline-devel
@@ -57,6 +57,9 @@ PATH=%{pginstdir}/bin:$PATH
 %endif
 
 %changelog
+* Mon Nov 30 2020 - Hanefi Onaldi <Hanefi.Onaldi@microsoft.com> 2.3.1.citus-1
+- Support for PostgreSQL 13, parallel queries/aggregates and bug fixes
+
 * Thu Oct 31 2019 - Hanefi Onaldi <Hanefi.Onaldi@microsoft.com> 2.3.0.citus-1
 - Adds PostgreSQL 12 support
 


### PR DESCRIPTION
We need to fix several issues for a clean release. See #559 for a similar PR

