### PR TITLE
Fixes repo push and repo delete problem for update_package_properties pipeline

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Clone tools branch
-        run: git clone -b v0.8.5 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b pg14-stable --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -5,6 +5,7 @@ env:
   PACKAGE_CLOUD_REPO_NAME: "citusdata/community"
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
   PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
   PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
 on:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -5,7 +5,6 @@ env:
   PACKAGE_CLOUD_REPO_NAME: "citusdata/community"
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
   PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
   PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
 on:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Clone tools branch
-        run: git clone -b pg14-stable --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.8 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -1,5 +1,9 @@
 name: Update Package Properties
 
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   PRJ_NAME: "citus"
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -61,5 +65,3 @@ jobs:
           --fancy_ver_no "${{ github.event.inputs.fancy_version_no }}" \
           --changelog_entry "${{ github.event.inputs.changelog_entry }}" \
           --exec_path "$(pwd)"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -39,7 +39,7 @@ jobs:
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources
 
       - name: Clone tools branch
-        run: git clone -b v0.8.6 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.8 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Set git name and email
         run: |

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -1,11 +1,11 @@
 name: Update Package Properties
 
 permissions:
-  contents: read/write
-  pull-requests: read/write
-  actions: read/write
-  repository projects: read/write
-  statuses: read/write
+  contents: write
+  pull-requests: write
+  actions: write
+  repository projects: write
+  statuses: write
 
 env:
   PRJ_NAME: "citus"

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -1,17 +1,5 @@
 name: Update Package Properties
 
-permissions:
-  actions: write
-  checks: write
-  contents: write
-  deployments: write
-  issues: write
-  packages: write
-  pull-requests: write
-  repository-projects: write
-  security-events: write
-  statuses: write
-
 env:
   PRJ_NAME: "citus"
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -45,30 +33,31 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+  - name: Install dependencies
+    run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources
 
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources
+  - name: Clone tools branch
+    run: git clone -b v0.8.6 --depth=1  https://github.com/citusdata/tools.git tools
 
-      - name: Clone tools branch
-        run: git clone -b v0.8.6 --depth=1  https://github.com/citusdata/tools.git tools
+  - name: Set git name and email
+    run: |
+      git config --global user.email "${{ github.event.inputs.microsoft_email }}" && \
+      git config --global user.name "${{ github.event.inputs.name }}"
 
-      - name: Set git name and email
-        run: |
-          git config --global user.email "${{ github.event.inputs.microsoft_email }}" && \
-          git config --global user.name "${{ github.event.inputs.name }}"
+  - name: Install python requirements
+    run: python -m pip install -r tools/packaging_automation/requirements.txt
 
-      - name: Install python requirements
-        run: python -m pip install -r tools/packaging_automation/requirements.txt
-
-      - name: Update package properties
-        run: |
-          python -m tools.packaging_automation.update_package_properties \
-          --gh_token="${GH_TOKEN}" \
-          --prj_name "${PRJ_NAME}" \
-          --tag_name ${{ github.event.inputs.tag_name }} \
-          --email ${{ github.event.inputs.microsoft_email }} \
-          --name "${{ github.event.inputs.name }}" \
-          --pipeline \
-          --fancy_ver_no "${{ github.event.inputs.fancy_version_no }}" \
-          --changelog_entry "${{ github.event.inputs.changelog_entry }}" \
-          --exec_path "$(pwd)"
+  - name: Update package properties
+    run: |
+      python -m tools.packaging_automation.update_package_properties \
+      --gh_token="${GH_TOKEN}" \
+      --prj_name "${PRJ_NAME}" \
+      --tag_name ${{ github.event.inputs.tag_name }} \
+      --email ${{ github.event.inputs.microsoft_email }} \
+      --name "${{ github.event.inputs.name }}" \
+      --pipeline \
+      --fancy_ver_no "${{ github.event.inputs.fancy_version_no }}" \
+      --changelog_entry "${{ github.event.inputs.changelog_entry }}" \
+      --exec_path "$(pwd)"

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -1,8 +1,11 @@
 name: Update Package Properties
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read/write
+  pull-requests: read/write
+  actions: read/write
+  repository projects: read/write
+  statuses: read/write
 
 env:
   PRJ_NAME: "citus"
@@ -35,20 +38,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set git name and email
-        run: |
-          git config --global user.email "${{ github.event.inputs.microsoft_email }}" && \
-          git config --global user.name "${{ github.event.inputs.name }}"
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          token: "${GH_TOKEN}"
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources
 
       - name: Clone tools branch
         run: git clone -b v0.8.6 --depth=1  https://github.com/citusdata/tools.git tools
+
+      - name: Set git name and email
+        run: |
+          git config --global user.email "${{ github.event.inputs.microsoft_email }}" && \
+          git config --global user.name "${{ github.event.inputs.name }}"
 
       - name: Install python requirements
         run: python -m pip install -r tools/packaging_automation/requirements.txt

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -35,6 +35,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set git name and email
+        run: |
+          git config --global user.email "${{ github.event.inputs.microsoft_email }}" && \
+          git config --global user.name "${{ github.event.inputs.name }}"
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
@@ -45,11 +49,6 @@ jobs:
 
       - name: Clone tools branch
         run: git clone -b v0.8.6 --depth=1  https://github.com/citusdata/tools.git tools
-
-      - name: Set git name and email
-        run: |
-          git config --global user.email "${{ github.event.inputs.microsoft_email }}" && \
-          git config --global user.name "${{ github.event.inputs.name }}"
 
       - name: Install python requirements
         run: python -m pip install -r tools/packaging_automation/requirements.txt

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -7,7 +7,6 @@ permissions:
 env:
   PRJ_NAME: "citus"
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -35,29 +35,29 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_TOKEN }}
-  - name: Install dependencies
-    run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources
 
-  - name: Clone tools branch
-    run: git clone -b v0.8.6 --depth=1  https://github.com/citusdata/tools.git tools
+      - name: Clone tools branch
+        run: git clone -b v0.8.6 --depth=1  https://github.com/citusdata/tools.git tools
 
-  - name: Set git name and email
-    run: |
-      git config --global user.email "${{ github.event.inputs.microsoft_email }}" && \
-      git config --global user.name "${{ github.event.inputs.name }}"
+      - name: Set git name and email
+        run: |
+          git config --global user.email "${{ github.event.inputs.microsoft_email }}" && \
+          git config --global user.name "${{ github.event.inputs.name }}"
 
-  - name: Install python requirements
-    run: python -m pip install -r tools/packaging_automation/requirements.txt
+      - name: Install python requirements
+        run: python -m pip install -r tools/packaging_automation/requirements.txt
 
-  - name: Update package properties
-    run: |
-      python -m tools.packaging_automation.update_package_properties \
-      --gh_token="${GH_TOKEN}" \
-      --prj_name "${PRJ_NAME}" \
-      --tag_name ${{ github.event.inputs.tag_name }} \
-      --email ${{ github.event.inputs.microsoft_email }} \
-      --name "${{ github.event.inputs.name }}" \
-      --pipeline \
-      --fancy_ver_no "${{ github.event.inputs.fancy_version_no }}" \
-      --changelog_entry "${{ github.event.inputs.changelog_entry }}" \
-      --exec_path "$(pwd)"
+      - name: Update package properties
+        run: |
+          python -m tools.packaging_automation.update_package_properties \
+          --gh_token="${GH_TOKEN}" \
+          --prj_name "${PRJ_NAME}" \
+          --tag_name ${{ github.event.inputs.tag_name }} \
+          --email ${{ github.event.inputs.microsoft_email }} \
+          --name "${{ github.event.inputs.name }}" \
+          --pipeline \
+          --fancy_ver_no "${{ github.event.inputs.fancy_version_no }}" \
+          --changelog_entry "${{ github.event.inputs.changelog_entry }}" \
+          --exec_path "$(pwd)"

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          token: "${GH_TOKEN}"
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -3,6 +3,7 @@ name: Update Package Properties
 env:
   PRJ_NAME: "citus"
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -1,10 +1,15 @@
 name: Update Package Properties
 
 permissions:
-  contents: write
-  pull-requests: write
   actions: write
-  repository projects: write
+  checks: write
+  contents: write
+  deployments: write
+  issues: write
+  packages: write
+  pull-requests: write
+  repository-projects: write
+  security-events: write
   statuses: write
 
 env:

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -61,3 +61,5 @@ jobs:
           --fancy_ver_no "${{ github.event.inputs.fancy_version_no }}" \
           --changelog_entry "${{ github.event.inputs.changelog_entry }}" \
           --exec_path "$(pwd)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Update package properties pipeline is responsible for updating versions in related packaging repository. This was working fine but when I checked it to replicate into other projects (citus-enterprise etc) , I found out that it does not work and getting errors
Fixed it by overriding the default secrets.GITHUB_TOKEN (autogenerated for each exec)  with the token we are using secrets.GH_TOKEN
Updated the tools tag into the latest one as well