### PR TITLE
Fixes package installation error for deb packages

### DIFF
--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -227,6 +227,7 @@ main ()
   apt_config_url="https://repos.citusdata.com/community-nightlies/config_file.list?os=${os}&dist=${dist}&source=script"
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_community-nightlies.list"
+    gpg_keyring_path="/usr/share/keyrings/citusdata_community-archive-keyring.gpg"
 
   echo -n "Installing $apt_source_path... "
 
@@ -272,7 +273,7 @@ main ()
 
   echo -n "Importing Citus Data gpg key... "
   # import the gpg key
-  curl -L "${gpg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
+  curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
   echo "done."
 
   echo -n "Running apt-get update... "

--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -227,7 +227,7 @@ main ()
   apt_config_url="https://repos.citusdata.com/community-nightlies/config_file.list?os=${os}&dist=${dist}&source=script"
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_community-nightlies.list"
-    gpg_keyring_path="/usr/share/keyrings/citusdata_community-archive-keyring.gpg"
+  gpg_keyring_path="/usr/share/keyrings/citusdata_community-archive-keyring.gpg"
 
   echo -n "Installing $apt_source_path... "
 

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -227,6 +227,7 @@ main ()
   apt_config_url="https://repos.citusdata.com/community/config_file.list?os=${os}&dist=${dist}&source=script"
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_community.list"
+  gpg_keyring_path="/usr/share/keyrings/citusdata_community-archive-keyring.gpg"
 
   echo -n "Installing $apt_source_path... "
 
@@ -272,7 +273,7 @@ main ()
 
   echo -n "Importing Citus Data gpg key... "
   # import the gpg key
-  curl -L "${gpg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
+  curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
   echo "done."
 
   echo -n "Running apt-get update... "

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -280,6 +280,7 @@ main ()
 
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_enterprise-nightlies.list"
+  gpg_keyring_path="/usr/share/keyrings/citusdata_community-archive-keyring.gpg"
 
   echo -n "Installing $apt_source_path... "
 
@@ -325,7 +326,7 @@ main ()
 
   echo -n "Importing Citus Data gpg key... "
   # import the gpg key
-  curl -L "${gpg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
+  curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
   echo "done."
 
   echo -n "Running apt-get update... "

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -280,6 +280,7 @@ main ()
 
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_enterprise.list"
+  gpg_keyring_path="/usr/share/keyrings/citusdata_community-archive-keyring.gpg"
 
   echo -n "Installing $apt_source_path... "
 
@@ -325,7 +326,7 @@ main ()
 
   echo -n "Importing Citus Data gpg key... "
   # import the gpg key
-  curl -L "${gpg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
+  curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
   echo "done."
 
   echo -n "Running apt-get update... "


### PR DESCRIPTION
GPG key import mechanism has changed in packagecloud debian repo installation script. I reflect this change to fix the package download for deb 
I executed tests for packaging rpm installations are successful.
If you want to test you can test with the script below

curl -s https://raw.githubusercontent.com/citusdata/packaging/debian_gpg_error/community/deb.sh | bash
apt-get install -y postgresql-14-citus-10.2=10.2.2

Test executions for all os list is as following
https://github.com/citusdata/tools/actions/runs/1503082566

Dropping packagecloud installation script just for reference
https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh