### PR TITLE
Adds postgres support matrix support for debian based systems

### DIFF
--- a/dockerfiles/debian-bullseye-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-bullseye-all/scripts/fetch_and_build_deb
@@ -49,19 +49,26 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-source /buildfiles/supported-postgres.txt
-# set default values for certain packaging variables
+# Read PostgreSQL versions from file.
+# supported-postgres file is derived file from postgres-matrix.yml file by citus_package.
+# If file does not exist, skip populating file
+[[ -f "/buildfiles/supported-postgres" ]] && source /buildfiles/supported-postgres
+
+# Fetch pkgname, hubproj, nightlyref, versioning from pkgvars file
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${release_versions:-${releasepg}}"
-nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
+# Fetch pg release and nightly versions from supported-postgres file which is originated from postgres-matrix.yml file
+# If this file is not found, releasepg and nightlypg parameters from pkgvars are used for defining pg versions
+pg_release_versions="${release_versions:-${releasepg}}"
+pg_nightly_versions="${nightly_versions:-${nightlypg}}"
+
 
 echo "Postgres versions:"
-echo "Release Versions:${releasepg}"
-echo "Nightly Versions:${nightlypg}"
+echo "Release Versions: ${pg_release_versions}"
+echo "Nightly Versions: ${pg_nightly_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -100,7 +107,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_release_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then
@@ -128,7 +135,7 @@ case "${1}" in
         packageversion="${nextversion}.citus~${packagesuffix}"
         export CONF_EXTRA_VERSION="+${packagesuffix}"
 
-        echo "${nightlypg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_nightly_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
 esac
 

--- a/dockerfiles/debian-bullseye-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-bullseye-all/scripts/fetch_and_build_deb
@@ -49,15 +49,19 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-
+source /buildfiles/supported-postgres.txt
 # set default values for certain packaging variables
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${releasepg:-11,12,13}"
-nightlypg="${nightlypg:-${releasepg}}"
+releasepg="${release_versions:-${releasepg}}"
+nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
+
+echo "Postgres versions:"
+echo "Release Versions:${releasepg}"
+echo "Nightly Versions:${nightlypg}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2

--- a/dockerfiles/debian-buster-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-buster-all/scripts/fetch_and_build_deb
@@ -49,19 +49,26 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-source /buildfiles/supported-postgres.txt
-# set default values for certain packaging variables
+# Read PostgreSQL versions from file.
+# supported-postgres file is derived file from postgres-matrix.yml file by citus_package.
+# If file does not exist, skip populating file
+[[ -f "/buildfiles/supported-postgres" ]] && source /buildfiles/supported-postgres
+
+# Fetch pkgname, hubproj, nightlyref, versioning from pkgvars file
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${release_versions:-${releasepg}}"
-nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
+# Fetch pg release and nightly versions from supported-postgres file which is originated from postgres-matrix.yml file
+# If this file is not found, releasepg and nightlypg parameters from pkgvars are used for defining pg versions
+pg_release_versions="${release_versions:-${releasepg}}"
+pg_nightly_versions="${nightly_versions:-${nightlypg}}"
+
 
 echo "Postgres versions:"
-echo "Release Versions:${releasepg}"
-echo "Nightly Versions:${nightlypg}"
+echo "Release Versions: ${pg_release_versions}"
+echo "Nightly Versions: ${pg_nightly_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -100,7 +107,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_release_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then
@@ -128,7 +135,7 @@ case "${1}" in
         packageversion="${nextversion}.citus~${packagesuffix}"
         export CONF_EXTRA_VERSION="+${packagesuffix}"
 
-        echo "${nightlypg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_nightly_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
 esac
 

--- a/dockerfiles/debian-buster-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-buster-all/scripts/fetch_and_build_deb
@@ -55,9 +55,10 @@ declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${releasepg:-11,12,13}"
-nightlypg="${nightlypg:-${releasepg}}"
+
 versioning="${versioning:-simple}"
+supported_postgres_versions="${postgres_versions:-11,12,13}"
+nightlypg="${supported_postgres_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -96,7 +97,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${supported_postgres_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then

--- a/dockerfiles/debian-buster-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-buster-all/scripts/fetch_and_build_deb
@@ -49,16 +49,19 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-
+source /buildfiles/supported-postgres.txt
 # set default values for certain packaging variables
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-
+releasepg="${release_versions:-${releasepg}}"
+nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
-supported_postgres_versions="${postgres_versions:-11,12,13}"
-nightlypg="${supported_postgres_versions}"
+
+echo "Postgres versions:"
+echo "Release Versions:${releasepg}"
+echo "Nightly Versions:${nightlypg}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -97,7 +100,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${supported_postgres_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then

--- a/dockerfiles/debian-stretch-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-stretch-all/scripts/fetch_and_build_deb
@@ -49,19 +49,26 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-source /buildfiles/supported-postgres.txt
-# set default values for certain packaging variables
+# Read PostgreSQL versions from file.
+# supported-postgres file is derived file from postgres-matrix.yml file by citus_package.
+# If file does not exist, skip populating file
+[[ -f "/buildfiles/supported-postgres" ]] && source /buildfiles/supported-postgres
+
+# Fetch pkgname, hubproj, nightlyref, versioning from pkgvars file
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${release_versions:-${releasepg}}"
-nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
+# Fetch pg release and nightly versions from supported-postgres file which is originated from postgres-matrix.yml file
+# If this file is not found, releasepg and nightlypg parameters from pkgvars are used for defining pg versions
+pg_release_versions="${release_versions:-${releasepg}}"
+pg_nightly_versions="${nightly_versions:-${nightlypg}}"
+
 
 echo "Postgres versions:"
-echo "Release Versions:${releasepg}"
-echo "Nightly Versions:${nightlypg}"
+echo "Release Versions: ${pg_release_versions}"
+echo "Nightly Versions: ${pg_nightly_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -100,7 +107,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_release_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then
@@ -128,7 +135,7 @@ case "${1}" in
         packageversion="${nextversion}.citus~${packagesuffix}"
         export CONF_EXTRA_VERSION="+${packagesuffix}"
 
-        echo "${nightlypg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_nightly_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
 esac
 

--- a/dockerfiles/debian-stretch-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-stretch-all/scripts/fetch_and_build_deb
@@ -55,9 +55,10 @@ declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${releasepg:-11,12,13}"
-nightlypg="${nightlypg:-${releasepg}}"
+
 versioning="${versioning:-simple}"
+supported_postgres_versions="${postgres_versions:-11,12,13}"
+nightlypg="${supported_postgres_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -96,7 +97,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${supported_postgres_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then

--- a/dockerfiles/debian-stretch-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-stretch-all/scripts/fetch_and_build_deb
@@ -49,16 +49,19 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-
+source /buildfiles/supported-postgres.txt
 # set default values for certain packaging variables
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-
+releasepg="${release_versions:-${releasepg}}"
+nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
-supported_postgres_versions="${postgres_versions:-11,12,13}"
-nightlypg="${supported_postgres_versions}"
+
+echo "Postgres versions:"
+echo "Release Versions:${releasepg}"
+echo "Nightly Versions:${nightlypg}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -97,7 +100,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${supported_postgres_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then

--- a/dockerfiles/ubuntu-bionic-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-bionic-all/scripts/fetch_and_build_deb
@@ -49,19 +49,26 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-source /buildfiles/supported-postgres.txt
-# set default values for certain packaging variables
+# Read PostgreSQL versions from file.
+# supported-postgres file is derived file from postgres-matrix.yml file by citus_package.
+# If file does not exist, skip populating file
+[[ -f "/buildfiles/supported-postgres" ]] && source /buildfiles/supported-postgres
+
+# Fetch pkgname, hubproj, nightlyref, versioning from pkgvars file
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${release_versions:-${releasepg}}"
-nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
+# Fetch pg release and nightly versions from supported-postgres file which is originated from postgres-matrix.yml file
+# If this file is not found, releasepg and nightlypg parameters from pkgvars are used for defining pg versions
+pg_release_versions="${release_versions:-${releasepg}}"
+pg_nightly_versions="${nightly_versions:-${nightlypg}}"
+
 
 echo "Postgres versions:"
-echo "Release Versions:${releasepg}"
-echo "Nightly Versions:${nightlypg}"
+echo "Release Versions: ${pg_release_versions}"
+echo "Nightly Versions: ${pg_nightly_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -100,7 +107,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_release_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then
@@ -128,7 +135,7 @@ case "${1}" in
         packageversion="${nextversion}.citus~${packagesuffix}"
         export CONF_EXTRA_VERSION="+${packagesuffix}"
 
-        echo "${nightlypg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_nightly_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
 esac
 

--- a/dockerfiles/ubuntu-bionic-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-bionic-all/scripts/fetch_and_build_deb
@@ -55,9 +55,10 @@ declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${releasepg:-11,12,13}"
-nightlypg="${nightlypg:-${releasepg}}"
+
 versioning="${versioning:-simple}"
+supported_postgres_versions="${postgres_versions:-11,12,13}"
+nightlypg="${supported_postgres_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -96,7 +97,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${supported_postgres_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then

--- a/dockerfiles/ubuntu-bionic-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-bionic-all/scripts/fetch_and_build_deb
@@ -49,16 +49,19 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-
+source /buildfiles/supported-postgres.txt
 # set default values for certain packaging variables
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-
+releasepg="${release_versions:-${releasepg}}"
+nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
-supported_postgres_versions="${postgres_versions:-11,12,13}"
-nightlypg="${supported_postgres_versions}"
+
+echo "Postgres versions:"
+echo "Release Versions:${releasepg}"
+echo "Nightly Versions:${nightlypg}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -97,7 +100,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${supported_postgres_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then

--- a/dockerfiles/ubuntu-focal-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-focal-all/scripts/fetch_and_build_deb
@@ -49,19 +49,26 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-source /buildfiles/supported-postgres.txt
-# set default values for certain packaging variables
+# Read PostgreSQL versions from file.
+# supported-postgres file is derived file from postgres-matrix.yml file by citus_package.
+# If file does not exist, skip populating file
+[[ -f "/buildfiles/supported-postgres" ]] && source /buildfiles/supported-postgres
+
+# Fetch pkgname, hubproj, nightlyref, versioning from pkgvars file
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${release_versions:-${releasepg}}"
-nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
+# Fetch pg release and nightly versions from supported-postgres file which is originated from postgres-matrix.yml file
+# If this file is not found, releasepg and nightlypg parameters from pkgvars are used for defining pg versions
+pg_release_versions="${release_versions:-${releasepg}}"
+pg_nightly_versions="${nightly_versions:-${nightlypg}}"
+
 
 echo "Postgres versions:"
-echo "Release Versions:${releasepg}"
-echo "Nightly Versions:${nightlypg}"
+echo "Release Versions: ${pg_release_versions}"
+echo "Nightly Versions: ${pg_nightly_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -100,7 +107,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_release_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then
@@ -128,7 +135,7 @@ case "${1}" in
         packageversion="${nextversion}.citus~${packagesuffix}"
         export CONF_EXTRA_VERSION="+${packagesuffix}"
 
-        echo "${nightlypg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_nightly_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
 esac
 

--- a/dockerfiles/ubuntu-focal-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-focal-all/scripts/fetch_and_build_deb
@@ -55,9 +55,10 @@ declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${releasepg:-11,12,13}"
-nightlypg="${nightlypg:-${releasepg}}"
+
 versioning="${versioning:-simple}"
+supported_postgres_versions="${postgres_versions:-11,12,13}"
+nightlypg="${supported_postgres_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -96,7 +97,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${supported_postgres_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then

--- a/dockerfiles/ubuntu-focal-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-focal-all/scripts/fetch_and_build_deb
@@ -49,16 +49,19 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-
+source /buildfiles/supported-postgres.txt
 # set default values for certain packaging variables
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-
+releasepg="${release_versions:-${releasepg}}"
+nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
-supported_postgres_versions="${postgres_versions:-11,12,13}"
-nightlypg="${supported_postgres_versions}"
+
+echo "Postgres versions:"
+echo "Release Versions:${releasepg}"
+echo "Nightly Versions:${nightlypg}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -97,7 +100,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${supported_postgres_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then

--- a/dockerfiles/ubuntu-xenial-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-xenial-all/scripts/fetch_and_build_deb
@@ -49,19 +49,26 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-source /buildfiles/supported-postgres.txt
-# set default values for certain packaging variables
+# Read PostgreSQL versions from file.
+# supported-postgres file is derived file from postgres-matrix.yml file by citus_package.
+# If file does not exist, skip populating file
+[[ -f "/buildfiles/supported-postgres" ]] && source /buildfiles/supported-postgres
+
+# Fetch pkgname, hubproj, nightlyref, versioning from pkgvars file
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${release_versions:-${releasepg}}"
-nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
+# Fetch pg release and nightly versions from supported-postgres file which is originated from postgres-matrix.yml file
+# If this file is not found, releasepg and nightlypg parameters from pkgvars are used for defining pg versions
+pg_release_versions="${release_versions:-${releasepg}}"
+pg_nightly_versions="${nightly_versions:-${nightlypg}}"
+
 
 echo "Postgres versions:"
-echo "Release Versions:${releasepg}"
-echo "Nightly Versions:${nightlypg}"
+echo "Release Versions: ${pg_release_versions}"
+echo "Nightly Versions: ${pg_nightly_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -100,7 +107,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_release_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then
@@ -128,7 +135,7 @@ case "${1}" in
         packageversion="${nextversion}.citus~${packagesuffix}"
         export CONF_EXTRA_VERSION="+${packagesuffix}"
 
-        echo "${nightlypg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_nightly_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
 esac
 

--- a/dockerfiles/ubuntu-xenial-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-xenial-all/scripts/fetch_and_build_deb
@@ -55,9 +55,10 @@ declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${releasepg:-11,12,13}"
-nightlypg="${nightlypg:-${releasepg}}"
+
 versioning="${versioning:-simple}"
+supported_postgres_versions="${postgres_versions:-11,12,13}"
+nightlypg="${supported_postgres_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -96,7 +97,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${supported_postgres_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then

--- a/dockerfiles/ubuntu-xenial-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-xenial-all/scripts/fetch_and_build_deb
@@ -49,16 +49,19 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-
+source /buildfiles/supported-postgres.txt
 # set default values for certain packaging variables
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-
+releasepg="${release_versions:-${releasepg}}"
+nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
-supported_postgres_versions="${postgres_versions:-11,12,13}"
-nightlypg="${supported_postgres_versions}"
+
+echo "Postgres versions:"
+echo "Release Versions:${releasepg}"
+echo "Nightly Versions:${nightlypg}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -97,7 +100,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${supported_postgres_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -67,8 +67,8 @@ pg_nightly_versions="${nightly_versions:-${nightlypg}}"
 
 
 echo "Postgres versions:"
-echo "Release Versions :${pg_release_versions}"
-echo "Nightly Versions :${pg_nightly_versions}"
+echo "Release Versions: ${pg_release_versions}"
+echo "Nightly Versions: ${pg_nightly_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -51,7 +51,8 @@ fi
 source /buildfiles/pkgvars
 # populate pg versions to be used for packaging.
 # supported-potgres file is derived file from postgres-matrix.yml file
-source /buildfiles/supported-postgres 2>/dev/null
+# If file does not exist, skip populating file
+[[ -f "/buildfiles/supported-postgres" ]] && source /buildfiles/supported-postgres
 
 # Fetch pkgname, hubproj, nightlyref, versioning from pkgvars file
 declare pkglatest # to make shellcheck happy

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -55,9 +55,10 @@ declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${releasepg:-11,12,13}"
-nightlypg="${nightlypg:-${releasepg}}"
+
 versioning="${versioning:-simple}"
+supported_postgres_versions="${postgres_versions:-11,12,13}"
+nightlypg="${supported_postgres_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -96,7 +97,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${supported_postgres_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -49,16 +49,19 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-
+source /buildfiles/supported-postgres.txt
 # set default values for certain packaging variables
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-
+releasepg="${release_versions:-${releasepg}}"
+nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
-supported_postgres_versions="${postgres_versions:-11,12,13}"
-nightlypg="${supported_postgres_versions}"
+
+echo "Postgres versions:"
+echo "Release Versions:${releasepg}"
+echo "Nightly Versions:${nightlypg}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -97,7 +100,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${supported_postgres_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -49,8 +49,8 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-# populate pg versions to be used for packaging.
-# supported-potgres file is derived file from postgres-matrix.yml file
+# Read PostgreSQL versions from file.
+# supported-postgres file is derived file from postgres-matrix.yml file by citus_package.
 # If file does not exist, skip populating file
 [[ -f "/buildfiles/supported-postgres" ]] && source /buildfiles/supported-postgres
 

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -60,8 +60,8 @@ nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
 
 echo "Postgres versions:"
-echo "Release Versions:${releasepg}"
-echo "Nightly Versions:${nightlypg}"
+echo "Release Versions :${releasepg}"
+echo "Nightly Versions :${nightlypg}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -49,19 +49,25 @@ fi
 # populate variables from packaging metadata file
 # shellcheck source=/dev/null
 source /buildfiles/pkgvars
-source /buildfiles/supported-postgres.txt
-# set default values for certain packaging variables
+# populate pg versions to be used for packaging.
+# supported-potgres file is derived file from postgres-matrix.yml file
+source /buildfiles/supported-postgres 2>/dev/null
+
+# Fetch pkgname, hubproj, nightlyref, versioning from pkgvars file
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
 nightlyref="${nightlyref:-master}"
-releasepg="${release_versions:-${releasepg}}"
-nightlypg="${nightly_versions:-${nightlypg}}"
 versioning="${versioning:-simple}"
+# Fetch pg release and nightly versions from supported-postgres file which is originated from postgres-matrix.yml file
+# If this file is not found, releasepg and nightlypg parameters from pkgvars are used for defining pg versions
+pg_release_versions="${release_versions:-${releasepg}}"
+pg_nightly_versions="${nightly_versions:-${nightlypg}}"
+
 
 echo "Postgres versions:"
-echo "Release Versions :${releasepg}"
-echo "Nightly Versions :${nightlypg}"
+echo "Release Versions :${pg_release_versions}"
+echo "Nightly Versions :${pg_nightly_versions}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2
@@ -100,7 +106,7 @@ case "${1}" in
             exit $failure
         fi
 
-        echo "${releasepg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_release_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
     *)
         if [ "${1}" == 'nightly' ]; then
@@ -128,7 +134,7 @@ case "${1}" in
         packageversion="${nextversion}.citus~${packagesuffix}"
         export CONF_EXTRA_VERSION="+${packagesuffix}"
 
-        echo "${nightlypg}" | tr ',' '\n' > "${builddir}/debian/pgversions"
+        echo "${pg_nightly_versions}" | tr ',' '\n' > "${builddir}/debian/pgversions"
         ;;
 esac
 


### PR DESCRIPTION
Build parametrization according to postgres version is handled in docker images for debian based systems since there is only one image for them. Versions should be added into debian/pgversions to be built. Before this PR these parameters are being taken from pkgvars. With this PR , I got these paramaters postgres-versions.txt file. 