### PR TITLE
Updates debian repository scripts based on updated packagecloud scripts

### DIFF
--- a/community/deb.sh
+++ b/community/deb.sh
@@ -97,7 +97,7 @@ pgdg_check ()
 
 install_debian_keyring ()
 {
-  if [ "${os}" = "debian" ]; then
+  if [ "${os,,}" = "debian" ]; then
     echo "Installing debian-archive-keyring which is needed for installing "
     echo "apt-transport-https on many Debian systems."
     apt-get install -y debian-archive-keyring &> /dev/null

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -155,6 +155,19 @@ detect_os ()
   echo "Detected operating system as $os/$dist."
 }
 
+detect_version_id () {
+  # detect version_id and round down float to integer
+  if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    version_id=${VERSION_ID%%.*}
+  elif [ -f /usr/lib/os-release ]; then
+    . /usr/lib/os-release
+    version_id=${VERSION_ID%%.*}
+  else
+    version_id="1"
+  fi
+}
+
 detect_codename ()
 {
   if [ "${os}" = "debian" ]; then
@@ -202,6 +215,7 @@ main ()
 {
   detect_os
   detect_codename
+  detect_version_id
 
   # Need to first run apt-get update so that apt-transport-https can be
   # installed
@@ -227,7 +241,11 @@ main ()
   apt_config_url="https://repos.citusdata.com/community/config_file.list?os=${os}&dist=${dist}&source=script"
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_community.list"
-  gpg_keyring_path="/usr/share/keyrings/citusdata_community-archive-keyring.gpg"
+  apt_keyrings_dir="/etc/apt/keyrings"
+  if [ ! -d "$apt_keyrings_dir" ]; then
+    mkdir -p "$apt_keyrings_dir"
+  fi
+  gpg_keyring_path="$apt_keyrings_dir/citusdata_community-archive-keyring.gpg"
 
   echo -n "Installing $apt_source_path... "
 

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -273,9 +273,24 @@ main ()
 
   echo -n "Importing Citus Data Community gpg key... "
   # import the gpg key
-  # below command decodes the ASCII armored gpg file (instead of binary file)
-  # and adds the unarmored gpg key as keyring
   curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
+  # grant 644 permisions to gpg keyring path
+  chmod 0644 "${gpg_keyring_path}"
+  # check for os/dist based on pre debian stretch
+  if
+  { [ "${os,,}" = "debian" ] && [ "${version_id}" -lt 9 ]; } ||
+  { [ "${os,,}" = "ubuntu" ] && [ "${version_id}" -lt 16 ]; } ||
+  { [ "${os,,}" = "linuxmint" ] && [ "${version_id}" -lt 19 ]; } ||
+  { [ "${os,,}" = "raspbian" ] && [ "${version_id}" -lt 9 ]; } ||
+  { { [ "${os,,}" = "elementaryos" ] || [ "${os,,}" = "elementary" ]; } && [ "${version_id}" -lt 5 ]; }
+  then
+    # move to trusted.gpg.d
+    mv ${gpg_keyring_path} /etc/apt/trusted.gpg.d/citusdata_community.gpg
+    # deletes the keyrings directory if it is empty
+    if ! ls -1qA $apt_keyrings_dir | grep -q .;then
+      rm -r $apt_keyrings_dir
+    fi
+  fi
   echo "done."
 
   echo -n "Running apt-get update... "


### PR DESCRIPTION
Packagecloud has updated its repo scripts and this updated broke our download operation. I reflect the changes fron packagecloud deb repo installation script into our de repo instalation script
Latest packagecloud installation script is as below
https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh 