### PR TITLE
Adds pg14 beta repo and libraries for deb based packaging images 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
     - TARGET_PLATFORM=oraclelinux,7
     - TARGET_PLATFORM=ubuntu,focal
     - TARGET_PLATFORM=ubuntu,bionic
-    - TARGET_PLATFORM=ubuntu,xenial
     - TARGET_PLATFORM=pgxn
 before_install:
   - echo $TARGET_PLATFORM > os-list.csv

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -38,7 +38,11 @@ RUN set -ex; \
     apt-key list
 
 # install build tools and PostgreSQL development files
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+# Since pg 14 is not released yet, pg 14 repo is needed to add  to install pg 14 related libraries.
+# Since postgresql-server-dev-all library does not include pg14 libraries, postgresql-server-dev-14
+# library is needed to add.
+# TODO After Pg14 official release the changes should be rolled back.
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main 14' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -62,6 +66,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' > /etc/
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
+        postgresql-server-dev-14 \
         wget \
         zlib1g-dev \
         python3-pip \

--- a/dockerfiles/debian-stretch-all/Dockerfile
+++ b/dockerfiles/debian-stretch-all/Dockerfile
@@ -38,7 +38,11 @@ RUN set -ex; \
     apt-key list
 
 # install build tools and PostgreSQL development files
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+# Since pg 14 is not released yet, pg 14 repo is needed to add  to install pg 14 related libraries.
+# Since postgresql-server-dev-all library does not include pg14 libraries, postgresql-server-dev-14
+# library is needed to add.
+# TODO After Pg14 official release the changes should be rolled back.
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main 14' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -62,6 +66,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
+        postgresql-server-dev-14 \
         wget \
         zlib1g-dev \
         python3-pip \

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -38,7 +38,11 @@ RUN set -ex; \
     apt-key list
 
 # install build tools and PostgreSQL development files
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+# Since pg 14 is not released yet, pg 14 repo is needed to add  to install pg 14 related libraries.
+# Since postgresql-server-dev-all library does not include pg14 libraries, postgresql-server-dev-14
+# library is needed to add.
+# TODO After Pg14 official release the changes should be rolled back.
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main 14' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -62,6 +66,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main' > /etc/
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
+        postgresql-server-dev-14 \
         wget \
         zlib1g-dev \
         python3-pip \

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -38,7 +38,11 @@ RUN set -ex; \
     apt-key list
 
 # install build tools and PostgreSQL development files
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+# Since pg 14 is not released yet, pg 14 repo is needed to add  to install pg 14 related libraries.
+# Since postgresql-server-dev-all library does not include pg14 libraries, postgresql-server-dev-14
+# library is needed to add.
+# TODO After Pg14 official release the changes should be rolled back.
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main 14' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -62,6 +66,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/a
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
+        postgresql-server-dev-14 \
         wget \
         zlib1g-dev \
         python3-pip \

--- a/dockerfiles/ubuntu-xenial-all/Dockerfile
+++ b/dockerfiles/ubuntu-xenial-all/Dockerfile
@@ -38,7 +38,11 @@ RUN set -ex; \
     apt-key list
 
 # install build tools and PostgreSQL development files
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+# Since pg 14 is not released yet, pg 14 repo is needed to add  to install pg 14 related libraries.
+# Since postgresql-server-dev-all library does not include pg14 libraries, postgresql-server-dev-14
+# library is needed to add.
+# TODO After Pg14 official release the changes should be rolled back.
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main 14' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -62,6 +66,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' > /etc/
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
+        postgresql-server-dev-14 \
         wget \
         zlib1g-dev \
         python3-pip \

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -38,7 +38,11 @@ RUN set -ex; \
     apt-key list
 
 # install build tools and PostgreSQL development files
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+# Since pg 14 is not released yet, pg 14 repo is needed to add  to install pg 14 related libraries.
+# Since postgresql-server-dev-all library does not include pg14 libraries, postgresql-server-dev-14
+# library is needed to add.
+# TODO After Pg14 official release the changes should be rolled back.
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main 14' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -62,6 +66,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main' > 
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
+        postgresql-server-dev-14 \
         wget \
         zlib1g-dev \
         python3-pip \


### PR DESCRIPTION
Pg 14 packages could not be created with our current packaging images. We need to change repo address and add additional postgresql-dev-14 package to be able to build images. I added postgresql-dev-14 package since  postgresql-dev-all does not include pg14 related packages