### PR TITLE
Bump Debian hll to 2.16

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+hll (2.16.citus-1) stable; urgency=low
+
+  * Support for PostgreSQL 14
+
+ -- Hanefi Onaldi <Hanefi.Onaldi@microsoft.com>  Mon, 13 Sep 2021 11:20:00 +0300
+
 hll (2.15.citus-1) stable; urgency=low
 
   * Support for PostgreSQL 13

--- a/pkgvars
+++ b/pkgvars
@@ -1,5 +1,5 @@
 pkgname=hll
 hubproj=postgresql-hll
 pkgdesc=HyperLogLog
-pkglatest=2.15.citus-1
+pkglatest=2.16.citus-1
 releasepg=11,12,13

--- a/pkgvars
+++ b/pkgvars
@@ -2,4 +2,4 @@ pkgname=hll
 hubproj=postgresql-hll
 pkgdesc=HyperLogLog
 pkglatest=2.16.citus-1
-releasepg=11,12,13
+releasepg=11,12,13,14


### PR DESCRIPTION
This PR needs to access PG14 packages in packaging docker images.

## Note to the tester/reviewer:
Please make sure that we can generate PG14 packages for all supported OS distros in the matrix.