### PR TITLE
Fixes patch for ubuntu and non-working centos-8 mirrors

### DIFF
--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM centos:7
 
+RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM centos:7
 
+RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM centos:7
 
+RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM centos:7
 
+RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM centos:7
 
+RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:8
 
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM centos:8
 
+RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:8
 
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:8
 
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM centos:8
 
+RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:8
 
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:8
 
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM centos:8
 
+RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:8
 
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:8
 
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM centos:8
 
+RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:8
 
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:8
 
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM centos:8
 
+RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:8
 
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/debian-bullseye-all/make_pg_buildext_parallel.patch
+++ b/dockerfiles/debian-bullseye-all/make_pg_buildext_parallel.patch
@@ -1,6 +1,6 @@
---- /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-+++ /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
-@@ -83,11 +83,13 @@
+--- /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
++++ /usr/bin/pg_buildext	2023-03-01 12:51:34.000000000 +0300
+@@ -107,11 +107,13 @@ substvars() {
  install() {
      prepare_env $1
      package=`echo $opt | sed -e "s:%v:$1:g"`
@@ -12,6 +12,6 @@
      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
 -    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
 +    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
+     substvars "$1" "$package"
  }
  
- clean() {

--- a/dockerfiles/debian-buster-all/make_pg_buildext_parallel.patch
+++ b/dockerfiles/debian-buster-all/make_pg_buildext_parallel.patch
@@ -1,6 +1,6 @@
---- /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-+++ /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
-@@ -83,11 +83,13 @@
+--- /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
++++ /usr/bin/pg_buildext	2023-03-01 12:51:34.000000000 +0300
+@@ -107,11 +107,13 @@ substvars() {
  install() {
      prepare_env $1
      package=`echo $opt | sed -e "s:%v:$1:g"`
@@ -12,6 +12,6 @@
      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
 -    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
 +    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
+     substvars "$1" "$package"
  }
  
- clean() {

--- a/dockerfiles/debian-stretch-all/make_pg_buildext_parallel.patch
+++ b/dockerfiles/debian-stretch-all/make_pg_buildext_parallel.patch
@@ -1,6 +1,6 @@
---- /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-+++ /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
-@@ -83,11 +83,13 @@
+--- /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
++++ /usr/bin/pg_buildext	2023-03-01 12:51:34.000000000 +0300
+@@ -107,11 +107,13 @@ substvars() {
  install() {
      prepare_env $1
      package=`echo $opt | sed -e "s:%v:$1:g"`
@@ -12,6 +12,6 @@
      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
 -    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
 +    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
+     substvars "$1" "$package"
  }
  
- clean() {

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:6
 
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:6
 
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
 
+RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:6
 
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:6
 
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
 
+RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:6
 
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:6
 
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
 
+RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:6
 
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:6
 
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
 
+RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:7
 
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
 
+RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:7
 
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:7
 
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
 
+RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:7
 
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:7
 
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
 
+RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:7
 
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:7
 
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
 
+RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:7
 
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:7
 
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
 
+RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:7
 
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
 
+RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:8
 
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:8
 
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
 
+RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:8
 
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:8
 
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
 
+RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:8
 
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:8
 
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
 
+RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:8
 
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:8
 
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
 
+RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:8
 
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:8
 
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/dockerfiles/pgxn-all/scripts/fetch_and_build_pgxn
+++ b/dockerfiles/pgxn-all/scripts/fetch_and_build_pgxn
@@ -44,7 +44,6 @@ source /buildfiles/pkgvars
 # set default values for certain packaging variables
 declare pkglatest # to make shellcheck happy
 hubproj="${hubproj:-${pkgname}}"
-nightlypg="${nightlypg:-${releasepg}}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2

--- a/dockerfiles/ubuntu-bionic-all/make_pg_buildext_parallel.patch
+++ b/dockerfiles/ubuntu-bionic-all/make_pg_buildext_parallel.patch
@@ -1,6 +1,6 @@
---- /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-+++ /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
-@@ -83,11 +83,13 @@
+--- /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
++++ /usr/bin/pg_buildext	2023-03-01 12:51:34.000000000 +0300
+@@ -107,11 +107,13 @@ substvars() {
  install() {
      prepare_env $1
      package=`echo $opt | sed -e "s:%v:$1:g"`
@@ -12,6 +12,6 @@
      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
 -    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
 +    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
+     substvars "$1" "$package"
  }
  
- clean() {

--- a/dockerfiles/ubuntu-focal-all/make_pg_buildext_parallel.patch
+++ b/dockerfiles/ubuntu-focal-all/make_pg_buildext_parallel.patch
@@ -1,6 +1,6 @@
---- /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-+++ /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
-@@ -83,11 +83,13 @@
+--- /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
++++ /usr/bin/pg_buildext	2023-03-01 12:51:34.000000000 +0300
+@@ -107,11 +107,13 @@ substvars() {
  install() {
      prepare_env $1
      package=`echo $opt | sed -e "s:%v:$1:g"`
@@ -12,6 +12,6 @@
      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
 -    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
 +    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
+     substvars "$1" "$package"
  }
  
- clean() {

--- a/make_pg_buildext_parallel.patch
+++ b/make_pg_buildext_parallel.patch
@@ -1,6 +1,6 @@
---- /usr/bin/pg_buildext	2018-12-16 10:56:59.000000000 +0000
-+++ /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
-@@ -83,11 +83,13 @@
+--- /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
++++ /usr/bin/pg_buildext	2023-03-01 12:51:34.000000000 +0300
+@@ -107,11 +107,13 @@ substvars() {
  install() {
      prepare_env $1
      package=`echo $opt | sed -e "s:%v:$1:g"`
@@ -12,6 +12,6 @@
      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
 -    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
 +    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
+     substvars "$1" "$package"
  }
  
- clean() {

--- a/scripts/fetch_and_build_pgxn
+++ b/scripts/fetch_and_build_pgxn
@@ -44,7 +44,6 @@ source /buildfiles/pkgvars
 # set default values for certain packaging variables
 declare pkglatest # to make shellcheck happy
 hubproj="${hubproj:-${pkgname}}"
-nightlypg="${nightlypg:-${releasepg}}"
 
 if [ -z "${pkglatest}" ]; then
     echo "$0: pkgvars file must specify a value for pkglatest" >&2

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -1,6 +1,11 @@
 # vim:set ft=dockerfile:
 FROM %%os%%:%%release%%
 
+RUN [[ %%os%% != centos ]] || [[ %%release%% != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    )
+
 RUN yum -y update
 
 # FIXME: Hack around docker/docker#10180

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -3,7 +3,7 @@ FROM %%os%%:%%release%%
 
 RUN [[ %%os%% != centos ]] || [[ %%release%% != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -3,7 +3,7 @@ FROM %%os%%:%%release%%
 
 RUN [[ %%os%% != centos ]] || [[ %%release%% != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update


### PR DESCRIPTION
While working on beta support for packages, I found out that docker build for ubuntu focal failed at the line below
https://github.com/citusdata/packaging/blob/351dd53fc1fd33f00af07e1b3af1e836914754f8/dockerfiles/ubuntu-focal-all/Dockerfile#L89
Additionally, centos repository mirrors were not working and I changed it with vault.epel.cloud
Removes nightlypg param from pgxn image which causes error after removal of releasepg and nightlypg parameters from pkgvars of pgxn
https://github.com/citusdata/packaging/blob/pgxn-citus/pkgvars