### PR TITLE
Fix broken enterprise cflags

### DIFF
--- a/citus-enterprise.spec
+++ b/citus-enterprise.spec
@@ -39,22 +39,14 @@ commands.
 
 %build
 
-# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
-SECURITY_CFLAGS="-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security"
-
 currentgccver="$(gcc -dumpversion)"
 requiredgccver="4.8.2"
 if [ "$(printf '%s\n' "$requiredgccver" "$currentgccver" | sort -V | head -n1)" != "$requiredgccver" ]; then
-    if [ -z "${UNENCRYPTED_PACKAGE:-}" ]; then
-        echo ERROR: At least GCC version "$requiredgccver" is needed to build Microsoft packages
-        exit 1
-    else
-        echo WARNING: Using slower security flags because of outdated compiler
-        SECURITY_CFLAGS="-fstack-protector-all -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security"
-    fi
+    echo ERROR: At least GCC version "$requiredgccver" is needed to build with security flags
+    exit 1
 fi
 
-%configure PG_CONFIG=%{pginstdir}/bin/pg_config --with-extra-version="%{?conf_extra_version}" CC=$(command -v gcc) CFLAGS="$SECURITY_CFLAGS"
+%configure PG_CONFIG=%{pginstdir}/bin/pg_config --with-extra-version="%{?conf_extra_version}" --with-security-flags CC=$(command -v gcc)
 make %{?_smp_mflags}
 
 %install

--- a/debian/rules
+++ b/debian/rules
@@ -1,10 +1,11 @@
 #!/usr/bin/make -f
 
 include /usr/share/postgresql-common/pgxs_debian_control.mk
+CFLAGS := -fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security
 
 override_dh_auto_build:
 	# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
-	+pg_buildext build build-%v '$(CFLAGS) -fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security'
+	+pg_buildext build build-%v
 
 override_dh_auto_clean:
 	# This breaks override_dh_auto_configure, so disable it.

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 include /usr/share/postgresql-common/pgxs_debian_control.mk
-CFLAGS := -fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security
+CFLAGS := $(CFLAGS) -fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security
 
 override_dh_auto_build:
 	# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide

--- a/debian/rules
+++ b/debian/rules
@@ -1,10 +1,8 @@
 #!/usr/bin/make -f
 
 include /usr/share/postgresql-common/pgxs_debian_control.mk
-CFLAGS := $(CFLAGS) -fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security
 
 override_dh_auto_build:
-	# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
 	+pg_buildext build build-%v
 
 override_dh_auto_clean:
@@ -18,7 +16,9 @@ override_dh_auto_test:
 
 override_dh_auto_configure:
 	debian/check-gcc-version.sh
-	+pg_buildext configure build-%v "--with-extra-version='$${CONF_EXTRA_VERSION:-}' --without-libcurl"
+	# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
+	+CFLAGS='$(CFLAGS) -fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security' \
+		pg_buildext configure build-%v "--with-extra-version='$${CONF_EXTRA_VERSION:-}' --without-libcurl"
 
 override_dh_auto_install:
 	+pg_buildext install build-%v postgresql-%v-citus-enterprise

--- a/debian/rules
+++ b/debian/rules
@@ -16,9 +16,7 @@ override_dh_auto_test:
 
 override_dh_auto_configure:
 	debian/check-gcc-version.sh
-	# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
-	+CFLAGS='$(CFLAGS) -fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security' \
-		pg_buildext configure build-%v "--with-extra-version='$${CONF_EXTRA_VERSION:-}' --without-libcurl"
+	+pg_buildext configure build-%v "--with-extra-version='$${CONF_EXTRA_VERSION:-}' --without-libcurl --with-security-flags"
 
 override_dh_auto_install:
 	+pg_buildext install build-%v postgresql-%v-citus-enterprise


### PR DESCRIPTION
It appears that pg_buildext has a bug, where a parameter that is supposed to be extra CFLAGS override current ones provided by pgxs, and we end up with missing compiler flags.

pg_buildext manpage ACTIONS section:

       build [src-dir] build-dir [extra-cflags]
           Build the extension in the build-dir directory.

There is a chain of makefiles that can potentially override CFLAGS and apparently if we want to supply extra-cflags parameter we lose original flags set by the packages.

- `include $(PGXS)` https://github.com/citusdata/citus/blob/8820541fd4e0bad7827417ee136afde57f6e834b/Makefile.global.in#L50
	- `include $(top_builddir)/src/Makefile.global` https://github.com/postgres/postgres/blob/6b40d9bdbdc9f873868b0ddecacd9a307fc8ee26/src/makefiles/pgxs.mk#L85
		- `CFLAGS = @CFLAGS@` https://github.com/postgres/postgres/blob/6b40d9bdbdc9f873868b0ddecacd9a307fc8ee26/src/Makefile.global.in#L260
	- several prepended flags. (Both := and +=) https://github.com/postgres/postgres/blob/6b40d9bdbdc9f873868b0ddecacd9a307fc8ee26/src/makefiles/pgxs.mk
- `override CFLAGS += @CFLAGS@ @CITUS_CFLAGS@` and similar changes https://github.com/citusdata/citus/blob/8820541fd4e0bad7827417ee136afde57f6e834b/Makefile.global.in#L88


The problem lies in the https://salsa.debian.org/postgresql/postgresql-common/-/blob/master/pg_buildext#L80
```
make -C $vtarget ${makefile:-} ${cflags:+CFLAGS="$cflags"} PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
```
Where the command line argument overrides all ordinary assignments of CFLAGS variables in the makefiles. See https://www.gnu.org/software/make/manual/html_node/Overriding.html#Overriding

This PR creates a workaround until pg_buildext is patched and fixed so that we do not get blocked.

Fixes https://github.com/citusdata/citus-enterprise/issues/516
Closes https://github.com/citusdata/packaging/pull/601