### PR TITLE
Adds columnar files into installed_files list

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -1,0 +1,73 @@
+name: Build and publish citus community nightly packages
+
+env:
+  PACKAGE_CLOUD_REPO_NAME: "citusdata/community-nightlies"
+  PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
+  PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
+  PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  DOCKERHUB_USER_NAME: ${{ secrets.DOCKERHUB_USER_NAME }}
+  DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+on:
+  push:
+    branches:
+      - "**"
+  workflow_dispatch:
+
+jobs:
+  build_package:
+    name: Build package
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - el/7
+          - el/8
+          - ol/7
+          - debian/stretch
+          - debian/buster
+          - debian/bullseye
+          - ubuntu/bionic
+          - ubuntu/focal
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # This step is to fetch the images unanonymously to have higher bandwidth
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER_NAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Clone tools branch
+        run: git clone -b v0.8.9 --depth=1  https://github.com/citusdata/tools.git tools
+
+      - name: Install package dependencies
+        run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources
+
+      - name: Install python requirements
+        run: python -m pip install -r tools/packaging_automation/requirements.txt
+
+      - name: Build packages
+        run: |
+          python -m  tools.packaging_automation.citus_package \
+          --gh_token "${GH_TOKEN}" \
+          --platform "${{ matrix.platform }}" \
+          --build_type "nightly" \
+          --secret_key "${PACKAGING_SECRET_KEY}" \
+          --passphrase "${PACKAGING_PASSPHRASE}" \
+          --output_dir "$(pwd)/packages/" \
+          --input_files_dir "$(pwd)"
+
+      - name: Publish packages
+        run: |
+          python -m  tools.packaging_automation.upload_to_package_cloud \
+          --platform "${{ matrix.platform }}" \
+          --package_cloud_api_token "${PACKAGE_CLOUD_API_TOKEN}" \
+          --repository_name "${PACKAGE_CLOUD_REPO_NAME}" \
+          --output_file_path "$(pwd)/packages" \
+          --current_branch "${GITHUB_REF##*/}" \
+          --main_branch "develop"

--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -43,7 +43,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.9 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.9 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build packages
         run: |
-          python -m  tools.packaging_automation.citus_package \
+          python -m tools.packaging_automation.citus_package \
           --gh_token "${GH_TOKEN}" \
           --platform "${{ matrix.platform }}" \
           --build_type "nightly" \
@@ -64,7 +64,7 @@ jobs:
 
       - name: Publish packages
         run: |
-          python -m  tools.packaging_automation.upload_to_package_cloud \
+          python -m tools.packaging_automation.upload_to_package_cloud \
           --platform "${{ matrix.platform }}" \
           --package_cloud_api_token "${PACKAGE_CLOUD_API_TOKEN}" \
           --repository_name "${PACKAGE_CLOUD_REPO_NAME}" \

--- a/citus.spec
+++ b/citus.spec
@@ -46,7 +46,7 @@ make %{?_smp_mflags}
 %{__cp} README.md %{buildroot}%{pginstdir}/doc/extension/README-%{sname}.md
 %{__cp} NOTICE %{buildroot}%{pginstdir}/doc/extension/NOTICE-%{sname}
 
-# Set paths to be packaged for citus  other than LICENSE, README & CHANGELOG.md
+# Set paths to be packaged other than LICENSE, README & CHANGELOG.md
 echo %{pginstdir}/include/server/citus_*.h >> installation_files.list
 echo %{pginstdir}/include/server/distributed/*.h >> installation_files.list
 echo %{pginstdir}/lib/%{sname}.so >> installation_files.list
@@ -69,9 +69,11 @@ echo %{pginstdir}/share/extension/%{sname}.control >> installation_files.list
     # Columnar files moved into its own directory like a seperate extension. Lines below adds these files into
     # package file list
     [[ -f %{buildroot}%{pginstdir}/lib/%{sname_columnar}.so ]] && echo %{pginstdir}/lib/%{sname_columnar}.so >> installation_files.list
-    [[ -d %{buildroot}%{pginstdir}/lib/bitcode/%{sname_columnar}/ ]] && echo %{pginstdir}/lib/bitcode/%{sname_columnar}/*.bc >> installation_files.list
-    [[ -d %{buildroot}%{pginstdir}/lib/bitcode/%{sname_columnar}/ ]] && echo %{pginstdir}/lib/bitcode/%{sname_columnar}*.bc >> installation_files.list
-    [[ -d %{buildroot}%{pginstdir}/lib/bitcode/%{sname_columnar}/ ]] && echo %{pginstdir}/lib/bitcode/%{sname_columnar}/*/*.bc >> installation_files.list
+    if [  -d %{buildroot}%{pginstdir}/lib/bitcode/%{sname_columnar}/ ]; then
+        echo %{pginstdir}/lib/bitcode/%{sname_columnar}/*.bc >> installation_files.list
+        echo %{pginstdir}/lib/bitcode/%{sname_columnar}*.bc >> installation_files.list
+        echo %{pginstdir}/lib/bitcode/%{sname_columnar}/*/*.bc >> installation_files.list
+    fi
   %endif
 %endif
 

--- a/citus.spec
+++ b/citus.spec
@@ -66,8 +66,8 @@ echo %{pginstdir}/share/extension/%{sname}.control >> installation_files.list
     # At this point, we don't have %{pginstdir},
     # so first check build directory for columnar.
     [[ -d %{buildroot}%{pginstdir}/lib/bitcode/columnar/ ]] && echo %{pginstdir}/lib/bitcode/columnar/*.bc >> installation_files.list
-    # Columnar files moved into its own directory like a seperate extension. Lines below adds these files into
-    # package file list
+    # Columnar files are installed into a different directory as a separate extension.
+    # Lines below add these files into package file list.
     [[ -f %{buildroot}%{pginstdir}/lib/%{sname_columnar}.so ]] && echo %{pginstdir}/lib/%{sname_columnar}.so >> installation_files.list
     if [  -d %{buildroot}%{pginstdir}/lib/bitcode/%{sname_columnar}/ ]; then
         echo %{pginstdir}/lib/bitcode/%{sname_columnar}/*.bc >> installation_files.list

--- a/citus.spec
+++ b/citus.spec
@@ -68,7 +68,7 @@ echo %{pginstdir}/share/extension/%{sname}.control >> installation_files.list
     [[ -d %{buildroot}%{pginstdir}/lib/bitcode/columnar/ ]] && echo %{pginstdir}/lib/bitcode/columnar/*.bc >> installation_files.list
     # Columnar files moved into its own directory like a seperate extension. Lines below adds these files into
     # package file list
-    [[ -f %{buildroot}%{pginstdir}/lib/%{sname_columnar}.so  ]] && echo %{pginstdir}/lib/%{sname_columnar}.so >> installation_files.list
+    [[ -f %{buildroot}%{pginstdir}/lib/%{sname_columnar}.so ]] && echo %{pginstdir}/lib/%{sname_columnar}.so >> installation_files.list
     [[ -d %{buildroot}%{pginstdir}/lib/bitcode/%{sname_columnar}/ ]] && echo %{pginstdir}/lib/bitcode/%{sname_columnar}/*.bc >> installation_files.list
     [[ -d %{buildroot}%{pginstdir}/lib/bitcode/%{sname_columnar}/ ]] && echo %{pginstdir}/lib/bitcode/%{sname_columnar}*.bc >> installation_files.list
     [[ -d %{buildroot}%{pginstdir}/lib/bitcode/%{sname_columnar}/ ]] && echo %{pginstdir}/lib/bitcode/%{sname_columnar}/*/*.bc >> installation_files.list

--- a/citus.spec
+++ b/citus.spec
@@ -2,6 +2,7 @@
 %global pgpackageversion 11
 %global pginstdir /usr/pgsql-%{pgpackageversion}
 %global sname citus
+%global sname_columnar citus_columnar
 
 Summary:	PostgreSQL-based distributed RDBMS
 Name:		%{sname}%{?pkginfix}_%{pgmajorversion}
@@ -45,24 +46,32 @@ make %{?_smp_mflags}
 %{__cp} README.md %{buildroot}%{pginstdir}/doc/extension/README-%{sname}.md
 %{__cp} NOTICE %{buildroot}%{pginstdir}/doc/extension/NOTICE-%{sname}
 
-# Set paths to be packaged other than LICENSE, README & CHANGELOG.md
+# Set paths to be packaged for citus  other than LICENSE, README & CHANGELOG.md
 echo %{pginstdir}/include/server/citus_*.h >> installation_files.list
 echo %{pginstdir}/include/server/distributed/*.h >> installation_files.list
 echo %{pginstdir}/lib/%{sname}.so >> installation_files.list
 echo %{pginstdir}/share/extension/%{sname}-*.sql >> installation_files.list
 echo %{pginstdir}/share/extension/%{sname}.control >> installation_files.list
+
 %ifarch ppc64 ppc64le
   %else
   %if 0%{?rhel} && 0%{?rhel} <= 6
   %else
+    # citus file paths to be added into package
     echo %{pginstdir}/lib/bitcode/%{sname}/*.bc >> installation_files.list
     echo %{pginstdir}/lib/bitcode/%{sname}*.bc >> installation_files.list
     echo %{pginstdir}/lib/bitcode/%{sname}/*/*.bc >> installation_files.list
-    
+
     # Columnar does not exist in Citus versions < 10.0
     # At this point, we don't have %{pginstdir},
     # so first check build directory for columnar.
     [[ -d %{buildroot}%{pginstdir}/lib/bitcode/columnar/ ]] && echo %{pginstdir}/lib/bitcode/columnar/*.bc >> installation_files.list
+    # Columnar files moved into its own directory like a seperate extension. Lines below adds these files into
+    # package file list
+    [[ -f %{buildroot}%{pginstdir}/lib/%{sname_columnar}.so  ]] && echo %{pginstdir}/lib/%{sname_columnar}.so >> installation_files.list
+    [[ -d %{buildroot}%{pginstdir}/lib/bitcode/%{sname_columnar}/ ]] && echo %{pginstdir}/lib/bitcode/%{sname_columnar}/*.bc >> installation_files.list
+    [[ -d %{buildroot}%{pginstdir}/lib/bitcode/%{sname_columnar}/ ]] && echo %{pginstdir}/lib/bitcode/%{sname_columnar}*.bc >> installation_files.list
+    [[ -d %{buildroot}%{pginstdir}/lib/bitcode/%{sname_columnar}/ ]] && echo %{pginstdir}/lib/bitcode/%{sname_columnar}/*/*.bc >> installation_files.list
   %endif
 %endif
 


### PR DESCRIPTION
columnar files has been moved so nightlies has been failed for rpm based systems. I added these files in citus.spec to fix the problem. Sample failing nightly execution is as below
https://github.com/citusdata/packaging/actions/runs/1919787540
Additionally, to be able to test nightlies with regular builds together, I added nightly pipelines into all-citus. With this pipeline, we will be able to detect changes that may cause problems in nightlies .