### PR TITLE
Add support for building repos with git submodules

### DIFF
--- a/dockerfiles/centos-7-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg10/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/centos-7-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg10/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/centos-7-pg10/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg10/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/centos-7-pg10/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg10/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/centos-7-pg10/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg10/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/centos-7-pg10/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg10/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/centos-7-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg11/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/centos-7-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg11/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/centos-7-pg11/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg11/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/centos-7-pg11/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg11/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/centos-7-pg11/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg11/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/centos-7-pg11/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg11/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/centos-7-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg12/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/centos-7-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg12/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/centos-7-pg12/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg12/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/centos-7-pg12/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg12/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/centos-7-pg12/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg12/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/centos-7-pg12/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg12/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/centos-7-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg13/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/centos-7-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg13/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/centos-7-pg13/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg13/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/centos-7-pg13/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg13/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/centos-7-pg13/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg13/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/centos-7-pg13/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg13/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/centos-7-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg14/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/centos-7-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg14/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/centos-7-pg14/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg14/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/centos-7-pg14/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg14/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/centos-7-pg14/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg14/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/centos-7-pg14/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg14/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/centos-7-pg15/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg15/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/centos-7-pg15/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-7-pg15/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/centos-7-pg15/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg15/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/centos-7-pg15/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg15/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/centos-7-pg15/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg15/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/centos-7-pg15/scripts/setup_submodules
+++ b/dockerfiles/centos-7-pg15/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/centos-8-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg10/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/centos-8-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg10/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/centos-8-pg10/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg10/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/centos-8-pg10/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg10/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/centos-8-pg10/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg10/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/centos-8-pg10/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg10/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/centos-8-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg11/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/centos-8-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg11/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/centos-8-pg11/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg11/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/centos-8-pg11/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg11/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/centos-8-pg11/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg11/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/centos-8-pg11/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg11/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/centos-8-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg12/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/centos-8-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg12/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/centos-8-pg12/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg12/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/centos-8-pg12/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg12/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/centos-8-pg12/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg12/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/centos-8-pg12/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg12/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/centos-8-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg13/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/centos-8-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg13/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/centos-8-pg13/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg13/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/centos-8-pg13/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg13/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/centos-8-pg13/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg13/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/centos-8-pg13/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg13/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/centos-8-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg14/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/centos-8-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg14/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/centos-8-pg14/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg14/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/centos-8-pg14/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg14/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/centos-8-pg14/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg14/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/centos-8-pg14/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg14/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/centos-8-pg15/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg15/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/centos-8-pg15/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-8-pg15/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/centos-8-pg15/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg15/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/centos-8-pg15/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg15/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/centos-8-pg15/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg15/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/centos-8-pg15/scripts/setup_submodules
+++ b/dockerfiles/centos-8-pg15/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/debian-bullseye-all/scripts/setup_submodules
+++ b/dockerfiles/debian-bullseye-all/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/debian-bullseye-all/scripts/setup_submodules
+++ b/dockerfiles/debian-bullseye-all/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/debian-bullseye-all/scripts/setup_submodules
+++ b/dockerfiles/debian-bullseye-all/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/debian-bullseye-all/scripts/setup_submodules
+++ b/dockerfiles/debian-bullseye-all/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/debian-buster-all/scripts/setup_submodules
+++ b/dockerfiles/debian-buster-all/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/debian-buster-all/scripts/setup_submodules
+++ b/dockerfiles/debian-buster-all/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/debian-buster-all/scripts/setup_submodules
+++ b/dockerfiles/debian-buster-all/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/debian-buster-all/scripts/setup_submodules
+++ b/dockerfiles/debian-buster-all/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/debian-stretch-all/scripts/setup_submodules
+++ b/dockerfiles/debian-stretch-all/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/debian-stretch-all/scripts/setup_submodules
+++ b/dockerfiles/debian-stretch-all/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/debian-stretch-all/scripts/setup_submodules
+++ b/dockerfiles/debian-stretch-all/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/debian-stretch-all/scripts/setup_submodules
+++ b/dockerfiles/debian-stretch-all/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-6-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg10/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-6-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg10/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-6-pg10/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg10/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-6-pg10/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg10/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-6-pg10/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg10/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-6-pg10/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg10/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-6-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg11/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-6-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg11/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-6-pg11/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg11/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-6-pg11/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg11/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-6-pg11/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg11/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-6-pg11/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg11/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-6-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg12/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-6-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg12/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-6-pg12/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg12/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-6-pg12/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg12/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-6-pg12/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg12/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-6-pg12/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg12/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-6-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg14/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-6-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg14/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-6-pg14/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg14/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-6-pg14/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg14/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-6-pg14/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg14/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-6-pg14/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg14/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-6-pg15/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg15/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-6-pg15/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-6-pg15/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-6-pg15/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg15/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-6-pg15/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg15/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-6-pg15/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg15/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-6-pg15/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-6-pg15/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-7-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg10/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-7-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg10/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-7-pg10/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg10/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-7-pg10/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg10/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-7-pg10/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg10/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-7-pg10/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg10/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-7-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg11/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-7-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg11/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-7-pg11/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg11/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-7-pg11/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg11/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-7-pg11/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg11/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-7-pg11/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg11/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-7-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg12/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-7-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg12/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-7-pg12/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg12/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-7-pg12/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg12/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-7-pg12/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg12/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-7-pg12/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg12/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-7-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg13/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-7-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg13/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-7-pg13/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg13/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-7-pg13/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg13/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-7-pg13/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg13/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-7-pg13/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg13/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-7-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg14/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-7-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg14/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-7-pg14/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg14/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-7-pg14/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg14/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-7-pg14/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg14/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-7-pg14/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg14/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-7-pg15/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg15/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-7-pg15/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-7-pg15/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-7-pg15/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg15/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-7-pg15/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg15/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-7-pg15/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg15/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-7-pg15/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-7-pg15/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-8-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg10/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-8-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg10/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-8-pg10/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg10/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-8-pg10/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg10/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-8-pg10/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg10/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-8-pg10/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg10/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-8-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg11/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-8-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg11/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-8-pg11/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg11/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-8-pg11/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg11/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-8-pg11/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg11/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-8-pg11/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg11/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-8-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg12/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-8-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg12/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-8-pg12/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg12/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-8-pg12/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg12/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-8-pg12/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg12/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-8-pg12/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg12/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-8-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg13/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-8-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg13/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-8-pg13/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg13/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-8-pg13/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg13/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-8-pg13/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg13/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-8-pg13/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg13/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-8-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg14/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-8-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg14/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-8-pg14/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg14/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-8-pg14/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg14/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-8-pg14/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg14/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-8-pg14/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg14/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/oraclelinux-8-pg15/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg15/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/dockerfiles/oraclelinux-8-pg15/scripts/fetch_and_build_rpm
+++ b/dockerfiles/oraclelinux-8-pg15/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/dockerfiles/oraclelinux-8-pg15/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg15/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/oraclelinux-8-pg15/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg15/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/oraclelinux-8-pg15/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg15/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/oraclelinux-8-pg15/scripts/setup_submodules
+++ b/dockerfiles/oraclelinux-8-pg15/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/pgxn-all/scripts/setup_submodules
+++ b/dockerfiles/pgxn-all/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/pgxn-all/scripts/setup_submodules
+++ b/dockerfiles/pgxn-all/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/pgxn-all/scripts/setup_submodules
+++ b/dockerfiles/pgxn-all/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/pgxn-all/scripts/setup_submodules
+++ b/dockerfiles/pgxn-all/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/ubuntu-bionic-all/scripts/setup_submodules
+++ b/dockerfiles/ubuntu-bionic-all/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/ubuntu-bionic-all/scripts/setup_submodules
+++ b/dockerfiles/ubuntu-bionic-all/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/ubuntu-bionic-all/scripts/setup_submodules
+++ b/dockerfiles/ubuntu-bionic-all/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/ubuntu-bionic-all/scripts/setup_submodules
+++ b/dockerfiles/ubuntu-bionic-all/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -98,7 +98,4 @@ ENV PATH /scripts:$PATH
 COPY scripts /scripts
 VOLUME /packages
 
-RUN apt update -y
-RUN apt install -y git
-
 ENTRYPOINT ["/scripts/fetch_and_build_deb"]

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -98,4 +98,7 @@ ENV PATH /scripts:$PATH
 COPY scripts /scripts
 VOLUME /packages
 
+RUN apt update -y
+RUN apt install -y git
+
 ENTRYPOINT ["/scripts/fetch_and_build_deb"]

--- a/dockerfiles/ubuntu-focal-all/scripts/setup_submodules
+++ b/dockerfiles/ubuntu-focal-all/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/ubuntu-focal-all/scripts/setup_submodules
+++ b/dockerfiles/ubuntu-focal-all/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/ubuntu-focal-all/scripts/setup_submodules
+++ b/dockerfiles/ubuntu-focal-all/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/ubuntu-focal-all/scripts/setup_submodules
+++ b/dockerfiles/ubuntu-focal-all/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/dockerfiles/ubuntu-jammy-all/scripts/setup_submodules
+++ b/dockerfiles/ubuntu-jammy-all/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/dockerfiles/ubuntu-jammy-all/scripts/setup_submodules
+++ b/dockerfiles/ubuntu-jammy-all/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/dockerfiles/ubuntu-jammy-all/scripts/setup_submodules
+++ b/dockerfiles/ubuntu-jammy-all/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/dockerfiles/ubuntu-jammy-all/scripts/setup_submodules
+++ b/dockerfiles/ubuntu-jammy-all/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -161,12 +161,20 @@ curl -sL "https://api.github.com/repos/${repopath}/tarball/${gitsha}" \
 mkdir -p "${packagepath}"
 tar xf "${tarballpath}" -C "${packagepath}" --strip-components 1
 
+if [[ -f "${packagepath}/.gitmodules" ]]; then
+    setup_submodules "${packagepath}"
+fi
+
 # add our email/name to debian control file as uploader if not a release
 if [ "${1}" != 'release' ]; then
     sed -i -E "/^Uploaders:/s/ .+$/ ${NAME} <${EMAIL}>/" "${builddir}/debian/control.in"
 fi
 
 cp -R "${builddir}/debian" "${packagepath}/debian"
+
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+
 
 cd "${packagepath}"
 

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -161,20 +161,12 @@ curl -sL "https://api.github.com/repos/${repopath}/tarball/${gitsha}" \
 mkdir -p "${packagepath}"
 tar xf "${tarballpath}" -C "${packagepath}" --strip-components 1
 
-if [[ -f "${packagepath}/.gitmodules" ]]; then
-    setup_submodules "${packagepath}"
-fi
-
 # add our email/name to debian control file as uploader if not a release
 if [ "${1}" != 'release' ]; then
     sed -i -E "/^Uploaders:/s/ .+$/ ${NAME} <${EMAIL}>/" "${builddir}/debian/control.in"
 fi
 
 cp -R "${builddir}/debian" "${packagepath}/debian"
-
-# git metadata needs to be setup to initialize submodules
-# in repos which rely on git submodules
-
 
 cd "${packagepath}"
 

--- a/scripts/fetch_and_build_rpm
+++ b/scripts/fetch_and_build_rpm
@@ -168,7 +168,7 @@ tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ $(ls -a "${pkgsrcdir}" | grep .gitmodules | wc -l) -gt 0 ]]; then
+if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
 

--- a/scripts/fetch_and_build_rpm
+++ b/scripts/fetch_and_build_rpm
@@ -166,6 +166,12 @@ tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
 tar czf "${tarballpath}" "${pkgsrcdir}"
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ $(ls -a "${pkgsrcdir}" | grep .gitmodules | wc -l) -gt 0 ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
           -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \

--- a/scripts/fetch_and_build_rpm
+++ b/scripts/fetch_and_build_rpm
@@ -164,13 +164,14 @@ curl -sL "${tarballurl}" -o "${download}"
 
 tarballpath="${rpmbuilddir}/${gitsha}"
 tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
-tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # git metadata needs to be setup to initialize submodules
 # in repos which rely on git submodules
-if [[ -z "${pkgsrcdir}/.gitmodules" ]]; then
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
     setup_submodules "${pkgsrcdir}"
 fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
 
 # force our URL and expanded folder names into spec
 sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \

--- a/scripts/setup_submodules
+++ b/scripts/setup_submodules
@@ -23,7 +23,11 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
 
-        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
     done

--- a/scripts/setup_submodules
+++ b/scripts/setup_submodules
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+
+        git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+    done

--- a/scripts/setup_submodules
+++ b/scripts/setup_submodules
@@ -9,6 +9,9 @@ cd $REPO_PATH
 
 git init
 
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
 git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
     while read -r KEY MODULE_PATH
     do
@@ -19,7 +22,10 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
 
         NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
 
+        # submodule.{SUBMODULE_NAME}.url
         url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"

--- a/scripts/setup_submodules
+++ b/scripts/setup_submodules
@@ -23,7 +23,7 @@ git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
         branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
 
         URL="$(git config -f .gitmodules --get "${url_key}")"
-        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "master")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "main")"
 
         git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
     done


### PR DESCRIPTION
This is my attempt at adding support to build repos which rely on git submodules.
The change is primarily a short script which gets executed only if the repo being built contains a .gitmodules file.
This should not affect current citus related packaging logic at all.

@hanefi @onurctirtir  since there is no released version yet, build package fails. Please ignore these errors