### PR TITLE
Fixes enterprise and nightlies repo installations

### DIFF
--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -273,6 +273,8 @@ main ()
 
   echo -n "Importing Citus Data gpg key... "
   # import the gpg key
+  # below command decodes the ASCII armored gpg file (instead of binary file)
+  # and adds the unarmored gpg key as keyring
   curl -L "${gpg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
   echo "done."
 

--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -278,6 +278,11 @@ main ()
   curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
   echo "done."
 
+  echo -n "Running apt-get update... "
+  # update apt on this system
+  apt-get update &> /dev/null
+  echo "done."
+
   echo
   echo "The repository is set up! You can now install packages."
 }

--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -227,7 +227,7 @@ main ()
   apt_config_url="https://repos.citusdata.com/community-nightlies/config_file.list?os=${os}&dist=${dist}&source=script"
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_community-nightlies.list"
-  gpg_keyring_path="/usr/share/keyrings/citusdata_community-archive-keyring.gpg"
+  gpg_keyring_path="/usr/share/keyrings/citusdata_community-nightlies-archive-keyring.gpg"
 
   echo -n "Installing $apt_source_path... "
 
@@ -273,12 +273,7 @@ main ()
 
   echo -n "Importing Citus Data gpg key... "
   # import the gpg key
-  curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
-  echo "done."
-
-  echo -n "Running apt-get update... "
-  # update apt on this system
-  apt-get update &> /dev/null
+  curl -L "${gpg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
   echo "done."
 
   echo

--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -271,7 +271,7 @@ main ()
     echo "done."
   fi
 
-  echo -n "Importing Citus Data gpg key... "
+  echo -n "Importing Citus Data Community nightlies gpg key... "
   # import the gpg key
   # below command decodes the ASCII armored gpg file (instead of binary file)
   # and adds the unarmored gpg key as keyring

--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -275,7 +275,7 @@ main ()
   # import the gpg key
   # below command decodes the ASCII armored gpg file (instead of binary file)
   # and adds the unarmored gpg key as keyring
-  curl -L "${gpg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
+  curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
   echo "done."
 
   echo

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -273,6 +273,8 @@ main ()
 
   echo -n "Importing Citus Data gpg key... "
   # import the gpg key
+  # below command decodes the ASCII armored gpg file (instead of binary file)
+  # and adds the unarmored gpg key as keyring
   curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
   echo "done."
 

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -271,7 +271,7 @@ main ()
     echo "done."
   fi
 
-  echo -n "Importing Citus Data gpg key... "
+  echo -n "Importing Citus Data Community gpg key... "
   # import the gpg key
   # below command decodes the ASCII armored gpg file (instead of binary file)
   # and adds the unarmored gpg key as keyring

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -326,6 +326,8 @@ main ()
 
   echo -n "Importing Citus Data Enterprise nightlies gpg key... "
   # import the gpg key
+  # below command decodes the ASCII armored gpg file (instead of binary file)
+  # and adds the unarmored gpg key as keyring
   curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
   echo "done."
 

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -280,7 +280,7 @@ main ()
 
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_enterprise-nightlies.list"
-  gpg_keyring_path="/usr/share/keyrings/citusdata_community-archive-keyring.gpg"
+  gpg_keyring_path="/usr/share/keyrings/citusdata_enterprise-nightlies-archive-keyring.gpg"
 
   echo -n "Installing $apt_source_path... "
 
@@ -324,7 +324,7 @@ main ()
     echo "done."
   fi
 
-  echo -n "Importing Citus Data gpg key... "
+  echo -n "Importing Citus Data Enterprise nightlies gpg key... "
   # import the gpg key
   curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
   echo "done."

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -326,6 +326,8 @@ main ()
 
   echo -n "Importing Citus Data Enterprise gpg key... "
   # import the gpg key
+  # below command decodes the ASCII armored gpg file (instead of binary file)
+  # and adds the unarmored gpg key as keyring
   curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
   echo "done."
 

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -280,7 +280,7 @@ main ()
 
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_enterprise.list"
-  gpg_keyring_path="/usr/share/keyrings/citusdata_community-archive-keyring.gpg"
+  gpg_keyring_path="/usr/share/keyrings/citusdata_enterprise-archive-keyring.gpg"
 
   echo -n "Installing $apt_source_path... "
 
@@ -324,7 +324,7 @@ main ()
     echo "done."
   fi
 
-  echo -n "Importing Citus Data gpg key... "
+  echo -n "Importing Citus Data Enterprise gpg key... "
   # import the gpg key
   curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
   echo "done."


### PR DESCRIPTION
It seems that packagecloud started storing gpg keys in armored style and when adding as gpg keydearmor operation is needed to perform to convert it to binary and then store it as keyring
Armor
https://www.techopedia.com/definition/23150/ascii-armor
dearmor
https://www.linuxjournal.com/article/8732