### PR TITLE
Enables ol/7 and removes debian stretch

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -25,7 +25,7 @@ jobs:
         platform:
           - el/7
           - el/8
-          - debian/stretch
+          - ol/7
           - debian/buster
           - debian/bullseye
           - ubuntu/bionic

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -25,6 +25,7 @@ jobs:
         platform:
           - el/7
           - el/8
+          - ol/7
           - ol/8
           - debian/buster
           - debian/bullseye


### PR DESCRIPTION
I tried to add ol/8 for nightlies but it got error. I will handle this problem with the issue below
https://github.com/citusdata/packaging/issues/1003