### PR TITLE
Fixes repository scripts for enterprise enterprise nightlies and community nightlies

### DIFF
--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -305,7 +305,7 @@ main ()
   { { [ "${os,,}" = "elementaryos" ] || [ "${os,,}" = "elementary" ]; } && [ "${version_id}" -lt 5 ]; }
   then
     # move to trusted.gpg.d
-    mv ${gpg_keyring_path} /etc/apt/trusted.gpg.d/citusdata_community.gpg
+    mv ${gpg_keyring_path} /etc/apt/trusted.gpg.d/citusdata_${repo_name}.gpg
     # deletes the keyrings directory if it is empty
     if ! ls -1qA $apt_keyrings_dir | grep -q .;then
       rm -r $apt_keyrings_dir

--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -97,7 +97,7 @@ pgdg_check ()
 
 install_debian_keyring ()
 {
-  if [ "${os}" = "debian" ]; then
+  if [ "${os,,}" = "debian" ]; then
     echo "Installing debian-archive-keyring which is needed for installing "
     echo "apt-transport-https on many Debian systems."
     apt-get install -y debian-archive-keyring &> /dev/null
@@ -155,6 +155,19 @@ detect_os ()
   echo "Detected operating system as $os/$dist."
 }
 
+detect_version_id () {
+  # detect version_id and round down float to integer
+  if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    version_id=${VERSION_ID%%.*}
+  elif [ -f /usr/lib/os-release ]; then
+    . /usr/lib/os-release
+    version_id=${VERSION_ID%%.*}
+  else
+    version_id="1"
+  fi
+}
+
 detect_codename ()
 {
   if [ "${os}" = "debian" ]; then
@@ -202,6 +215,7 @@ main ()
 {
   detect_os
   detect_codename
+  detect_version_id
 
   # Need to first run apt-get update so that apt-transport-https can be
   # installed
@@ -222,12 +236,16 @@ main ()
   apt-get install -y apt-transport-https &> /dev/null
   echo "done."
 
+  repo_name="community-nightlies"
+  gpg_key_url="https://repos.citusdata.com/${repo_name}/gpgkey"
+  apt_config_url="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${dist}&source=script"
 
-  gpg_key_url="https://repos.citusdata.com/community-nightlies/gpgkey"
-  apt_config_url="https://repos.citusdata.com/community-nightlies/config_file.list?os=${os}&dist=${dist}&source=script"
-
-  apt_source_path="/etc/apt/sources.list.d/citusdata_community-nightlies.list"
-  gpg_keyring_path="/usr/share/keyrings/citusdata_community-nightlies-archive-keyring.gpg"
+  apt_source_path="/etc/apt/sources.list.d/citusdata_${repo_name}.list"
+  apt_keyrings_dir="/etc/apt/keyrings"
+  if [ ! -d "$apt_keyrings_dir" ]; then
+    mkdir -p "$apt_keyrings_dir"
+  fi
+  gpg_keyring_path="${apt_keyrings_dir}/citusdata_${repo_name}-archive-keyring.gpg"
 
   echo -n "Installing $apt_source_path... "
 
@@ -276,6 +294,23 @@ main ()
   # below command decodes the ASCII armored gpg file (instead of binary file)
   # and adds the unarmored gpg key as keyring
   curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
+  # grant 644 permisions to gpg keyring path
+  chmod 0644 "${gpg_keyring_path}"
+  # check for os/dist based on pre debian stretch
+  if
+  { [ "${os,,}" = "debian" ] && [ "${version_id}" -lt 9 ]; } ||
+  { [ "${os,,}" = "ubuntu" ] && [ "${version_id}" -lt 16 ]; } ||
+  { [ "${os,,}" = "linuxmint" ] && [ "${version_id}" -lt 19 ]; } ||
+  { [ "${os,,}" = "raspbian" ] && [ "${version_id}" -lt 9 ]; } ||
+  { { [ "${os,,}" = "elementaryos" ] || [ "${os,,}" = "elementary" ]; } && [ "${version_id}" -lt 5 ]; }
+  then
+    # move to trusted.gpg.d
+    mv ${gpg_keyring_path} /etc/apt/trusted.gpg.d/citusdata_community.gpg
+    # deletes the keyrings directory if it is empty
+    if ! ls -1qA $apt_keyrings_dir | grep -q .;then
+      rm -r $apt_keyrings_dir
+    fi
+  fi
   echo "done."
 
   echo -n "Running apt-get update... "

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -236,16 +236,16 @@ main ()
   apt-get install -y apt-transport-https &> /dev/null
   echo "done."
 
+  repo_name="community"
+  gpg_key_url="https://repos.citusdata.com/${repo_name}/gpgkey"
+  apt_config_url="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${dist}&source=script"
 
-  gpg_key_url="https://repos.citusdata.com/community/gpgkey"
-  apt_config_url="https://repos.citusdata.com/community/config_file.list?os=${os}&dist=${dist}&source=script"
-
-  apt_source_path="/etc/apt/sources.list.d/citusdata_community.list"
+  apt_source_path="/etc/apt/sources.list.d/citusdata_${repo_name}.list"
   apt_keyrings_dir="/etc/apt/keyrings"
   if [ ! -d "$apt_keyrings_dir" ]; then
     mkdir -p "$apt_keyrings_dir"
   fi
-  gpg_keyring_path="$apt_keyrings_dir/citusdata_community-archive-keyring.gpg"
+  gpg_keyring_path="${apt_keyrings_dir}/citusdata_${repo_name}-archive-keyring.gpg"
 
   echo -n "Installing $apt_source_path... "
 
@@ -291,6 +291,8 @@ main ()
 
   echo -n "Importing Citus Data Community gpg key... "
   # import the gpg key
+  # below command decodes the ASCII armored gpg file (instead of binary file)
+  # and adds the unarmored gpg key as keyring
   curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
   # grant 644 permisions to gpg keyring path
   chmod 0644 "${gpg_keyring_path}"

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -283,7 +283,7 @@ main ()
 
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
   gpg_key_install_url="https://repos.citusdata.com/enterprise-nightlies/gpg_key_url.list?os=${os}&dist=${dist}"
-  apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/enterprise-nightlies/config_file.list?os=${os}&dist=${dist}&name=${unique_id}&source=script
+  apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/enterprise-nightlies/config_file.list?os=${os}&dist=${dist}&name=${unique_id}&source=script"
 
   gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -283,7 +283,7 @@ main ()
 
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
   gpg_key_install_url="https://repos.citusdata.com/enterprise-nightlies/gpg_key_url.list?os=${os}&dist=${dist}"
-  apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/enterprise-nightlies/config_file.list?os=${os}&dist=${dist}&name=${unique_id}&source=script"
+  apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/enterprise-nightlies/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
 
   gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -299,7 +299,7 @@ main ()
   echo -n "Installing $apt_source_path... "
 
   # create an apt config file for this repository
-  curl -GsSf -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${apt_config_url}" > $apt_source_path
+  curl -sSf "${apt_config_url}" > $apt_source_path
   curl_exit_code=$?
 
   if [ "$curl_exit_code" = "22" ]; then

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -97,7 +97,7 @@ pgdg_check ()
 
 install_debian_keyring ()
 {
-  if [ "${os}" = "debian" ]; then
+  if [ "${os,,}" = "debian" ]; then
     echo "Installing debian-archive-keyring which is needed for installing "
     echo "apt-transport-https on many Debian systems."
     apt-get install -y debian-archive-keyring &> /dev/null
@@ -185,6 +185,19 @@ detect_os ()
   echo "Detected operating system as $os/$dist."
 }
 
+detect_version_id () {
+  # detect version_id and round down float to integer
+  if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    version_id=${VERSION_ID%%.*}
+  elif [ -f /usr/lib/os-release ]; then
+    . /usr/lib/os-release
+    version_id=${VERSION_ID%%.*}
+  else
+    version_id="1"
+  fi
+}
+
 detect_codename ()
 {
   if [ "${os}" = "debian" ]; then
@@ -232,6 +245,7 @@ main ()
 {
   detect_os
   detect_codename
+  detect_version_id
 
   # Need to first run apt-get update so that apt-transport-https can be
   # installed
@@ -279,8 +293,9 @@ main ()
   fi
 
 
-  apt_source_path="/etc/apt/sources.list.d/citusdata_enterprise.list"
-  gpg_keyring_path="/usr/share/keyrings/citusdata_enterprise-archive-keyring.gpg"
+  repo_name="enterprise"
+  gpg_key_url="https://repos.citusdata.com/${repo_name}/gpgkey"
+  apt_config_url="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${dist}&source=script"
 
   echo -n "Installing $apt_source_path... "
 
@@ -329,6 +344,23 @@ main ()
   # below command decodes the ASCII armored gpg file (instead of binary file)
   # and adds the unarmored gpg key as keyring
   curl -fsSL "${gpg_key_url}" | gpg --dearmor > ${gpg_keyring_path}
+  # grant 644 permisions to gpg keyring path
+  chmod 0644 "${gpg_keyring_path}"
+  # check for os/dist based on pre debian stretch
+  if
+  { [ "${os,,}" = "debian" ] && [ "${version_id}" -lt 9 ]; } ||
+  { [ "${os,,}" = "ubuntu" ] && [ "${version_id}" -lt 16 ]; } ||
+  { [ "${os,,}" = "linuxmint" ] && [ "${version_id}" -lt 19 ]; } ||
+  { [ "${os,,}" = "raspbian" ] && [ "${version_id}" -lt 9 ]; } ||
+  { { [ "${os,,}" = "elementaryos" ] || [ "${os,,}" = "elementary" ]; } && [ "${version_id}" -lt 5 ]; }
+  then
+    # move to trusted.gpg.d
+    mv ${gpg_keyring_path} /etc/apt/trusted.gpg.d/citusdata_community.gpg
+    # deletes the keyrings directory if it is empty
+    if ! ls -1qA $apt_keyrings_dir | grep -q .;then
+      rm -r $apt_keyrings_dir
+    fi
+  fi
   echo "done."
 
   echo -n "Running apt-get update... "

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -282,8 +282,8 @@ main ()
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
-  gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
-  apt_config_url="https://repos.citusdata.com/enterprise/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+  gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}"
+  apt_config_url="https://repos.citusdata.com/enterprise/config_file.list?os=${os}&dist=${dist}&source=script"
 
   gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -284,7 +284,7 @@ main ()
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
   gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
 
-  apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/enterprise/config_file.list?os=${os}&dist=${dist}&name=${unique_id}&source=script"
+  apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/enterprise/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
 
   gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -282,8 +282,8 @@ main ()
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
-  gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}"
-  apt_config_url="https://repos.citusdata.com/enterprise/config_file.list?os=${os}&dist=${dist}&source=script"
+  gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}&name=${unique_id}"
+  apt_config_url="https://repos.citusdata.com/enterprise/config_file.list?os=${os}&dist=${dist}&name=${unique_id}&source=script"
 
   gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -293,14 +293,17 @@ main ()
   fi
 
 
-  repo_name="enterprise"
-  gpg_key_url="https://repos.citusdata.com/${repo_name}/gpgkey"
-  apt_config_url="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${dist}&source=script"
+  apt_source_path="/etc/apt/sources.list.d/citusdata_enterprise.list"
+  apt_keyrings_dir="/etc/apt/keyrings"
+  if [ ! -d "$apt_keyrings_dir" ]; then
+    mkdir -p "$apt_keyrings_dir"
+  fi
+  gpg_keyring_path="$apt_keyrings_dir/citusdata_enterprise-archive-keyring.gpg"
 
-  echo -n "Installing $apt_source_path... "
+  echo -n "Installing $apt_source_path..."
 
   # create an apt config file for this repository
-  curl -GsSf -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${apt_config_url}" > $apt_source_path
+  curl -sSf "${apt_config_url}" > $apt_source_path
   curl_exit_code=$?
 
   if [ "$curl_exit_code" = "22" ]; then
@@ -355,7 +358,7 @@ main ()
   { { [ "${os,,}" = "elementaryos" ] || [ "${os,,}" = "elementary" ]; } && [ "${version_id}" -lt 5 ]; }
   then
     # move to trusted.gpg.d
-    mv ${gpg_keyring_path} /etc/apt/trusted.gpg.d/citusdata_community.gpg
+    mv ${gpg_keyring_path} /etc/apt/trusted.gpg.d/citusdata_enterprise.gpg
     # deletes the keyrings directory if it is empty
     if ! ls -1qA $apt_keyrings_dir | grep -q .;then
       rm -r $apt_keyrings_dir

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -282,8 +282,9 @@ main ()
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
-  gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}"
-  apt_config_url="https://repos.citusdata.com/enterprise/config_file.list?os=${os}&dist=${dist}&source=script"
+  gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
+
+  apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/enterprise/config_file.list?os=${os}&dist=${dist}&name=${unique_id}&source=script"
 
   gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -282,8 +282,8 @@ main ()
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
-  gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}&name=${unique_id}"
-  apt_config_url="https://repos.citusdata.com/enterprise/config_file.list?os=${os}&dist=${dist}&name=${unique_id}&source=script"
+  gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
+  apt_config_url="https://repos.citusdata.com/enterprise/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
 
   gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then


### PR DESCRIPTION
This PR fixes enterprise, enterprise nightly and community-nightly repository script problems. Recently, Packagecloud changes repository scripts which broke our scripts as well.

Community-nightly is like community script and it has now work arounds. But for enterprise and enterprise-communities scripts has workarounds in apt_config_url set since there is a new parameter 'name' which is "CITUS_REPO_HOST_ID"
This parameter does not work with the repo.citusdata.com URI. When I set this, I got 404 error.
 There need to be some kind of configuration for the new parameter in somewhere in citusdata.com reverse proxy

Test:
curl https://raw.githubusercontent.com/citusdata/packaging/deb_fix_other/community-nightlies/deb.sh | sudo bash
curl https://raw.githubusercontent.com/citusdata/packaging/deb_fix_other/enterprise-nightlies/deb.sh | sudo CITUS_REPO_TOKEN='token' bash
curl https://raw.githubusercontent.com/citusdata/packaging/deb_fix_other/enterprise/deb.sh | sudo CITUS_REPO_TOKEN='token' bash
