### PR TITLE
Add debian/bullseye to packaging tests

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -29,6 +29,7 @@ jobs:
           - ol/7
           - debian/stretch
           - debian/buster
+          - debian/bullseye
           - ubuntu/bionic
           - ubuntu/focal
 

--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Clone tools branch
-        run: git clone -b v0.8.2 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.6 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Clone all-citus branch
         run: git clone -b all-citus --depth=1  https://github.com/citusdata/packaging.git packaging

--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -1,4 +1,4 @@
-name: Buildand publish citus nightly package
+name: Build and publish citus nightly package
 
 env:
   MAIN_BRANCH: "all-citus"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: required
 services: [docker]
 language: perl
-perl: "5.18"
+perl:
+  - "5.18"
 env:
   matrix:
     - TARGET_PLATFORM=centos,8


### PR DESCRIPTION
I went over all CI configs and added `debian/bullseye` to the single place where it made sense. While doing that I also solved 2 small issues with our CI configs as well.

@gurkanindibay please make sure the tests pass for `debian/bullseye` and feel free to take the ownership of this PR.