### PR TITLE
Fixes wrong packagecloud repo name from pipeline

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -2,7 +2,7 @@ name: Build Package
 
 env:
   MAIN_BRANCH: "all-pgautofailover-enterprise"
-  PACKAGE_CLOUD_REPO_NAME: "sample"
+  PACKAGE_CLOUD_REPO_NAME: "citusdata/enterprise"
   PACKAGE_ENCRYPTION_KEY: ${{ secrets.PACKAGE_ENCRYPTION_KEY }}
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}


### PR DESCRIPTION
I left my test repo so that I needed to change it with the correct one.