### PR TITLE
Parameterizes default branch for repo

### DIFF
--- a/dockerfiles/centos-7-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg10/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/centos-7-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg11/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/centos-7-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg12/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/centos-7-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg13/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/centos-7-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg14/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/centos-8-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg10/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/centos-8-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg11/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/centos-8-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg12/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/centos-8-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg13/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/centos-8-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg14/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/debian-bullseye-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-bullseye-all/scripts/fetch_and_build_deb
@@ -24,7 +24,7 @@ usage: fetch_and_build_deb build_type
 
 fetch_and_build_deb builds Debian packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch, commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,11 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
 versioning="${versioning:-simple}"
 if [[ "${pkglatest}" == *"beta"* ]]; then
     release_type="beta"
@@ -89,7 +93,7 @@ export EMAIL
 EMAIL=$(determine_email)
 
 cp -R /buildfiles/debian "${builddir}"
-repopath="citusdata/${hubproj}"
+
 
 case "${1}" in
     release)
@@ -118,6 +122,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/debian-buster-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-buster-all/scripts/fetch_and_build_deb
@@ -24,7 +24,7 @@ usage: fetch_and_build_deb build_type
 
 fetch_and_build_deb builds Debian packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch, commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,11 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
 versioning="${versioning:-simple}"
 if [[ "${pkglatest}" == *"beta"* ]]; then
     release_type="beta"
@@ -89,7 +93,7 @@ export EMAIL
 EMAIL=$(determine_email)
 
 cp -R /buildfiles/debian "${builddir}"
-repopath="citusdata/${hubproj}"
+
 
 case "${1}" in
     release)
@@ -118,6 +122,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/debian-stretch-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-stretch-all/scripts/fetch_and_build_deb
@@ -24,7 +24,7 @@ usage: fetch_and_build_deb build_type
 
 fetch_and_build_deb builds Debian packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch, commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,11 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
 versioning="${versioning:-simple}"
 if [[ "${pkglatest}" == *"beta"* ]]; then
     release_type="beta"
@@ -89,7 +93,7 @@ export EMAIL
 EMAIL=$(determine_email)
 
 cp -R /buildfiles/debian "${builddir}"
-repopath="citusdata/${hubproj}"
+
 
 case "${1}" in
     release)
@@ -118,6 +122,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-6-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg10/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-6-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg11/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-6-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg12/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-6-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg14/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-7-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg10/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-7-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg11/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-7-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg12/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-7-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg13/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-7-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg14/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-8-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg10/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-8-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg11/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-8-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg12/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-8-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg13/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/oraclelinux-8-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg14/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/ubuntu-bionic-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-bionic-all/scripts/fetch_and_build_deb
@@ -24,7 +24,7 @@ usage: fetch_and_build_deb build_type
 
 fetch_and_build_deb builds Debian packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch, commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,11 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
 versioning="${versioning:-simple}"
 if [[ "${pkglatest}" == *"beta"* ]]; then
     release_type="beta"
@@ -89,7 +93,7 @@ export EMAIL
 EMAIL=$(determine_email)
 
 cp -R /buildfiles/debian "${builddir}"
-repopath="citusdata/${hubproj}"
+
 
 case "${1}" in
     release)
@@ -118,6 +122,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/dockerfiles/ubuntu-focal-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-focal-all/scripts/fetch_and_build_deb
@@ -24,7 +24,7 @@ usage: fetch_and_build_deb build_type
 
 fetch_and_build_deb builds Debian packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch, commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,11 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
 versioning="${versioning:-simple}"
 if [[ "${pkglatest}" == *"beta"* ]]; then
     release_type="beta"
@@ -89,7 +93,7 @@ export EMAIL
 EMAIL=$(determine_email)
 
 cp -R /buildfiles/debian "${builddir}"
-repopath="citusdata/${hubproj}"
+
 
 case "${1}" in
     release)
@@ -118,6 +122,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -24,7 +24,7 @@ usage: fetch_and_build_deb build_type
 
 fetch_and_build_deb builds Debian packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch, commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,11 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
 versioning="${versioning:-simple}"
 if [[ "${pkglatest}" == *"beta"* ]]; then
     release_type="beta"
@@ -89,7 +93,7 @@ export EMAIL
 EMAIL=$(determine_email)
 
 cp -R /buildfiles/debian "${builddir}"
-repopath="citusdata/${hubproj}"
+
 
 case "${1}" in
     release)
@@ -118,6 +122,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'

--- a/scripts/fetch_and_build_rpm
+++ b/scripts/fetch_and_build_rpm
@@ -24,7 +24,7 @@ usage: fetch_and_build_rpm build_type build_directory
 
 fetch_and_build_rpm builds Red Hat packages using local build files. The build
 type 'release' builds the latest release tag, 'nightly' builds a nightly from
-the latest 'master' commit, and any other type is interpreted as a git ref to
+the latest on default branch commit, and any other type is interpreted as a git ref to
 facilitate building one-off packages for customers.
 E_O_USAGE
 
@@ -58,7 +58,12 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${rpm_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
-nightlyref="${nightlyref:-master}"
+
+repopath="citusdata/${hubproj}"
+default_branch=$(curl -s "https://api.github.com/repos/${repopath}" | \
+                 jq -r '.object.sha')
+nightlyref="${nightlyref:-${default_branch}}"
+
 releasepg="${releasepg:-11,12,13}"
 nightlypg="${nightlypg:-${releasepg}}"
 versioning="${versioning:-simple}"
@@ -80,7 +85,6 @@ email=$(determine_email)
 export RPM_PACKAGER="${name} <${email}>"
 
 cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
-repopath="citusdata/${hubproj}"
 
 case "${1}" in
     release)
@@ -115,6 +119,7 @@ case "${1}" in
         if [ "${1}" == 'nightly' ]; then
             ref=${nightlyref}
             infix='git'
+            echo "Nightly build is using the branch ${ref}"
         else
             ref=${1}
             infix='pre'


### PR DESCRIPTION
Pgaf nightlies are failing since there is a problem with one pyahton library in deb docker images. I will fix afterwards. Let us not block this PR with this problem already on production as following
https://github.com/citusdata/packaging/actions/runs/2539434832