### PR TITLE
Do not use caches on docker build

### DIFF
--- a/update_image
+++ b/update_image
@@ -25,7 +25,7 @@ IFS=',' read -r os release <<< "${TARGET_PLATFORM}"
 
 if [[ "${os}" = 'debian' ]] || [[ "${os}" = 'ubuntu' ]]; then
     tag="${os}-${release}-all"
-    args+="build -t citus/packaging:${tag} -f ${dockerfiles_dir}/${tag}/Dockerfile .\n"
+    args+="build --pull --no-cache -t citus/packaging:${tag} -f ${dockerfiles_dir}/${tag}/Dockerfile .\n"
 elif [[ "${os}" = 'centos' ]] || [[ "${os}" = 'oraclelinux' ]]; then
     # redhat variants need an image for each PostgreSQL version
     IFS=' '
@@ -38,11 +38,11 @@ elif [[ "${os}" = 'centos' ]] || [[ "${os}" = 'oraclelinux' ]]; then
         fi
         pgshort=${pgversion//./}
         tag="${os}-${release}-pg${pgshort}"
-        args+="build -t citus/packaging:${tag} -f ${dockerfiles_dir}/${tag}/Dockerfile .\n"
+        args+="build --pull --no-cache -t citus/packaging:${tag} -f ${dockerfiles_dir}/${tag}/Dockerfile .\n"
     done
 elif [[ "${os}" = 'pgxn' ]]; then
     tag="${os}-all"
-    args+="build -t citus/packaging:${tag} -f ${dockerfiles_dir}/${tag}/Dockerfile .\n"
+    args+="build --pull --no-cache -t citus/packaging:${tag} -f ${dockerfiles_dir}/${tag}/Dockerfile .\n"
 else
     echo "$0: unrecognized OS -- ${os}" >&2
     exit $badusage


### PR DESCRIPTION
I added two new options to our docker build commands.

--pull : Always attempt to pull a newer version of the base update_image

We can have new patches, or updates to our base images. It is a nice
idea to keep them updated.

--no-cache : Do not use cache when building the image

We can have some outdated package versions, if we use cached
intermediate steps. It is a good idea to run all the steps to make sure
we have up-to-date packages.

Related: https://github.com/citusdata/packaging/pull/864#discussion_r757590751