### PR TITLE
Adds debian bullseye support into repo installation scripts

### DIFF
--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -171,6 +171,9 @@ detect_codename ()
       10)
         codename='buster'
         ;;
+      11)
+        codename='bullseye'
+        ;;
       wheezy)
         codename="${dist}"
         ;;
@@ -181,6 +184,9 @@ detect_codename ()
         codename="${dist}"
         ;;
       buster)
+        codename="${dist}"
+        ;;
+      bullseye)
         codename="${dist}"
         ;;
       *)

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -171,6 +171,9 @@ detect_codename ()
       10)
         codename='buster'
         ;;
+      11)
+        codename='bullseye'
+        ;;
       wheezy)
         codename="${dist}"
         ;;
@@ -181,6 +184,9 @@ detect_codename ()
         codename="${dist}"
         ;;
       buster)
+        codename="${dist}"
+        ;;
+      bullseye)
         codename="${dist}"
         ;;
       *)

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -201,6 +201,9 @@ detect_codename ()
       10)
         codename='buster'
         ;;
+      11)
+        codename='bullseye'
+        ;;
       wheezy)
         codename="${dist}"
         ;;
@@ -211,6 +214,9 @@ detect_codename ()
         codename="${dist}"
         ;;
       buster)
+        codename="${dist}"
+        ;;
+      bullseye)
         codename="${dist}"
         ;;
       *)

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -201,6 +201,9 @@ detect_codename ()
       10)
         codename='buster'
         ;;
+      11)
+        codename='bullseye'
+        ;;
       wheezy)
         codename="${dist}"
         ;;
@@ -211,6 +214,9 @@ detect_codename ()
         codename="${dist}"
         ;;
       buster)
+        codename="${dist}"
+        ;;
+      bullseye)
         codename="${dist}"
         ;;
       *)


### PR DESCRIPTION
Adds debian bullseye among supported os list
Below test was performed on debian 11

![image](https://user-images.githubusercontent.com/1596331/134870522-196212e8-2e09-42c0-aa6e-a2612d07bbb3.png)
