### PR TITLE
Bump pgautofailover to 1.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - TARGET_PLATFORM=ubuntu/bionic
     - TARGET_PLATFORM=ubuntu/xenial
 before_install:
-  - git clone -b v0.7.17 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.7.21 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - export PACKAGING_SECRET_KEY="$(openssl aes-256-cbc -K $encrypted_a39e3f1ee8ba_key -iv $encrypted_a39e3f1ee8ba_iv -in signing_key.asc.enc -d | base64)"
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,10 @@ env:
     #- TARGET_PLATFORM=ol/8
     - TARGET_PLATFORM=el/7
     - TARGET_PLATFORM=ol/7
-    - TARGET_PLATFORM=el/6
     # Oracle Linux 6 is old and it doesn't work with static assert:
     # https://github.com/citusdata/pg_auto_failover/issues/200
     # - TARGET_PLATFORM=ol/6
     - TARGET_PLATFORM=debian/buster
-    - TARGET_PLATFORM=debian/jessie
     - TARGET_PLATFORM=debian/stretch
     - TARGET_PLATFORM=ubuntu/focal
     - TARGET_PLATFORM=ubuntu/bionic

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pg-auto-failover (1.4.1-1) stable; urgency=low
+
+  * Official 1.4.1 release of pg_auto_failover
+
+ -- Hanefi Onaldi <Hanefi.Onaldi@microsoft.com>  Thu, 3 Dec 2020 15:51:21 +0300
+
 pg-auto-failover (1.4.0-1) stable; urgency=low
 
   * Official 1.4.0 release of pg_auto_failover

--- a/debian/control.in
+++ b/debian/control.in
@@ -3,7 +3,7 @@ Section: database
 Priority: optional
 Maintainer: Citus Data <packaging@citusdata.com>
 Uploaders: Nils Dijk <nils@citusdata.com>
-Build-Depends: debhelper (>= 9), autotools-dev, flex, postgresql-server-dev-all (>= 158~), libedit-dev, libpam0g-dev, libselinux1-dev, libxslt1-dev
+Build-Depends: debhelper (>= 9), autotools-dev, flex, postgresql-server-dev-all (>= 158~), libedit-dev, libpam0g-dev, libreadline-dev, libselinux1-dev, libxslt1-dev
 Standards-Version: 3.9.7
 Homepage: https://github.com/citusdata/pg_auto_failover
 

--- a/pg-auto-failover.spec
+++ b/pg-auto-failover.spec
@@ -9,11 +9,11 @@ Summary:	Postgres extension for automated failover and high-availability
 Name:		%{sname}%{?pkginfix}_%{pgmajorversion}
 Provides:	%{sname}_%{pgmajorversion}
 Conflicts:	%{sname}_%{pgmajorversion}
-Version:	1.4.0
+Version:	1.4.1
 Release:	1%{dist}
 License:	PostgreSQL
 Group:		Applications/Databases
-Source0:	https://github.com/citusdata/pg-auto-failover/archive/v1.4.0.tar.gz
+Source0:	https://github.com/citusdata/pg-auto-failover/archive/v1.4.1.tar.gz
 URL:		https://github.com/citusdata/pg_auto_failover
 BuildRequires:	postgresql%{pgmajorversion}-devel postgresql%{pgmajorversion}-server libxml2-devel
 BuildRequires:	libxslt-devel openssl-devel pam-devel readline-devel
@@ -82,6 +82,9 @@ PATH=%{pginstdir}/bin:$PATH
 
 
 %changelog
+* Thu Dec 3 2020 - Hanefi Onaldi <Hanefi.Onaldi@microsoft.com> 1.4.1-1
+- Official 1.4.1 release of pg_auto_failover
+
 * Wed Sep 23 2020 - Onur Tirtir <Onur.Tirtir@microsoft.com> 1.4.0-1
 - Official 1.4.0 release of pg_auto_failover
 

--- a/pkgvars
+++ b/pkgvars
@@ -3,5 +3,5 @@ deb_pkgname=auto-failover
 hubproj=pg_auto_failover
 pkgdesc='Postgres extension for automated failover and high-availability'
 pkglatest=1.4.1-1
-releasepg=10,11,12
+releasepg=10,11,12,13
 versioning=fancy

--- a/pkgvars
+++ b/pkgvars
@@ -2,6 +2,6 @@ rpm_pkgname=pg-auto-failover
 deb_pkgname=auto-failover
 hubproj=pg_auto_failover
 pkgdesc='Postgres extension for automated failover and high-availability'
-pkglatest=1.4.0-1
+pkglatest=1.4.1-1
 releasepg=10,11,12
 versioning=fancy


### PR DESCRIPTION
- Remove EL6 and Debian Jessie
- Add PG13 support
- Add libreadline-dev build dependency