### PR TITLE
Stop nightly builds

### DIFF
--- a/.github/workflows/build-citus-enterprise-nightlies.yml
+++ b/.github/workflows/build-citus-enterprise-nightlies.yml
@@ -8,9 +8,10 @@ env:
   DOCKERHUB_USER_NAME: ${{ secrets.DOCKERHUB_USER_NAME }}
   DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 on:
-  push:
-    branches:
-      - "**"
+  # TODO: revert this once we finish backports of security patches
+  # push:
+  #   branches:
+  #     - "**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Nightly packages will fail during backport releases to earlier versions of Citus. Hence, we want to disable them as discussed over chat, and https://github.com/citusdata/packaging/pull/915#issuecomment-1132837250 