### PR TITLE
Adds pgazure nightly support

### DIFF
--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -1,0 +1,81 @@
+name: Build and publish citus community nightly packages
+
+env:
+  MAIN_BRANCH: "all-pg-azure-storage"
+  PACKAGE_CLOUD_REPO_NAME: "citusdata/community-nightlies"
+  PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
+  PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
+  PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  DOCKERHUB_USER_NAME: ${{ secrets.DOCKERHUB_USER_NAME }}
+  DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+on:
+  push:
+    branches:
+      - "**"
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  build_package:
+    name: Build package
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - el/7
+          - el/8
+# temporarily removed from nightlies since pg15 beta is not being downloaded for ol/7
+# - ol/7
+# Haven't worked on deb support for pgazure. Will enable below block after deb support is added
+#          - debian/stretch
+#          - debian/buster
+#          - debian/bullseye
+#          - ubuntu/bionic
+#          - ubuntu/focal
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # This step is to fetch the images unanonymously to have higher bandwidth
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER_NAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Clone tools branch
+        run: git clone -b v0.8.17 --depth=1  https://github.com/citusdata/tools.git tools
+
+      - name: Clone build branch
+        run: git clone -b "${MAIN_BRANCH}" --depth=1  https://github.com/citusdata/packaging.git packaging
+
+      - name: Install package dependencies
+        run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources
+
+      - name: Install python requirements
+        run: python -m pip install -r tools/packaging_automation/requirements.txt
+
+      - name: Build packages
+        run: |
+          python -m  tools.packaging_automation.citus_package \
+          --gh_token "${GH_TOKEN}" \
+          --platform "${{ matrix.platform }}" \
+          --build_type "nightly" \
+          --secret_key "${PACKAGING_SECRET_KEY}" \
+          --passphrase "${PACKAGING_PASSPHRASE}" \
+          --output_dir "$(pwd)/packages/" \
+          --input_files_dir "$(pwd)/packaging"
+
+      - name: Publish packages
+        run: |
+          python -m  tools.packaging_automation.upload_to_package_cloud \
+          --platform "${{ matrix.platform }}" \
+          --package_cloud_api_token "${PACKAGE_CLOUD_API_TOKEN}" \
+          --repository_name "${PACKAGE_CLOUD_REPO_NAME}" \
+          --output_file_path "$(pwd)/packages" \
+          --current_branch "${GITHUB_REF##*/}" \
+          --main_branch "develop"

--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -1,4 +1,4 @@
-name: Build and publish citus community nightly packages
+name: Build and publish pgazure nightly packages
 
 env:
   MAIN_BRANCH: "all-pg-azure-storage"


### PR DESCRIPTION
Marlin team needs nightlies to be able to test pgazure. With this PR we will start to create el/7 and el/8 nightly packages
You can check the packaging configuration for pg_azure, you can check this PR. 
https://github.com/citusdata/packaging/pull/961
Now checks fail, since there is no release version yet. Therefore I put an nonexistent version to be able to build nightlies