### PR TITLE
Adds pgazure packaging image changes for deb packages

### DIFF
--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -81,7 +81,6 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main 15' > 
         checkinstall \
         git \
         libtemplate-perl \
-        make \
         pkg-config \
         tar \
         unzip \

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -39,10 +39,8 @@ RUN set -ex; \
 
 # add buster backports repo to be able to download missing packages in buster main repo
 RUN ( [ debian != debian ] || [ bullseye != buster ] ) || ( \
-    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
-    apt-get update -y \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list  \
     )
-
 
 # install build tools and PostgreSQL development files
 
@@ -79,7 +77,19 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main 15' > 
         liblz4-1 \
         libzstd1 \
         libzstd-dev \
-        sudo
+# below are needed for cmake and pgazure build
+        checkinstall \
+        git \
+        libtemplate-perl \
+        make \
+        pkg-config \
+        tar \
+        unzip \
+        uuid \
+        uuid-dev \
+        zip \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install sphinx
 
@@ -95,18 +105,6 @@ RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/scr
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
 
-# install cmake dependencies and pgazure build dependencies
-RUN apt install -y  checkinstall \
-                    git \
-                    libtemplate-perl \
-                    make \
-                    pkg-config \
-                    tar \
-                    unzip \
-                    uuid \
-                    uuid-dev \
-                    zip \
-                 && rm -rf /var/lib/apt/lists/*
 
 # install cmake from source
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -37,6 +37,13 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME"; \
     apt-key list
 
+# add buster backports repo to be able to download missing packages in buster main repo
+RUN ( [ debian != debian ] || [ bullseye != buster ] ) || ( \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
+    apt-get update -y \
+    )
+
+
 # install build tools and PostgreSQL development files
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main 15' > /etc/apt/sources.list.d/pgdg.list \
@@ -109,6 +116,8 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     make install && \
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
+
+
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -71,7 +71,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main 15' > 
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev
+        libzstd-dev \
+        sudo
 
 RUN pip3 install sphinx
 

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -99,7 +99,8 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
+    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -71,9 +71,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main 15' > 
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev \
-        sudo \
-    && rm -rf /var/lib/apt/lists/*
+        libzstd-dev
 
 RUN pip3 install sphinx
 
@@ -83,12 +81,33 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && rm -rf /var/lib/apt/lists/*
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
+
+# install cmake dependencies and pgazure build dependencies
+RUN apt install -y  checkinstall \
+                    git \
+                    libtemplate-perl \
+                    make \
+                    pkg-config \
+                    tar \
+                    unzip \
+                    uuid \
+                    uuid-dev \
+                    zip \
+                 && rm -rf /var/lib/apt/lists/*
+
+# install cmake from source
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \
+    tar -zxvf cmake-3.22.2.tar.gz && \
+    cd cmake-3.22.2 && ./bootstrap && \
+    make && \
+    make install && \
+    rm -f cmake-3.22.2.tar.gz && \
+    rm -rf cmake-3.22.2
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/dockerfiles/debian-bullseye-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-bullseye-all/scripts/fetch_and_build_deb
@@ -161,6 +161,12 @@ curl -sL "https://api.github.com/repos/${repopath}/tarball/${gitsha}" \
 mkdir -p "${packagepath}"
 tar xf "${tarballpath}" -C "${packagepath}" --strip-components 1
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${packagepath}/.gitmodules" ]]; then
+    setup_submodules "${packagepath}"
+fi
+
 # add our email/name to debian control file as uploader if not a release
 if [ "${1}" != 'release' ]; then
     sed -i -E "/^Uploaders:/s/ .+$/ ${NAME} <${EMAIL}>/" "${builddir}/debian/control.in"

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -71,7 +71,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main 15' > /e
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev
+        libzstd-dev \
+        sudo
 
 RUN pip3 install sphinx
 

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -39,10 +39,8 @@ RUN set -ex; \
 
 # add buster backports repo to be able to download missing packages in buster main repo
 RUN ( [ debian != debian ] || [ buster != buster ] ) || ( \
-    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
-    apt-get update -y \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list  \
     )
-
 
 # install build tools and PostgreSQL development files
 
@@ -79,7 +77,19 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main 15' > /e
         liblz4-1 \
         libzstd1 \
         libzstd-dev \
-        sudo
+# below are needed for cmake and pgazure build
+        checkinstall \
+        git \
+        libtemplate-perl \
+        make \
+        pkg-config \
+        tar \
+        unzip \
+        uuid \
+        uuid-dev \
+        zip \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install sphinx
 
@@ -95,18 +105,6 @@ RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/scr
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
 
-# install cmake dependencies and pgazure build dependencies
-RUN apt install -y  checkinstall \
-                    git \
-                    libtemplate-perl \
-                    make \
-                    pkg-config \
-                    tar \
-                    unzip \
-                    uuid \
-                    uuid-dev \
-                    zip \
-                 && rm -rf /var/lib/apt/lists/*
 
 # install cmake from source
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -71,9 +71,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main 15' > /e
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev \
-        sudo \
-    && rm -rf /var/lib/apt/lists/*
+        libzstd-dev
 
 RUN pip3 install sphinx
 
@@ -83,12 +81,33 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && rm -rf /var/lib/apt/lists/*
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
+
+# install cmake dependencies and pgazure build dependencies
+RUN apt install -y  checkinstall \
+                    git \
+                    libtemplate-perl \
+                    make \
+                    pkg-config \
+                    tar \
+                    unzip \
+                    uuid \
+                    uuid-dev \
+                    zip \
+                 && rm -rf /var/lib/apt/lists/*
+
+# install cmake from source
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \
+    tar -zxvf cmake-3.22.2.tar.gz && \
+    cd cmake-3.22.2 && ./bootstrap && \
+    make && \
+    make install && \
+    rm -f cmake-3.22.2.tar.gz && \
+    rm -rf cmake-3.22.2
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -81,7 +81,6 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main 15' > /e
         checkinstall \
         git \
         libtemplate-perl \
-        make \
         pkg-config \
         tar \
         unzip \

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -99,7 +99,8 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
+    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -37,6 +37,13 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME"; \
     apt-key list
 
+# add buster backports repo to be able to download missing packages in buster main repo
+RUN ( [ debian != debian ] || [ buster != buster ] ) || ( \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
+    apt-get update -y \
+    )
+
+
 # install build tools and PostgreSQL development files
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main 15' > /etc/apt/sources.list.d/pgdg.list \
@@ -109,6 +116,8 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     make install && \
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
+
+
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/dockerfiles/debian-buster-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-buster-all/scripts/fetch_and_build_deb
@@ -161,6 +161,12 @@ curl -sL "https://api.github.com/repos/${repopath}/tarball/${gitsha}" \
 mkdir -p "${packagepath}"
 tar xf "${tarballpath}" -C "${packagepath}" --strip-components 1
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${packagepath}/.gitmodules" ]]; then
+    setup_submodules "${packagepath}"
+fi
+
 # add our email/name to debian control file as uploader if not a release
 if [ "${1}" != 'release' ]; then
     sed -i -E "/^Uploaders:/s/ .+$/ ${NAME} <${EMAIL}>/" "${builddir}/debian/control.in"

--- a/dockerfiles/debian-stretch-all/Dockerfile
+++ b/dockerfiles/debian-stretch-all/Dockerfile
@@ -71,7 +71,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main 15' > /
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev
+        libzstd-dev \
+        sudo
 
 RUN pip3 install sphinx
 

--- a/dockerfiles/debian-stretch-all/Dockerfile
+++ b/dockerfiles/debian-stretch-all/Dockerfile
@@ -81,7 +81,6 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main 15' > /
         checkinstall \
         git \
         libtemplate-perl \
-        make \
         pkg-config \
         tar \
         unzip \

--- a/dockerfiles/debian-stretch-all/Dockerfile
+++ b/dockerfiles/debian-stretch-all/Dockerfile
@@ -71,9 +71,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main 15' > /
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev \
-        sudo \
-    && rm -rf /var/lib/apt/lists/*
+        libzstd-dev
 
 RUN pip3 install sphinx
 
@@ -83,12 +81,33 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && rm -rf /var/lib/apt/lists/*
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
+
+# install cmake dependencies and pgazure build dependencies
+RUN apt install -y  checkinstall \
+                    git \
+                    libtemplate-perl \
+                    make \
+                    pkg-config \
+                    tar \
+                    unzip \
+                    uuid \
+                    uuid-dev \
+                    zip \
+                 && rm -rf /var/lib/apt/lists/*
+
+# install cmake from source
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \
+    tar -zxvf cmake-3.22.2.tar.gz && \
+    cd cmake-3.22.2 && ./bootstrap && \
+    make && \
+    make install && \
+    rm -f cmake-3.22.2.tar.gz && \
+    rm -rf cmake-3.22.2
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/dockerfiles/debian-stretch-all/Dockerfile
+++ b/dockerfiles/debian-stretch-all/Dockerfile
@@ -99,7 +99,8 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
+    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/dockerfiles/debian-stretch-all/Dockerfile
+++ b/dockerfiles/debian-stretch-all/Dockerfile
@@ -39,10 +39,8 @@ RUN set -ex; \
 
 # add buster backports repo to be able to download missing packages in buster main repo
 RUN ( [ debian != debian ] || [ stretch != buster ] ) || ( \
-    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
-    apt-get update -y \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list  \
     )
-
 
 # install build tools and PostgreSQL development files
 
@@ -79,7 +77,19 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main 15' > /
         liblz4-1 \
         libzstd1 \
         libzstd-dev \
-        sudo
+# below are needed for cmake and pgazure build
+        checkinstall \
+        git \
+        libtemplate-perl \
+        make \
+        pkg-config \
+        tar \
+        unzip \
+        uuid \
+        uuid-dev \
+        zip \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install sphinx
 
@@ -95,18 +105,6 @@ RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/scr
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
 
-# install cmake dependencies and pgazure build dependencies
-RUN apt install -y  checkinstall \
-                    git \
-                    libtemplate-perl \
-                    make \
-                    pkg-config \
-                    tar \
-                    unzip \
-                    uuid \
-                    uuid-dev \
-                    zip \
-                 && rm -rf /var/lib/apt/lists/*
 
 # install cmake from source
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \

--- a/dockerfiles/debian-stretch-all/Dockerfile
+++ b/dockerfiles/debian-stretch-all/Dockerfile
@@ -37,6 +37,13 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME"; \
     apt-key list
 
+# add buster backports repo to be able to download missing packages in buster main repo
+RUN ( [ debian != debian ] || [ stretch != buster ] ) || ( \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
+    apt-get update -y \
+    )
+
+
 # install build tools and PostgreSQL development files
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main 15' > /etc/apt/sources.list.d/pgdg.list \
@@ -109,6 +116,8 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     make install && \
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
+
+
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/dockerfiles/debian-stretch-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/debian-stretch-all/scripts/fetch_and_build_deb
@@ -161,6 +161,12 @@ curl -sL "https://api.github.com/repos/${repopath}/tarball/${gitsha}" \
 mkdir -p "${packagepath}"
 tar xf "${tarballpath}" -C "${packagepath}" --strip-components 1
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${packagepath}/.gitmodules" ]]; then
+    setup_submodules "${packagepath}"
+fi
+
 # add our email/name to debian control file as uploader if not a release
 if [ "${1}" != 'release' ]; then
     sed -i -E "/^Uploaders:/s/ .+$/ ${NAME} <${EMAIL}>/" "${builddir}/debian/control.in"

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -71,9 +71,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main 15' > /e
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev \
-        sudo \
-    && rm -rf /var/lib/apt/lists/*
+        libzstd-dev
 
 RUN pip3 install sphinx
 
@@ -83,12 +81,33 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && rm -rf /var/lib/apt/lists/*
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
+
+# install cmake dependencies and pgazure build dependencies
+RUN apt install -y  checkinstall \
+                    git \
+                    libtemplate-perl \
+                    make \
+                    pkg-config \
+                    tar \
+                    unzip \
+                    uuid \
+                    uuid-dev \
+                    zip \
+                 && rm -rf /var/lib/apt/lists/*
+
+# install cmake from source
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \
+    tar -zxvf cmake-3.22.2.tar.gz && \
+    cd cmake-3.22.2 && ./bootstrap && \
+    make && \
+    make install && \
+    rm -f cmake-3.22.2.tar.gz && \
+    rm -rf cmake-3.22.2
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -37,6 +37,13 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME"; \
     apt-key list
 
+# add buster backports repo to be able to download missing packages in buster main repo
+RUN ( [ ubuntu != debian ] || [ bionic != buster ] ) || ( \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
+    apt-get update -y \
+    )
+
+
 # install build tools and PostgreSQL development files
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main 15' > /etc/apt/sources.list.d/pgdg.list \
@@ -109,6 +116,8 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     make install && \
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
+
+
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -81,7 +81,6 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main 15' > /e
         checkinstall \
         git \
         libtemplate-perl \
-        make \
         pkg-config \
         tar \
         unzip \

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -99,7 +99,8 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
+    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -71,7 +71,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main 15' > /e
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev
+        libzstd-dev \
+        sudo
 
 RUN pip3 install sphinx
 

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -39,10 +39,8 @@ RUN set -ex; \
 
 # add buster backports repo to be able to download missing packages in buster main repo
 RUN ( [ ubuntu != debian ] || [ bionic != buster ] ) || ( \
-    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
-    apt-get update -y \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list  \
     )
-
 
 # install build tools and PostgreSQL development files
 
@@ -79,7 +77,19 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main 15' > /e
         liblz4-1 \
         libzstd1 \
         libzstd-dev \
-        sudo
+# below are needed for cmake and pgazure build
+        checkinstall \
+        git \
+        libtemplate-perl \
+        make \
+        pkg-config \
+        tar \
+        unzip \
+        uuid \
+        uuid-dev \
+        zip \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install sphinx
 
@@ -95,18 +105,6 @@ RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/scr
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
 
-# install cmake dependencies and pgazure build dependencies
-RUN apt install -y  checkinstall \
-                    git \
-                    libtemplate-perl \
-                    make \
-                    pkg-config \
-                    tar \
-                    unzip \
-                    uuid \
-                    uuid-dev \
-                    zip \
-                 && rm -rf /var/lib/apt/lists/*
 
 # install cmake from source
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \

--- a/dockerfiles/ubuntu-bionic-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-bionic-all/scripts/fetch_and_build_deb
@@ -161,6 +161,12 @@ curl -sL "https://api.github.com/repos/${repopath}/tarball/${gitsha}" \
 mkdir -p "${packagepath}"
 tar xf "${tarballpath}" -C "${packagepath}" --strip-components 1
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${packagepath}/.gitmodules" ]]; then
+    setup_submodules "${packagepath}"
+fi
+
 # add our email/name to debian control file as uploader if not a release
 if [ "${1}" != 'release' ]; then
     sed -i -E "/^Uploaders:/s/ .+$/ ${NAME} <${EMAIL}>/" "${builddir}/debian/control.in"

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -71,9 +71,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main 15' > /et
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev \
-        sudo \
-    && rm -rf /var/lib/apt/lists/*
+        libzstd-dev
 
 RUN pip3 install sphinx
 
@@ -83,12 +81,33 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && rm -rf /var/lib/apt/lists/*
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
+
+# install cmake dependencies and pgazure build dependencies
+RUN apt install -y  checkinstall \
+                    git \
+                    libtemplate-perl \
+                    make \
+                    pkg-config \
+                    tar \
+                    unzip \
+                    uuid \
+                    uuid-dev \
+                    zip \
+                 && rm -rf /var/lib/apt/lists/*
+
+# install cmake from source
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \
+    tar -zxvf cmake-3.22.2.tar.gz && \
+    cd cmake-3.22.2 && ./bootstrap && \
+    make && \
+    make install && \
+    rm -f cmake-3.22.2.tar.gz && \
+    rm -rf cmake-3.22.2
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -39,10 +39,8 @@ RUN set -ex; \
 
 # add buster backports repo to be able to download missing packages in buster main repo
 RUN ( [ ubuntu != debian ] || [ focal != buster ] ) || ( \
-    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
-    apt-get update -y \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list  \
     )
-
 
 # install build tools and PostgreSQL development files
 
@@ -79,7 +77,19 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main 15' > /et
         liblz4-1 \
         libzstd1 \
         libzstd-dev \
-        sudo
+# below are needed for cmake and pgazure build
+        checkinstall \
+        git \
+        libtemplate-perl \
+        make \
+        pkg-config \
+        tar \
+        unzip \
+        uuid \
+        uuid-dev \
+        zip \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install sphinx
 
@@ -95,18 +105,6 @@ RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/scr
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
 
-# install cmake dependencies and pgazure build dependencies
-RUN apt install -y  checkinstall \
-                    git \
-                    libtemplate-perl \
-                    make \
-                    pkg-config \
-                    tar \
-                    unzip \
-                    uuid \
-                    uuid-dev \
-                    zip \
-                 && rm -rf /var/lib/apt/lists/*
 
 # install cmake from source
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -71,7 +71,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main 15' > /et
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev
+        libzstd-dev \
+        sudo
 
 RUN pip3 install sphinx
 

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -81,7 +81,6 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main 15' > /et
         checkinstall \
         git \
         libtemplate-perl \
-        make \
         pkg-config \
         tar \
         unzip \

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -99,7 +99,8 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
+    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -37,6 +37,13 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME"; \
     apt-key list
 
+# add buster backports repo to be able to download missing packages in buster main repo
+RUN ( [ ubuntu != debian ] || [ focal != buster ] ) || ( \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
+    apt-get update -y \
+    )
+
+
 # install build tools and PostgreSQL development files
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main 15' > /etc/apt/sources.list.d/pgdg.list \
@@ -109,6 +116,8 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     make install && \
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
+
+
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/dockerfiles/ubuntu-focal-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-focal-all/scripts/fetch_and_build_deb
@@ -161,6 +161,12 @@ curl -sL "https://api.github.com/repos/${repopath}/tarball/${gitsha}" \
 mkdir -p "${packagepath}"
 tar xf "${tarballpath}" -C "${packagepath}" --strip-components 1
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${packagepath}/.gitmodules" ]]; then
+    setup_submodules "${packagepath}"
+fi
+
 # add our email/name to debian control file as uploader if not a release
 if [ "${1}" != 'release' ]; then
     sed -i -E "/^Uploaders:/s/ .+$/ ${NAME} <${EMAIL}>/" "${builddir}/debian/control.in"

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -37,6 +37,13 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME"; \
     apt-key list
 
+# add buster backports repo to be able to download missing packages in buster main repo
+RUN ( [ ubuntu != debian ] || [ jammy != buster ] ) || ( \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
+    apt-get update -y \
+    )
+
+
 # install build tools and PostgreSQL development files
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main 15' > /etc/apt/sources.list.d/pgdg.list \
@@ -109,6 +116,8 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     make install && \
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
+
+
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -81,7 +81,6 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main 15' > /et
         checkinstall \
         git \
         libtemplate-perl \
-        make \
         pkg-config \
         tar \
         unzip \

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -39,10 +39,8 @@ RUN set -ex; \
 
 # add buster backports repo to be able to download missing packages in buster main repo
 RUN ( [ ubuntu != debian ] || [ jammy != buster ] ) || ( \
-    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
-    apt-get update -y \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list  \
     )
-
 
 # install build tools and PostgreSQL development files
 
@@ -79,7 +77,19 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main 15' > /et
         liblz4-1 \
         libzstd1 \
         libzstd-dev \
-        sudo
+# below are needed for cmake and pgazure build
+        checkinstall \
+        git \
+        libtemplate-perl \
+        make \
+        pkg-config \
+        tar \
+        unzip \
+        uuid \
+        uuid-dev \
+        zip \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install sphinx
 
@@ -95,18 +105,6 @@ RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/scr
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
 
-# install cmake dependencies and pgazure build dependencies
-RUN apt install -y  checkinstall \
-                    git \
-                    libtemplate-perl \
-                    make \
-                    pkg-config \
-                    tar \
-                    unzip \
-                    uuid \
-                    uuid-dev \
-                    zip \
-                 && rm -rf /var/lib/apt/lists/*
 
 # install cmake from source
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -71,9 +71,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main 15' > /et
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev \
-        sudo \
-    && rm -rf /var/lib/apt/lists/*
+        libzstd-dev
 
 RUN pip3 install sphinx
 
@@ -83,12 +81,33 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && rm -rf /var/lib/apt/lists/*
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
+
+# install cmake dependencies and pgazure build dependencies
+RUN apt install -y  checkinstall \
+                    git \
+                    libtemplate-perl \
+                    make \
+                    pkg-config \
+                    tar \
+                    unzip \
+                    uuid \
+                    uuid-dev \
+                    zip \
+                 && rm -rf /var/lib/apt/lists/*
+
+# install cmake from source
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \
+    tar -zxvf cmake-3.22.2.tar.gz && \
+    cd cmake-3.22.2 && ./bootstrap && \
+    make && \
+    make install && \
+    rm -f cmake-3.22.2.tar.gz && \
+    rm -rf cmake-3.22.2
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -71,7 +71,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main 15' > /et
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev
+        libzstd-dev \
+        sudo
 
 RUN pip3 install sphinx
 

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -99,7 +99,8 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
+    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/dockerfiles/ubuntu-jammy-all/scripts/fetch_and_build_deb
+++ b/dockerfiles/ubuntu-jammy-all/scripts/fetch_and_build_deb
@@ -161,6 +161,12 @@ curl -sL "https://api.github.com/repos/${repopath}/tarball/${gitsha}" \
 mkdir -p "${packagepath}"
 tar xf "${tarballpath}" -C "${packagepath}" --strip-components 1
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${packagepath}/.gitmodules" ]]; then
+    setup_submodules "${packagepath}"
+fi
+
 # add our email/name to debian control file as uploader if not a release
 if [ "${1}" != 'release' ]; then
     sed -i -E "/^Uploaders:/s/ .+$/ ${NAME} <${EMAIL}>/" "${builddir}/debian/control.in"

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -161,6 +161,12 @@ curl -sL "https://api.github.com/repos/${repopath}/tarball/${gitsha}" \
 mkdir -p "${packagepath}"
 tar xf "${tarballpath}" -C "${packagepath}" --strip-components 1
 
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${packagepath}/.gitmodules" ]]; then
+    setup_submodules "${packagepath}"
+fi
+
 # add our email/name to debian control file as uploader if not a release
 if [ "${1}" != 'release' ]; then
     sed -i -E "/^Uploaders:/s/ .+$/ ${NAME} <${EMAIL}>/" "${builddir}/debian/control.in"

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -71,9 +71,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main 15'
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev \
-        sudo \
-    && rm -rf /var/lib/apt/lists/*
+        libzstd-dev
 
 RUN pip3 install sphinx
 
@@ -83,12 +81,33 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
-    && rm -rf /var/lib/apt/lists/*
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
+
+# install cmake dependencies and pgazure build dependencies
+RUN apt install -y  checkinstall \
+                    git \
+                    libtemplate-perl \
+                    make \
+                    pkg-config \
+                    tar \
+                    unzip \
+                    uuid \
+                    uuid-dev \
+                    zip \
+                 && rm -rf /var/lib/apt/lists/*
+
+# install cmake from source
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \
+    tar -zxvf cmake-3.22.2.tar.gz && \
+    cd cmake-3.22.2 && ./bootstrap && \
+    make && \
+    make install && \
+    rm -f cmake-3.22.2.tar.gz && \
+    rm -rf cmake-3.22.2
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -71,7 +71,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main 15'
         liblz4-dev \
         liblz4-1 \
         libzstd1 \
-        libzstd-dev
+        libzstd-dev \
+        sudo
 
 RUN pip3 install sphinx
 

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -99,7 +99,8 @@ RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 
     && chmod +x /usr/bin/jq
 
 # install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash
+RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
+    && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
 COPY make_pg_buildext_parallel.patch /

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -81,7 +81,6 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main 15'
         checkinstall \
         git \
         libtemplate-perl \
-        make \
         pkg-config \
         tar \
         unzip \

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -37,6 +37,13 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME"; \
     apt-key list
 
+# add buster backports repo to be able to download missing packages in buster main repo
+RUN ( [ %%os%% != debian ] || [ %%release%% != buster ] ) || ( \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
+    apt-get update -y \
+    )
+
+
 # install build tools and PostgreSQL development files
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main 15' > /etc/apt/sources.list.d/pgdg.list \
@@ -109,6 +116,8 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     make install && \
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
+
+
 
 # Added for pg15 beta package support.
 ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15"

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -39,10 +39,8 @@ RUN set -ex; \
 
 # add buster backports repo to be able to download missing packages in buster main repo
 RUN ( [ %%os%% != debian ] || [ %%release%% != buster ] ) || ( \
-    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
-    apt-get update -y \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list  \
     )
-
 
 # install build tools and PostgreSQL development files
 
@@ -79,7 +77,19 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main 15'
         liblz4-1 \
         libzstd1 \
         libzstd-dev \
-        sudo
+# below are needed for cmake and pgazure build
+        checkinstall \
+        git \
+        libtemplate-perl \
+        make \
+        pkg-config \
+        tar \
+        unzip \
+        uuid \
+        uuid-dev \
+        zip \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install sphinx
 
@@ -95,18 +105,6 @@ RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/scr
 COPY make_pg_buildext_parallel.patch /
 RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
 
-# install cmake dependencies and pgazure build dependencies
-RUN apt install -y  checkinstall \
-                    git \
-                    libtemplate-perl \
-                    make \
-                    pkg-config \
-                    tar \
-                    unzip \
-                    uuid \
-                    uuid-dev \
-                    zip \
-                 && rm -rf /var/lib/apt/lists/*
 
 # install cmake from source
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \


### PR DESCRIPTION
Pg azure project is using build technologies different from other citus applications. 
Differences
1. Uses git submodule to be able to fetch submodules from their git repos.
2. Uses cmake and vpkg to be able to fetch and build from source of their dependencies

We already added integration for rpm packages. With this PR, we aim to add support for deb packages
