### PR TITLE
Adds ignore for useless-provides for rpm in pgaf enterprise

### DIFF
--- a/rpmlintrc
+++ b/rpmlintrc
@@ -1,4 +1,5 @@
 addFilter("E: binary-or-shlib-defines-rpath .*");
+addFilter("E: useless-provides .*");
 addFilter("W: devel-file-in-non-devel-package .*");
 addFilter("W: incoherent-version-in-changelog .*el7");
 addFilter("W: invalid-url .*404: Not Found");


### PR DESCRIPTION
When building nightlies we saw the error below
https://github.com/citusdata/packaging/runs/3662202754?check_suite_focus=true
When I look into the error, I realized that this same error has been addes ignore list for citus
 https://github.com/citusdata/packaging/blob/383c0a7a575cc198787ab35688a8c85a904b5305/rpmlintrc#L2
When I look for this error since the same package is shown multiple times it is not an error and it is ignorable as defined below
https://github.com/rpm-software-management/rpmlint/issues/427