### PR TITLE
Bump pgautofailover enterprise to 1.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
     - secure: "pZmrxStWj0vXaG/YAyJORvxfaKQHvr+O+66yjFF52gQTVd2zNb83Mn4zDLNqMwU3nkXEKYuFbpXKbDSMX9zNbE7W/w1ARSa8MVXnMVM3jbj+OCaBu7fyVrA0tvT3EZkMh943paTRcSyPSzd61P3CNOkcY1RycDHBbJtNrzSdUbdAy6//TWgNxC66dxSeHASRJIIs49caxQssMMSGRgC5aGH4KLU5eSdP3wnWDEHr+aLqaI2DF2W3lNMI0WJwtGN6cLEYzAsA3BkoPoYRFDd4jjTpolVdrFBXRaT1EIg0FXjsvjyFrQfQLBIqvSx42H5w4rCIYoKYYgRgCKDATLK8XxPbFsgPKLVSHFD6t9ebuYacYxS20oMakkqj5e98qMIWe2vkm+V9YNeADIlhYT+NsF9Kug2B6pLK+U+Hhj6TldFpP18snPXttRKzsg9QrGbnBUVq2wv60U7/3pWs+T3tpr9bIFyaUYbRRAwl/hv2hVkFiSdsiLB6tJphbILB7EDKBCu1iK9PC9tlYoGrqptRxj6bmlawOvcnEKRtoPNJ9eyrvHPDd8FmmW6xWbq89zJ97Ztl7VR8CzNePqvG9vwdtJigXovuXfzu4CHX+jOt3jvllB6rMprsK5r++qBzh1SS24sYqo/APtUfoYdkleWhC+tSuhbucZb2yGUCMo/ZhDo="
   matrix:
     # Packages on packages.microsoft.com
-    - TARGET_PLATFORM=el/6
     # Removed for now because it has no gcc4.8+ (which is required for security
     # compliance) and we also don't have oracle linux repos on microsoft
     # - TARGET_PLATFORM=ol/6
@@ -25,13 +24,11 @@ env:
     # - TARGET_PLATFORM=ol/8
     - TARGET_PLATFORM=debian/buster
     - TARGET_PLATFORM=debian/stretch
-    - TARGET_PLATFORM=debian/jessie
     # We do not have Ubuntu Focal repos yet on packages.microsoft.com
     # - TARGET_PLATFORM=ubuntu/focal
     - TARGET_PLATFORM=ubuntu/bionic
     - TARGET_PLATFORM=ubuntu/xenial
     # Packages on package cloud
-    - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=el/6
     # Oracle Linux 6 is old and it doesn't work with static assert:
     # https://github.com/citusdata/pg_auto_failover/issues/200
     # - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ol/6
@@ -42,7 +39,6 @@ env:
     # - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ol/8
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=debian/buster
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=debian/stretch
-    - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=debian/jessie
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ubuntu/focal
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ubuntu/bionic
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ubuntu/xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ env:
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ubuntu/bionic
     - UNENCRYPTED_PACKAGE=true TARGET_PLATFORM=ubuntu/xenial
 before_install:
-  - git clone -b v0.7.17 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.7.21 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - |
     if [ -z "${UNENCRYPTED_PACKAGE:-}" ]; then

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pg-auto-failover-enterprise (1.4.1-1) stable; urgency=low
+
+  * Official 1.4.1 release of pg_auto_failover enterprise
+
+ -- Hanefi Onaldi <Hanefi.Onaldi@microsoft.com>  Thu, 3 Dec 2020 18:51:21 +0300
+
 pg-auto-failover-enterprise (1.3.2-1) stable; urgency=low
 
   * Official 1.3.2 release of pg_auto_failover enterprise

--- a/debian/control.in
+++ b/debian/control.in
@@ -3,7 +3,7 @@ Section: database
 Priority: optional
 Maintainer: Citus Data <packaging@citusdata.com>
 Uploaders: Nils Dijk <nils@citusdata.com>
-Build-Depends: debhelper (>= 9), autotools-dev, flex, postgresql-server-dev-all (>= 158~), libedit-dev, libpam0g-dev, libselinux1-dev, libxslt1-dev
+Build-Depends: debhelper (>= 9), autotools-dev, flex, postgresql-server-dev-all (>= 158~), libedit-dev, libpam0g-dev, libreadline-dev, libselinux1-dev, libxslt1-dev
 Standards-Version: 3.9.7
 Homepage: https://github.com/citusdata/citus-ha
 

--- a/pg-auto-failover-enterprise.spec
+++ b/pg-auto-failover-enterprise.spec
@@ -30,9 +30,6 @@ Postgres.
 
 %build
 
-# TODO: Fix this in pg_auto_failover
-PG_CONFIG_CFLAGS="$(%{pginstdir}/bin/pg_config --cflags)"
-
 # Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
 SECURITY_CFLAGS="-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security"
 SHARED_LIB_SECURITY_CFLAGS="-fpic"
@@ -60,7 +57,7 @@ fi
 
 PATH=%{pginstdir}/bin:$PATH
 make -C src/bin/pg_autoctl %{?_smp_mflags} CFLAGS="$SECURITY_CFLAGS $EXECUTABLE_SECURITY_CFLAGS"
-make -C src/monitor %{?_smp_mflags} CFLAGS="$PG_CONFIG_CFLAGS $SECURITY_CFLAGS $SHARED_LIB_SECURITY_CFLAGS"
+make -C src/monitor %{?_smp_mflags} CFLAGS="$SECURITY_CFLAGS $SHARED_LIB_SECURITY_CFLAGS"
 %if 0%{?rhel} && 0%{?rhel} <= 6
 %else
   export PYTHONPATH=$(echo /usr/local/lib64/python3.*/site-packages):$(echo /usr/local/lib/python3.*/site-packages)

--- a/pg-auto-failover-enterprise.spec
+++ b/pg-auto-failover-enterprise.spec
@@ -10,11 +10,11 @@ Summary:	Auto-HA support for Citus
 Name:		%{sname}%{?pkginfix}_%{pgmajorversion}
 Provides:	%{sname}_%{pgmajorversion}
 Conflicts:	%{sname}_%{pgmajorversion}
-Version:	1.3.2
+Version:	1.4.1
 Release:	1%{dist}
 License:	Commercial
 Group:		Applications/Databases
-Source0:	https://github.com/citusdata/pg-auto-failover-enterprise/archive/v1.3.2.tar.gz
+Source0:	https://github.com/citusdata/pg-auto-failover-enterprise/archive/v1.4.1.tar.gz
 URL:		https://github.com/citusdata/citus-ha
 BuildRequires:	postgresql%{pgmajorversion}-devel postgresql%{pgmajorversion}-server libxml2-devel
 BuildRequires:	libxslt-devel openssl-devel pam-devel readline-devel
@@ -374,6 +374,9 @@ rm -f %{pginstdir}/bin/pg_autoctl
 
 
 %changelog
+* Thu Dec 3 2020 - Hanefi Onaldi <Hanefi.Onaldi@microsoft.com> 1.4.1-1
+- Official 1.4.1 release of pg_auto_failover enterprise
+
 * Mon Nov 23 2020 - Onur Tirtir <Onur.Tirtir@microsoft.com> 1.3.2-1
 - Official 1.3.2 release of pg_auto_failover enterprise
 

--- a/pkgvars
+++ b/pkgvars
@@ -3,5 +3,5 @@ deb_pkgname=auto-failover-enterprise
 hubproj=citus-ha
 pkgdesc='Postgres extension for automated failover and high-availability'
 pkglatest=1.4.1-1
-releasepg=10,11,12
+releasepg=10,11,12,13
 versioning=fancy

--- a/pkgvars
+++ b/pkgvars
@@ -2,6 +2,6 @@ rpm_pkgname=pg-auto-failover-enterprise
 deb_pkgname=auto-failover-enterprise
 hubproj=citus-ha
 pkgdesc='Postgres extension for automated failover and high-availability'
-pkglatest=1.3.2-1
+pkglatest=1.4.1-1
 releasepg=10,11,12
 versioning=fancy


### PR DESCRIPTION
- Remove EL6 and Debian Jessie
- Add PG13 support
- Add libreadline-dev build dependency