### PR TITLE
Changes packagecloud repo into enterprise-nightlies

### DIFF
--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -2,7 +2,7 @@ name: Build and publish pgazure nightly packages
 
 env:
   MAIN_BRANCH: "all-pg-azure-storage"
-  PACKAGE_CLOUD_REPO_NAME: "citusdata/community-nightlies"
+  PACKAGE_CLOUD_REPO_NAME: "citusdata/enterprise-nightlies"
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
   PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
   PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}


### PR DESCRIPTION
Adam requestes us to change the pg_azure nightlies into enterprise-nightlies since they don't expose packages before ignite