### PR TITLE
Updates travis os to focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: required
 services: [docker]
 language: perl
 perl: "5.18"
+arch: amd64
+os: linux
+dist: focal
 env:
   matrix:
     - TARGET_PLATFORM=centos,8


### PR DESCRIPTION
Debian 11 build are failing on travis since travis default build environment is xenial
https://app.travis-ci.com/github/citusdata/packaging/jobs/540749740
I updated os dist into focal and now there is not such problem