### PR TITLE
Changes community nightly branch into regular one

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -1,7 +1,7 @@
 name: Build and publish citus community nightly packages
 
 env:
-  MAIN_BRANCH: "all-citus-pg15-beta"
+  MAIN_BRANCH: "all-citus"
   PACKAGE_CLOUD_REPO_NAME: "citusdata/community-nightlies"
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
   PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}

--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -26,7 +26,9 @@ jobs:
       matrix:
         platform:
           - el/7
-          - el/8
+# We will remove el/8 support for all apps in the future. For this project packaging image should be updated.But we
+# don't want to invest.
+          # - el/8
 # temporarily removed from nightlies since pg15 beta is not being downloaded for ol/7
 # - ol/7
 # Haven't worked on deb support for pgazure. Will enable below block after deb support is added


### PR DESCRIPTION
Before 11.1.1 release --without-pg-version-checks flag was used. With this PR we used the regular branch which does not include this flag 