### PR TITLE
Fix warnings in travis configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
-sudo: required
 services: [docker]
 language: perl
-perl: "5.18"
+perl:
+  - "5.18"
 arch: amd64
 os: linux
 dist: focal
 env:
-  matrix:
+  jobs:
     - TARGET_PLATFORM=centos,8
     - TARGET_PLATFORM=centos,7
     - TARGET_PLATFORM=debian,bullseye


### PR DESCRIPTION
We have 1 warning and 1 info message in Travis
website about our configurations.

Warning:
root: deprecated key sudo (The key `sudo` has no effect anymore.)

Info:
env: key matrix is an alias for jobs, using jobs

I realized those when reviewing #815 and I wanted to fix them in a separate PR.