### PR TITLE
Use "-fno-strict-aliasing" option when building packages

### DIFF
--- a/citus-enterprise.spec
+++ b/citus-enterprise.spec
@@ -40,7 +40,12 @@ commands.
 %build
 
 # Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
-SECURITY_CFLAGS="-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security"
+#
+# Plus, we use "-fno-strict-aliasing" to get rid of "dereferencing type-punned
+# pointer will break strict-aliasing rules" warnings.
+# This is benefical from security perspective too since otherwise we might violate
+# the assumptions made by compiler optimizations and then get undefined behavior.
+SECURITY_CFLAGS="-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security -fno-strict-aliasing"
 
 currentgccver="$(gcc -dumpversion)"
 requiredgccver="4.8.2"
@@ -50,7 +55,7 @@ if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | head -n1)" 
         exit 1
     else
         echo WARNING: Using slower security flags because of outdated compiler
-        SECURITY_CFLAGS="-fstack-protector-all -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security"
+        SECURITY_CFLAGS="-fstack-protector-all -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security -fno-strict-aliasing"
     fi
 fi
 

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,12 @@ include /usr/share/postgresql-common/pgxs_debian_control.mk
 
 override_dh_auto_build:
 	# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
-	+pg_buildext build build-%v '$(CFLAGS) -fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security'
+	#
+	# Plus, we use "-fno-strict-aliasing" to get rid of "dereferencing type-punned
+	# pointer will break strict-aliasing rules" warnings.
+	# This is benefical from security perspective too since otherwise we might violate
+	# the assumptions made by compiler optimizations and then get undefined behavior.
+	+pg_buildext build build-%v '$(CFLAGS) -fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security -fno-strict-aliasing'
 
 override_dh_auto_clean:
 	# This breaks override_dh_auto_configure, so disable it.


### PR DESCRIPTION
- [x] I will test ubuntu/xenial & centos/7 packages and then will request review

Fixes https://github.com/citusdata/citus-enterprise/issues/516