### PR TITLE
Adds almalinux 9 as el/ol 9 build distro

### DIFF
--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -77,12 +77,12 @@ jobs:
       - name: Clone tools repo for test
         run: git clone -b almalinux_test_changes --depth=1  https://github.com/citusdata/tools.git tools
 
-      - name: Execute packaging tests
-        run: |
-          python -m pip install -r tools/packaging_automation/requirements.txt
-          python -m pytest -q tools/packaging_automation/tests/test_citus_package.py -k 'test_build_packages'
-        env:
-          PACKAGING_IMAGE_PLATFORM: "${{matrix.TARGET_PLATFORM}}"
+#      - name: Execute packaging tests
+#        run: |
+#          python -m pip install -r tools/packaging_automation/requirements.txt
+#          python -m pytest -q tools/packaging_automation/tests/test_citus_package.py -k 'test_build_packages'
+#        env:
+#          PACKAGING_IMAGE_PLATFORM: "${{matrix.TARGET_PLATFORM}}"
 
       - name: Push images
         run: |

--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -40,6 +40,7 @@ jobs:
           - centos,7
           - oraclelinux,8
           - oraclelinux,7
+          - almalinux,9
         POSTGRES_VERSION:
           - 10
           - 11

--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -77,12 +77,12 @@ jobs:
       - name: Clone tools repo for test
         run: git clone -b almalinux_test_changes --depth=1  https://github.com/citusdata/tools.git tools
 
-#      - name: Execute packaging tests
-#        run: |
-#          python -m pip install -r tools/packaging_automation/requirements.txt
-#          python -m pytest -q tools/packaging_automation/tests/test_citus_package.py -k 'test_build_packages'
-#        env:
-#          PACKAGING_IMAGE_PLATFORM: "${{matrix.TARGET_PLATFORM}}"
+      - name: Execute packaging tests
+        run: |
+          python -m pip install -r tools/packaging_automation/requirements.txt
+          python -m pytest -q tools/packaging_automation/tests/test_citus_package.py -k 'test_build_packages'
+        env:
+          PACKAGING_IMAGE_PLATFORM: "${{matrix.TARGET_PLATFORM}}"
 
       - name: Push images
         run: |

--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -75,7 +75,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.22 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b almalinux_test_changes --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -76,7 +76,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b almalinux_test_changes --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.23 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -41,6 +41,7 @@ jobs:
           - centos,7
           - oraclelinux,8
           - oraclelinux,7
+          - almalinux,9
         POSTGRES_VERSION:
           - 10
           - 11

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -78,7 +78,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b almalinux_test_changes --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.23 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -77,7 +77,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.22 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b almalinux_test_changes --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/ci/push_images
+++ b/ci/push_images
@@ -35,7 +35,7 @@ while read -r line; do
     if [[ "${os}" = 'debian' ]] || [[ "${os}" = 'ubuntu' ]]; then
         tag="${os}-${release}-all"
         args+="push citus/${image_name}:${tag}\n"
-    elif [[ "${os}" = 'centos' ]] || [[ "${os}" = 'fedora' ]] || [[ "${os}" = 'oraclelinux' ]]
+    elif [[ "${os}" = 'centos' ]] || [[ "${os}" = 'fedora' ]] || [[ "${os}" = 'oraclelinux' ]] ||
          [[ "${os}" = 'almalinux' ]] ; then
         # redhat variants need an image for each PostgreSQL version
         IFS=' '

--- a/ci/push_images
+++ b/ci/push_images
@@ -35,7 +35,8 @@ while read -r line; do
     if [[ "${os}" = 'debian' ]] || [[ "${os}" = 'ubuntu' ]]; then
         tag="${os}-${release}-all"
         args+="push citus/${image_name}:${tag}\n"
-    elif [[ "${os}" = 'centos' ]] || [[ "${os}" = 'fedora' ]] || [[ "${os}" = 'oraclelinux' ]]; then
+    elif [[ "${os}" = 'centos' ]] || [[ "${os}" = 'fedora' ]] || [[ "${os}" = 'oraclelinux' ]]
+         [[ "${os}" = 'almalinux' ]] ; then
         # redhat variants need an image for each PostgreSQL version
         IFS=' '
         for pgversion in ${pgversions}; do

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -1,0 +1,117 @@
+# vim:set ft=dockerfile:
+FROM almalinux:9
+
+RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
+    )
+
+RUN yum -y update
+
+# FIXME: Hack around docker/docker#10180
+RUN ( yum install -y yum-plugin-ovl || yum install -y yum-plugin-ovl || touch /var/lib/rpm/* ) \
+    && yum clean all
+
+# Enable some other repos for some dependencies in OL/7 
+# see https://yum.oracle.com/getting-started.html#installing-from-oracle-linux-yum-server
+RUN [[ almalinux != oraclelinux ]] || [[ 9 != 7 ]] || ( \
+       yum install -y oraclelinux-release-el7 oracle-softwarecollection-release-el7 oracle-epel-release-el7  oraclelinux-developer-release-el7 \
+       && yum-config-manager --enable \
+            ol7_software_collections \
+            ol7_developer \
+            ol7_developer_EPEL \
+            ol7_optional_latest \
+            ol7_optional_archive \
+            ol7_u9_base \
+            ol7_security_validation \
+            ol7_addons \
+         )
+
+# lz4 1.8 is preloaded in oracle 7 however, lz4-devel is not loaded and only 1.7.5 version exists
+# in oracle 7 repos. So package from centos repo was used
+# There is no package in oracle repos for lz4. Also it is not preloaded. So both lz4 and lz4-devel packages
+# were downloaded from centos el/6 repos
+RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wget \
+        && wget http://mirror.centos.org/centos/7/os/x86_64/Packages/lz4-devel-1.8.3-1.el7.x86_64.rpm \
+        && rpm -ivh lz4-devel-1.8.3-1.el7.x86_64.rpm ; \
+        elif [[ almalinux   == oraclelinux ]] && [[ 9 == 6 ]]; then yum install -y wget \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-r131-1.el6.x86_64.rpm \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-devel-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-devel-r131-1.el6.x86_64.rpm;  \
+        else yum install -y lz4 lz4-devel; fi
+
+# install build tools and PostgreSQL development files
+RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
+    && [[ -z "epel-release" ]] || yum install -y epel-release) \
+    && yum groupinstall -y 'Development Tools' \
+    && yum install -y \
+        flex \
+        gcc-c++ \
+        hunspell-en \
+        libcurl-devel \
+        libicu-devel \
+        libstdc++-devel \
+        libxml2-devel \
+        libxslt-devel \
+        openssl-devel \
+        pam-devel \
+        readline-devel \
+        rpm-build \
+        rpmlint \
+        tar \
+        libzstd \
+        libzstd-devel \
+        llvm-toolset ccache rpmdevtools krb5-devel \
+    && ( [[ 9 != 8 ]] || dnf -qy module disable postgresql ) \
+    && yum install -y postgresql10-server postgresql10-devel \
+    && yum clean all
+
+# install jq to process JSON API responses
+RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+         -o /usr/bin/jq \
+    && chmod +x /usr/bin/jq
+
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
+    } \
+    && yum clean all
+
+# install sphinx on distros with python3
+RUN { \
+        { yum search python3-pip 2>&1 | grep 'No matches found' ; } \
+        || { \
+            yum install -y python3-pip && \
+            pip3 install sphinx==1.8 \
+            ; \
+        } \
+    } \
+    && yum clean all
+
+# install cmake, devtoolset and its dependencies to build azure sdk
+RUN yum -y install  perl-IPC-Cmd libuuid-devel cmake3
+
+# by default git 1.8.x is being installed in centos 7
+# Git 2.7.1 is minimum requirement for cmake so we remove and reinstall latests git from an up-to-date repo
+# Symbolic link is not being created for cmake from cmake3 by default. Therefore, we need to create the link as well.
+# devtoolset-8-gcc-c++ is required to compile azure sdk in pg azure storage project
+RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
+    yum -y install  perl-IPC-Cmd libuuid-devel cmake3 && \
+    ln -s /usr/bin/cmake3 /usr/bin/cmake  && \
+    yum -y remove git && \
+    yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && \
+    yum -y install git && \
+    yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
+
+RUN touch /rpmlintrc \
+    && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
+
+# set PostgreSQL version, place scripts on path, and declare output volume
+ENV PGVERSION=10 \
+    PATH=/scripts:$PATH
+COPY scripts /scripts
+VOLUME /packages
+
+ENTRYPOINT ["/scripts/fetch_and_build_rpm"]

--- a/dockerfiles/almalinux-9-pg10/scripts/determine_email
+++ b/dockerfiles/almalinux-9-pg10/scripts/determine_email
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# make bash behave
+set -uo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+# fallback to public email
+email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
+
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
+citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
+
+if [ -n "${citusemail}" ]; then
+    email="${citusemail}"
+fi
+
+if [ -z "${email}" ]; then
+    echo "$0: could not determine email" >&2
+    exit $failure
+fi
+
+echo "${email}"
+exit $success

--- a/dockerfiles/almalinux-9-pg10/scripts/determine_name
+++ b/dockerfiles/almalinux-9-pg10/scripts/determine_name
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+fullname=$(curl -sf https://api.github.com/user | jq -r '.name // empty')
+
+if [ -z "${fullname}" ]; then
+    echo "$0: could not determine user name" >&2
+    exit $failure
+fi
+
+echo "${fullname}"
+exit $success

--- a/dockerfiles/almalinux-9-pg10/scripts/fetch_and_build_rpm
+++ b/dockerfiles/almalinux-9-pg10/scripts/fetch_and_build_rpm
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+# In one branch we execute commands inside One Branch steps, since One Branch does not allow executing docker inside
+# docker. Additionally, Onebranch needs containers not to close so we make it hang for OneBranch to be able to
+# execute commands.
+if [ "${CONTAINER_BUILD_RUN_ENABLED:-""}" == "" ]; then
+  echo "INFO: Image working in waiting mode. Not executing build script"
+  tail -f /dev/null
+fi
+
+IFS=$'\n\t'
+
+# constants
+stdout=1
+stderr=2
+success=0
+failure=1
+badusage=64
+noinput=66
+
+nextversion='0.0.0'
+builddir=$(pwd)
+
+# outputs usage message on specified device before exiting with provided status
+usage() {
+    cat << 'E_O_USAGE' >&"$1"
+usage: fetch_and_build_rpm build_type build_directory
+
+    build_type: 'release', 'nightly', or a valid git reference
+
+fetch_and_build_rpm builds Red Hat packages using local build files. The build
+type 'release' builds the latest release tag, 'nightly' builds a nightly from
+the latest 'master' commit, and any other type is interpreted as a git ref to
+facilitate building one-off packages for customers.
+E_O_USAGE
+
+    exit "${2}";
+}
+
+# sets the next version variable used during non-release builds
+setnextversion() {
+    # First line replaces '~' and '_' characters and splits the version by '-' and gets the first
+    # from the array.
+    # Second line strips '.citus' suffix
+    # e.g. input->11.0.0_beta-1.citus; output->11.0.0
+    baseversion=$(echo "$1" | tr '~' '-' | tr '_' '-' | cut -d- -f1)
+    baseversion="${baseversion%.citus}"
+    nextversion=$(echo "$baseversion" | perl -pe 's/^(\d+\.)(\d+)(\.\d+)$/$1.($2+1).".0"/e')
+}
+
+if [ "$#" -ne 1 ]; then
+    usage $stderr $badusage
+fi
+
+if [ "${1}" = '-h' ]; then
+    usage $stdout $success
+fi
+
+# populate variables from packaging metadata file
+# shellcheck source=/dev/null
+source /buildfiles/pkgvars
+
+# set default values for certain packaging variables
+declare pkglatest # to make shellcheck happy
+pkgname="${rpm_pkgname:-${pkgname}}"
+hubproj="${hubproj:-${pkgname}}"
+nightlyref="${nightlyref:-master}"
+releasepg="${releasepg:-11,12,13}"
+nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
+if [[ "${pkglatest}" == *"beta"* ]]; then
+    release_type="beta"
+else
+    release_type="stable"
+fi
+
+if [ -z "${pkglatest}" ]; then
+    echo "$0: pkgvars file must specify a value for pkglatest" >&2
+    exit $noinput
+fi
+
+echo "header=\"Authorization: token ${GITHUB_TOKEN}\"" > ~/.curlrc
+
+name=$(determine_name)
+email=$(determine_email)
+export RPM_PACKAGER="${name} <${email}>"
+
+cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
+repopath="citusdata/${hubproj}"
+
+case "${1}" in
+    release)
+        packageversion=${pkglatest%-*}
+        releasetag="v${packageversion%.citus}"
+
+        # Since the only part of the release version after '-' character is fancy version, package release
+        # will alwayse be empty string. So the releasetag is always equal to packageversion
+        packagerelease=$(echo "${pkglatest#*-}" | sed -E 's/^[0-9.]+//')
+        if [ -n "${packagerelease}" ]; then
+            releasetag="v${packageversion}-${packagerelease}"
+        fi
+
+        conf_extra_version="%{nil}"
+
+        gitsha=$(curl -s "https://api.github.com/repos/${repopath}/git/refs/tags/${releasetag}" | \
+                 jq -r '.object.sha')
+        if [ "${gitsha}" == 'null' ]; then
+            echo "$0: could not determine commit for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+
+        verified=$(curl -sH 'Accept:application/vnd.github.cryptographer-preview+sha' \
+                   "https://api.github.com/repos/${repopath}/git/tags/${gitsha}" | \
+                   jq -r '.verification.verified')
+        if [ "${verified}" != 'true' ]; then
+            echo "$0: could not verify signature for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+        ;;
+    *)
+        if [ "${1}" == 'nightly' ]; then
+            ref=${nightlyref}
+            infix='git'
+        else
+            ref=${1}
+            infix='pre'
+        fi
+
+        setnextversion "${pkglatest}"
+
+        set +e
+        gitsha=$(curl -sfH 'Accept:application/vnd.github.v3.sha' \
+                 "https://api.github.com/repos/${repopath}/commits/${ref}")
+        if [ "${?}" -ne 0 ]; then
+            echo "$0: could not determine commit for git ref ${ref}" >&2
+            exit $failure
+        fi
+        set -e
+
+        packageversion="${nextversion}.citus"
+        timestamp=$(date +'%Y%m%d')
+        packagesuffix="${infix}.${timestamp}.${gitsha:0:7}"
+        packagerelease="0.0.${packagesuffix}"
+        conf_extra_version="+${packagesuffix}"
+
+        sed -i -E -e "/^Version:/s/[^ \\t]*$/${packageversion}/" \
+                  -e "/^Release:/s/[^ \\t]*$/${packagerelease}%{dist}/" \
+            "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# this should all take place in a package-build directory
+rpmbuilddir="${builddir}/citus-rpm-build"
+mkdir -p "${rpmbuilddir}"
+
+pkgsrcdir="${builddir}/${pkgname}-${packageversion}"
+mkdir "${pkgsrcdir}"
+
+download=$(mktemp)
+tarballurl="https://api.github.com/repos/${repopath}/tarball/${gitsha}"
+curl -sL "${tarballurl}" -o "${download}"
+
+tarballpath="${rpmbuilddir}/${gitsha}"
+tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
+
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
+
+# force our URL and expanded folder names into spec
+sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
+          -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \
+          -e "/^%global pgpackageversion/s/[0-9.]+$/${PGVERSION}/" \
+    "${builddir}/${pkgname}.spec"
+
+os_name=$(awk '{print $1}' /etc/system-release)
+os_release=$(awk '{print $4}' /etc/system-release)
+if [ "${os_name}" == 'Oracle' ]; then
+    locale='C'
+elif [ "${os_name}" == 'Fedora' ] || [[ "${os_name}" == 'CentOS'  && "${os_release}" == 8* ]]; then
+    locale='C.utf8'
+else
+    locale='en_US.utf8'
+fi
+
+# add minor/major version to package name if using fancy versioning
+if [ "${versioning}" == 'fancy' ]; then
+  infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+  if [ "${release_type}" == "stable" ]; then
+      package_prefix="${infix}"
+  else
+      package_prefix="${infix}_${release_type}"
+  fi
+  sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+fi
+
+# add a changelog entry into nightly build
+case "${1}" in
+    release)
+        # Changelogs for release builds are being added by packaging scripts and could not be autogenerated
+        # Therefore there is nothing to do for release builds
+        ;;
+    nightly)
+        msg="Nightly package. Built from ${nightlyref} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.git/0.0.git/' "${builddir}/${pkgname}.spec"
+        sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+        ;;
+    *)
+        msg="Custom package. Built from ${gitsha:0:7} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.pre/0.0.pre/' "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
+rpmbuild --define "_sourcedir ${rpmbuilddir}" \
+--define "_specdir ${rpmbuilddir}" \
+--define "_builddir ${rpmbuilddir}" \
+--define "_srcrpmdir ${rpmbuilddir}" \
+--define "_rpmdir ${rpmbuilddir}" \
+--define "conf_extra_version ${conf_extra_version}" \
+-bb "${builddir}/${pkgname}.spec"
+
+cp /citus-rpm-build/x86_64/*.rpm /packages

--- a/dockerfiles/almalinux-9-pg10/scripts/setup_submodules
+++ b/dockerfiles/almalinux-9-pg10/scripts/setup_submodules
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        # submodule.{SUBMODULE_NAME}.url
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
+
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
+    done

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -1,0 +1,117 @@
+# vim:set ft=dockerfile:
+FROM almalinux:9
+
+RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
+    )
+
+RUN yum -y update
+
+# FIXME: Hack around docker/docker#10180
+RUN ( yum install -y yum-plugin-ovl || yum install -y yum-plugin-ovl || touch /var/lib/rpm/* ) \
+    && yum clean all
+
+# Enable some other repos for some dependencies in OL/7 
+# see https://yum.oracle.com/getting-started.html#installing-from-oracle-linux-yum-server
+RUN [[ almalinux != oraclelinux ]] || [[ 9 != 7 ]] || ( \
+       yum install -y oraclelinux-release-el7 oracle-softwarecollection-release-el7 oracle-epel-release-el7  oraclelinux-developer-release-el7 \
+       && yum-config-manager --enable \
+            ol7_software_collections \
+            ol7_developer \
+            ol7_developer_EPEL \
+            ol7_optional_latest \
+            ol7_optional_archive \
+            ol7_u9_base \
+            ol7_security_validation \
+            ol7_addons \
+         )
+
+# lz4 1.8 is preloaded in oracle 7 however, lz4-devel is not loaded and only 1.7.5 version exists
+# in oracle 7 repos. So package from centos repo was used
+# There is no package in oracle repos for lz4. Also it is not preloaded. So both lz4 and lz4-devel packages
+# were downloaded from centos el/6 repos
+RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wget \
+        && wget http://mirror.centos.org/centos/7/os/x86_64/Packages/lz4-devel-1.8.3-1.el7.x86_64.rpm \
+        && rpm -ivh lz4-devel-1.8.3-1.el7.x86_64.rpm ; \
+        elif [[ almalinux   == oraclelinux ]] && [[ 9 == 6 ]]; then yum install -y wget \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-r131-1.el6.x86_64.rpm \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-devel-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-devel-r131-1.el6.x86_64.rpm;  \
+        else yum install -y lz4 lz4-devel; fi
+
+# install build tools and PostgreSQL development files
+RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
+    && [[ -z "epel-release" ]] || yum install -y epel-release) \
+    && yum groupinstall -y 'Development Tools' \
+    && yum install -y \
+        flex \
+        gcc-c++ \
+        hunspell-en \
+        libcurl-devel \
+        libicu-devel \
+        libstdc++-devel \
+        libxml2-devel \
+        libxslt-devel \
+        openssl-devel \
+        pam-devel \
+        readline-devel \
+        rpm-build \
+        rpmlint \
+        tar \
+        libzstd \
+        libzstd-devel \
+        llvm-toolset ccache rpmdevtools krb5-devel \
+    && ( [[ 9 != 8 ]] || dnf -qy module disable postgresql ) \
+    && yum install -y postgresql11-server postgresql11-devel \
+    && yum clean all
+
+# install jq to process JSON API responses
+RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+         -o /usr/bin/jq \
+    && chmod +x /usr/bin/jq
+
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
+    } \
+    && yum clean all
+
+# install sphinx on distros with python3
+RUN { \
+        { yum search python3-pip 2>&1 | grep 'No matches found' ; } \
+        || { \
+            yum install -y python3-pip && \
+            pip3 install sphinx==1.8 \
+            ; \
+        } \
+    } \
+    && yum clean all
+
+# install cmake, devtoolset and its dependencies to build azure sdk
+RUN yum -y install  perl-IPC-Cmd libuuid-devel cmake3
+
+# by default git 1.8.x is being installed in centos 7
+# Git 2.7.1 is minimum requirement for cmake so we remove and reinstall latests git from an up-to-date repo
+# Symbolic link is not being created for cmake from cmake3 by default. Therefore, we need to create the link as well.
+# devtoolset-8-gcc-c++ is required to compile azure sdk in pg azure storage project
+RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
+    yum -y install  perl-IPC-Cmd libuuid-devel cmake3 && \
+    ln -s /usr/bin/cmake3 /usr/bin/cmake  && \
+    yum -y remove git && \
+    yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && \
+    yum -y install git && \
+    yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
+
+RUN touch /rpmlintrc \
+    && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
+
+# set PostgreSQL version, place scripts on path, and declare output volume
+ENV PGVERSION=11 \
+    PATH=/scripts:$PATH
+COPY scripts /scripts
+VOLUME /packages
+
+ENTRYPOINT ["/scripts/fetch_and_build_rpm"]

--- a/dockerfiles/almalinux-9-pg11/scripts/determine_email
+++ b/dockerfiles/almalinux-9-pg11/scripts/determine_email
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# make bash behave
+set -uo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+# fallback to public email
+email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
+
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
+citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
+
+if [ -n "${citusemail}" ]; then
+    email="${citusemail}"
+fi
+
+if [ -z "${email}" ]; then
+    echo "$0: could not determine email" >&2
+    exit $failure
+fi
+
+echo "${email}"
+exit $success

--- a/dockerfiles/almalinux-9-pg11/scripts/determine_name
+++ b/dockerfiles/almalinux-9-pg11/scripts/determine_name
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+fullname=$(curl -sf https://api.github.com/user | jq -r '.name // empty')
+
+if [ -z "${fullname}" ]; then
+    echo "$0: could not determine user name" >&2
+    exit $failure
+fi
+
+echo "${fullname}"
+exit $success

--- a/dockerfiles/almalinux-9-pg11/scripts/fetch_and_build_rpm
+++ b/dockerfiles/almalinux-9-pg11/scripts/fetch_and_build_rpm
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+# In one branch we execute commands inside One Branch steps, since One Branch does not allow executing docker inside
+# docker. Additionally, Onebranch needs containers not to close so we make it hang for OneBranch to be able to
+# execute commands.
+if [ "${CONTAINER_BUILD_RUN_ENABLED:-""}" == "" ]; then
+  echo "INFO: Image working in waiting mode. Not executing build script"
+  tail -f /dev/null
+fi
+
+IFS=$'\n\t'
+
+# constants
+stdout=1
+stderr=2
+success=0
+failure=1
+badusage=64
+noinput=66
+
+nextversion='0.0.0'
+builddir=$(pwd)
+
+# outputs usage message on specified device before exiting with provided status
+usage() {
+    cat << 'E_O_USAGE' >&"$1"
+usage: fetch_and_build_rpm build_type build_directory
+
+    build_type: 'release', 'nightly', or a valid git reference
+
+fetch_and_build_rpm builds Red Hat packages using local build files. The build
+type 'release' builds the latest release tag, 'nightly' builds a nightly from
+the latest 'master' commit, and any other type is interpreted as a git ref to
+facilitate building one-off packages for customers.
+E_O_USAGE
+
+    exit "${2}";
+}
+
+# sets the next version variable used during non-release builds
+setnextversion() {
+    # First line replaces '~' and '_' characters and splits the version by '-' and gets the first
+    # from the array.
+    # Second line strips '.citus' suffix
+    # e.g. input->11.0.0_beta-1.citus; output->11.0.0
+    baseversion=$(echo "$1" | tr '~' '-' | tr '_' '-' | cut -d- -f1)
+    baseversion="${baseversion%.citus}"
+    nextversion=$(echo "$baseversion" | perl -pe 's/^(\d+\.)(\d+)(\.\d+)$/$1.($2+1).".0"/e')
+}
+
+if [ "$#" -ne 1 ]; then
+    usage $stderr $badusage
+fi
+
+if [ "${1}" = '-h' ]; then
+    usage $stdout $success
+fi
+
+# populate variables from packaging metadata file
+# shellcheck source=/dev/null
+source /buildfiles/pkgvars
+
+# set default values for certain packaging variables
+declare pkglatest # to make shellcheck happy
+pkgname="${rpm_pkgname:-${pkgname}}"
+hubproj="${hubproj:-${pkgname}}"
+nightlyref="${nightlyref:-master}"
+releasepg="${releasepg:-11,12,13}"
+nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
+if [[ "${pkglatest}" == *"beta"* ]]; then
+    release_type="beta"
+else
+    release_type="stable"
+fi
+
+if [ -z "${pkglatest}" ]; then
+    echo "$0: pkgvars file must specify a value for pkglatest" >&2
+    exit $noinput
+fi
+
+echo "header=\"Authorization: token ${GITHUB_TOKEN}\"" > ~/.curlrc
+
+name=$(determine_name)
+email=$(determine_email)
+export RPM_PACKAGER="${name} <${email}>"
+
+cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
+repopath="citusdata/${hubproj}"
+
+case "${1}" in
+    release)
+        packageversion=${pkglatest%-*}
+        releasetag="v${packageversion%.citus}"
+
+        # Since the only part of the release version after '-' character is fancy version, package release
+        # will alwayse be empty string. So the releasetag is always equal to packageversion
+        packagerelease=$(echo "${pkglatest#*-}" | sed -E 's/^[0-9.]+//')
+        if [ -n "${packagerelease}" ]; then
+            releasetag="v${packageversion}-${packagerelease}"
+        fi
+
+        conf_extra_version="%{nil}"
+
+        gitsha=$(curl -s "https://api.github.com/repos/${repopath}/git/refs/tags/${releasetag}" | \
+                 jq -r '.object.sha')
+        if [ "${gitsha}" == 'null' ]; then
+            echo "$0: could not determine commit for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+
+        verified=$(curl -sH 'Accept:application/vnd.github.cryptographer-preview+sha' \
+                   "https://api.github.com/repos/${repopath}/git/tags/${gitsha}" | \
+                   jq -r '.verification.verified')
+        if [ "${verified}" != 'true' ]; then
+            echo "$0: could not verify signature for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+        ;;
+    *)
+        if [ "${1}" == 'nightly' ]; then
+            ref=${nightlyref}
+            infix='git'
+        else
+            ref=${1}
+            infix='pre'
+        fi
+
+        setnextversion "${pkglatest}"
+
+        set +e
+        gitsha=$(curl -sfH 'Accept:application/vnd.github.v3.sha' \
+                 "https://api.github.com/repos/${repopath}/commits/${ref}")
+        if [ "${?}" -ne 0 ]; then
+            echo "$0: could not determine commit for git ref ${ref}" >&2
+            exit $failure
+        fi
+        set -e
+
+        packageversion="${nextversion}.citus"
+        timestamp=$(date +'%Y%m%d')
+        packagesuffix="${infix}.${timestamp}.${gitsha:0:7}"
+        packagerelease="0.0.${packagesuffix}"
+        conf_extra_version="+${packagesuffix}"
+
+        sed -i -E -e "/^Version:/s/[^ \\t]*$/${packageversion}/" \
+                  -e "/^Release:/s/[^ \\t]*$/${packagerelease}%{dist}/" \
+            "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# this should all take place in a package-build directory
+rpmbuilddir="${builddir}/citus-rpm-build"
+mkdir -p "${rpmbuilddir}"
+
+pkgsrcdir="${builddir}/${pkgname}-${packageversion}"
+mkdir "${pkgsrcdir}"
+
+download=$(mktemp)
+tarballurl="https://api.github.com/repos/${repopath}/tarball/${gitsha}"
+curl -sL "${tarballurl}" -o "${download}"
+
+tarballpath="${rpmbuilddir}/${gitsha}"
+tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
+
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
+
+# force our URL and expanded folder names into spec
+sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
+          -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \
+          -e "/^%global pgpackageversion/s/[0-9.]+$/${PGVERSION}/" \
+    "${builddir}/${pkgname}.spec"
+
+os_name=$(awk '{print $1}' /etc/system-release)
+os_release=$(awk '{print $4}' /etc/system-release)
+if [ "${os_name}" == 'Oracle' ]; then
+    locale='C'
+elif [ "${os_name}" == 'Fedora' ] || [[ "${os_name}" == 'CentOS'  && "${os_release}" == 8* ]]; then
+    locale='C.utf8'
+else
+    locale='en_US.utf8'
+fi
+
+# add minor/major version to package name if using fancy versioning
+if [ "${versioning}" == 'fancy' ]; then
+  infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+  if [ "${release_type}" == "stable" ]; then
+      package_prefix="${infix}"
+  else
+      package_prefix="${infix}_${release_type}"
+  fi
+  sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+fi
+
+# add a changelog entry into nightly build
+case "${1}" in
+    release)
+        # Changelogs for release builds are being added by packaging scripts and could not be autogenerated
+        # Therefore there is nothing to do for release builds
+        ;;
+    nightly)
+        msg="Nightly package. Built from ${nightlyref} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.git/0.0.git/' "${builddir}/${pkgname}.spec"
+        sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+        ;;
+    *)
+        msg="Custom package. Built from ${gitsha:0:7} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.pre/0.0.pre/' "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
+rpmbuild --define "_sourcedir ${rpmbuilddir}" \
+--define "_specdir ${rpmbuilddir}" \
+--define "_builddir ${rpmbuilddir}" \
+--define "_srcrpmdir ${rpmbuilddir}" \
+--define "_rpmdir ${rpmbuilddir}" \
+--define "conf_extra_version ${conf_extra_version}" \
+-bb "${builddir}/${pkgname}.spec"
+
+cp /citus-rpm-build/x86_64/*.rpm /packages

--- a/dockerfiles/almalinux-9-pg11/scripts/setup_submodules
+++ b/dockerfiles/almalinux-9-pg11/scripts/setup_submodules
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        # submodule.{SUBMODULE_NAME}.url
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
+
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
+    done

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -1,0 +1,117 @@
+# vim:set ft=dockerfile:
+FROM almalinux:9
+
+RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
+    )
+
+RUN yum -y update
+
+# FIXME: Hack around docker/docker#10180
+RUN ( yum install -y yum-plugin-ovl || yum install -y yum-plugin-ovl || touch /var/lib/rpm/* ) \
+    && yum clean all
+
+# Enable some other repos for some dependencies in OL/7 
+# see https://yum.oracle.com/getting-started.html#installing-from-oracle-linux-yum-server
+RUN [[ almalinux != oraclelinux ]] || [[ 9 != 7 ]] || ( \
+       yum install -y oraclelinux-release-el7 oracle-softwarecollection-release-el7 oracle-epel-release-el7  oraclelinux-developer-release-el7 \
+       && yum-config-manager --enable \
+            ol7_software_collections \
+            ol7_developer \
+            ol7_developer_EPEL \
+            ol7_optional_latest \
+            ol7_optional_archive \
+            ol7_u9_base \
+            ol7_security_validation \
+            ol7_addons \
+         )
+
+# lz4 1.8 is preloaded in oracle 7 however, lz4-devel is not loaded and only 1.7.5 version exists
+# in oracle 7 repos. So package from centos repo was used
+# There is no package in oracle repos for lz4. Also it is not preloaded. So both lz4 and lz4-devel packages
+# were downloaded from centos el/6 repos
+RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wget \
+        && wget http://mirror.centos.org/centos/7/os/x86_64/Packages/lz4-devel-1.8.3-1.el7.x86_64.rpm \
+        && rpm -ivh lz4-devel-1.8.3-1.el7.x86_64.rpm ; \
+        elif [[ almalinux   == oraclelinux ]] && [[ 9 == 6 ]]; then yum install -y wget \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-r131-1.el6.x86_64.rpm \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-devel-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-devel-r131-1.el6.x86_64.rpm;  \
+        else yum install -y lz4 lz4-devel; fi
+
+# install build tools and PostgreSQL development files
+RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
+    && [[ -z "epel-release" ]] || yum install -y epel-release) \
+    && yum groupinstall -y 'Development Tools' \
+    && yum install -y \
+        flex \
+        gcc-c++ \
+        hunspell-en \
+        libcurl-devel \
+        libicu-devel \
+        libstdc++-devel \
+        libxml2-devel \
+        libxslt-devel \
+        openssl-devel \
+        pam-devel \
+        readline-devel \
+        rpm-build \
+        rpmlint \
+        tar \
+        libzstd \
+        libzstd-devel \
+        llvm-toolset ccache rpmdevtools krb5-devel \
+    && ( [[ 9 != 8 ]] || dnf -qy module disable postgresql ) \
+    && yum install -y postgresql12-server postgresql12-devel \
+    && yum clean all
+
+# install jq to process JSON API responses
+RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+         -o /usr/bin/jq \
+    && chmod +x /usr/bin/jq
+
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
+    } \
+    && yum clean all
+
+# install sphinx on distros with python3
+RUN { \
+        { yum search python3-pip 2>&1 | grep 'No matches found' ; } \
+        || { \
+            yum install -y python3-pip && \
+            pip3 install sphinx==1.8 \
+            ; \
+        } \
+    } \
+    && yum clean all
+
+# install cmake, devtoolset and its dependencies to build azure sdk
+RUN yum -y install  perl-IPC-Cmd libuuid-devel cmake3
+
+# by default git 1.8.x is being installed in centos 7
+# Git 2.7.1 is minimum requirement for cmake so we remove and reinstall latests git from an up-to-date repo
+# Symbolic link is not being created for cmake from cmake3 by default. Therefore, we need to create the link as well.
+# devtoolset-8-gcc-c++ is required to compile azure sdk in pg azure storage project
+RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
+    yum -y install  perl-IPC-Cmd libuuid-devel cmake3 && \
+    ln -s /usr/bin/cmake3 /usr/bin/cmake  && \
+    yum -y remove git && \
+    yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && \
+    yum -y install git && \
+    yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
+
+RUN touch /rpmlintrc \
+    && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
+
+# set PostgreSQL version, place scripts on path, and declare output volume
+ENV PGVERSION=12 \
+    PATH=/scripts:$PATH
+COPY scripts /scripts
+VOLUME /packages
+
+ENTRYPOINT ["/scripts/fetch_and_build_rpm"]

--- a/dockerfiles/almalinux-9-pg12/scripts/determine_email
+++ b/dockerfiles/almalinux-9-pg12/scripts/determine_email
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# make bash behave
+set -uo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+# fallback to public email
+email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
+
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
+citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
+
+if [ -n "${citusemail}" ]; then
+    email="${citusemail}"
+fi
+
+if [ -z "${email}" ]; then
+    echo "$0: could not determine email" >&2
+    exit $failure
+fi
+
+echo "${email}"
+exit $success

--- a/dockerfiles/almalinux-9-pg12/scripts/determine_name
+++ b/dockerfiles/almalinux-9-pg12/scripts/determine_name
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+fullname=$(curl -sf https://api.github.com/user | jq -r '.name // empty')
+
+if [ -z "${fullname}" ]; then
+    echo "$0: could not determine user name" >&2
+    exit $failure
+fi
+
+echo "${fullname}"
+exit $success

--- a/dockerfiles/almalinux-9-pg12/scripts/fetch_and_build_rpm
+++ b/dockerfiles/almalinux-9-pg12/scripts/fetch_and_build_rpm
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+# In one branch we execute commands inside One Branch steps, since One Branch does not allow executing docker inside
+# docker. Additionally, Onebranch needs containers not to close so we make it hang for OneBranch to be able to
+# execute commands.
+if [ "${CONTAINER_BUILD_RUN_ENABLED:-""}" == "" ]; then
+  echo "INFO: Image working in waiting mode. Not executing build script"
+  tail -f /dev/null
+fi
+
+IFS=$'\n\t'
+
+# constants
+stdout=1
+stderr=2
+success=0
+failure=1
+badusage=64
+noinput=66
+
+nextversion='0.0.0'
+builddir=$(pwd)
+
+# outputs usage message on specified device before exiting with provided status
+usage() {
+    cat << 'E_O_USAGE' >&"$1"
+usage: fetch_and_build_rpm build_type build_directory
+
+    build_type: 'release', 'nightly', or a valid git reference
+
+fetch_and_build_rpm builds Red Hat packages using local build files. The build
+type 'release' builds the latest release tag, 'nightly' builds a nightly from
+the latest 'master' commit, and any other type is interpreted as a git ref to
+facilitate building one-off packages for customers.
+E_O_USAGE
+
+    exit "${2}";
+}
+
+# sets the next version variable used during non-release builds
+setnextversion() {
+    # First line replaces '~' and '_' characters and splits the version by '-' and gets the first
+    # from the array.
+    # Second line strips '.citus' suffix
+    # e.g. input->11.0.0_beta-1.citus; output->11.0.0
+    baseversion=$(echo "$1" | tr '~' '-' | tr '_' '-' | cut -d- -f1)
+    baseversion="${baseversion%.citus}"
+    nextversion=$(echo "$baseversion" | perl -pe 's/^(\d+\.)(\d+)(\.\d+)$/$1.($2+1).".0"/e')
+}
+
+if [ "$#" -ne 1 ]; then
+    usage $stderr $badusage
+fi
+
+if [ "${1}" = '-h' ]; then
+    usage $stdout $success
+fi
+
+# populate variables from packaging metadata file
+# shellcheck source=/dev/null
+source /buildfiles/pkgvars
+
+# set default values for certain packaging variables
+declare pkglatest # to make shellcheck happy
+pkgname="${rpm_pkgname:-${pkgname}}"
+hubproj="${hubproj:-${pkgname}}"
+nightlyref="${nightlyref:-master}"
+releasepg="${releasepg:-11,12,13}"
+nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
+if [[ "${pkglatest}" == *"beta"* ]]; then
+    release_type="beta"
+else
+    release_type="stable"
+fi
+
+if [ -z "${pkglatest}" ]; then
+    echo "$0: pkgvars file must specify a value for pkglatest" >&2
+    exit $noinput
+fi
+
+echo "header=\"Authorization: token ${GITHUB_TOKEN}\"" > ~/.curlrc
+
+name=$(determine_name)
+email=$(determine_email)
+export RPM_PACKAGER="${name} <${email}>"
+
+cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
+repopath="citusdata/${hubproj}"
+
+case "${1}" in
+    release)
+        packageversion=${pkglatest%-*}
+        releasetag="v${packageversion%.citus}"
+
+        # Since the only part of the release version after '-' character is fancy version, package release
+        # will alwayse be empty string. So the releasetag is always equal to packageversion
+        packagerelease=$(echo "${pkglatest#*-}" | sed -E 's/^[0-9.]+//')
+        if [ -n "${packagerelease}" ]; then
+            releasetag="v${packageversion}-${packagerelease}"
+        fi
+
+        conf_extra_version="%{nil}"
+
+        gitsha=$(curl -s "https://api.github.com/repos/${repopath}/git/refs/tags/${releasetag}" | \
+                 jq -r '.object.sha')
+        if [ "${gitsha}" == 'null' ]; then
+            echo "$0: could not determine commit for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+
+        verified=$(curl -sH 'Accept:application/vnd.github.cryptographer-preview+sha' \
+                   "https://api.github.com/repos/${repopath}/git/tags/${gitsha}" | \
+                   jq -r '.verification.verified')
+        if [ "${verified}" != 'true' ]; then
+            echo "$0: could not verify signature for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+        ;;
+    *)
+        if [ "${1}" == 'nightly' ]; then
+            ref=${nightlyref}
+            infix='git'
+        else
+            ref=${1}
+            infix='pre'
+        fi
+
+        setnextversion "${pkglatest}"
+
+        set +e
+        gitsha=$(curl -sfH 'Accept:application/vnd.github.v3.sha' \
+                 "https://api.github.com/repos/${repopath}/commits/${ref}")
+        if [ "${?}" -ne 0 ]; then
+            echo "$0: could not determine commit for git ref ${ref}" >&2
+            exit $failure
+        fi
+        set -e
+
+        packageversion="${nextversion}.citus"
+        timestamp=$(date +'%Y%m%d')
+        packagesuffix="${infix}.${timestamp}.${gitsha:0:7}"
+        packagerelease="0.0.${packagesuffix}"
+        conf_extra_version="+${packagesuffix}"
+
+        sed -i -E -e "/^Version:/s/[^ \\t]*$/${packageversion}/" \
+                  -e "/^Release:/s/[^ \\t]*$/${packagerelease}%{dist}/" \
+            "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# this should all take place in a package-build directory
+rpmbuilddir="${builddir}/citus-rpm-build"
+mkdir -p "${rpmbuilddir}"
+
+pkgsrcdir="${builddir}/${pkgname}-${packageversion}"
+mkdir "${pkgsrcdir}"
+
+download=$(mktemp)
+tarballurl="https://api.github.com/repos/${repopath}/tarball/${gitsha}"
+curl -sL "${tarballurl}" -o "${download}"
+
+tarballpath="${rpmbuilddir}/${gitsha}"
+tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
+
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
+
+# force our URL and expanded folder names into spec
+sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
+          -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \
+          -e "/^%global pgpackageversion/s/[0-9.]+$/${PGVERSION}/" \
+    "${builddir}/${pkgname}.spec"
+
+os_name=$(awk '{print $1}' /etc/system-release)
+os_release=$(awk '{print $4}' /etc/system-release)
+if [ "${os_name}" == 'Oracle' ]; then
+    locale='C'
+elif [ "${os_name}" == 'Fedora' ] || [[ "${os_name}" == 'CentOS'  && "${os_release}" == 8* ]]; then
+    locale='C.utf8'
+else
+    locale='en_US.utf8'
+fi
+
+# add minor/major version to package name if using fancy versioning
+if [ "${versioning}" == 'fancy' ]; then
+  infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+  if [ "${release_type}" == "stable" ]; then
+      package_prefix="${infix}"
+  else
+      package_prefix="${infix}_${release_type}"
+  fi
+  sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+fi
+
+# add a changelog entry into nightly build
+case "${1}" in
+    release)
+        # Changelogs for release builds are being added by packaging scripts and could not be autogenerated
+        # Therefore there is nothing to do for release builds
+        ;;
+    nightly)
+        msg="Nightly package. Built from ${nightlyref} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.git/0.0.git/' "${builddir}/${pkgname}.spec"
+        sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+        ;;
+    *)
+        msg="Custom package. Built from ${gitsha:0:7} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.pre/0.0.pre/' "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
+rpmbuild --define "_sourcedir ${rpmbuilddir}" \
+--define "_specdir ${rpmbuilddir}" \
+--define "_builddir ${rpmbuilddir}" \
+--define "_srcrpmdir ${rpmbuilddir}" \
+--define "_rpmdir ${rpmbuilddir}" \
+--define "conf_extra_version ${conf_extra_version}" \
+-bb "${builddir}/${pkgname}.spec"
+
+cp /citus-rpm-build/x86_64/*.rpm /packages

--- a/dockerfiles/almalinux-9-pg12/scripts/setup_submodules
+++ b/dockerfiles/almalinux-9-pg12/scripts/setup_submodules
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        # submodule.{SUBMODULE_NAME}.url
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
+
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
+    done

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -1,0 +1,117 @@
+# vim:set ft=dockerfile:
+FROM almalinux:9
+
+RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
+    )
+
+RUN yum -y update
+
+# FIXME: Hack around docker/docker#10180
+RUN ( yum install -y yum-plugin-ovl || yum install -y yum-plugin-ovl || touch /var/lib/rpm/* ) \
+    && yum clean all
+
+# Enable some other repos for some dependencies in OL/7 
+# see https://yum.oracle.com/getting-started.html#installing-from-oracle-linux-yum-server
+RUN [[ almalinux != oraclelinux ]] || [[ 9 != 7 ]] || ( \
+       yum install -y oraclelinux-release-el7 oracle-softwarecollection-release-el7 oracle-epel-release-el7  oraclelinux-developer-release-el7 \
+       && yum-config-manager --enable \
+            ol7_software_collections \
+            ol7_developer \
+            ol7_developer_EPEL \
+            ol7_optional_latest \
+            ol7_optional_archive \
+            ol7_u9_base \
+            ol7_security_validation \
+            ol7_addons \
+         )
+
+# lz4 1.8 is preloaded in oracle 7 however, lz4-devel is not loaded and only 1.7.5 version exists
+# in oracle 7 repos. So package from centos repo was used
+# There is no package in oracle repos for lz4. Also it is not preloaded. So both lz4 and lz4-devel packages
+# were downloaded from centos el/6 repos
+RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wget \
+        && wget http://mirror.centos.org/centos/7/os/x86_64/Packages/lz4-devel-1.8.3-1.el7.x86_64.rpm \
+        && rpm -ivh lz4-devel-1.8.3-1.el7.x86_64.rpm ; \
+        elif [[ almalinux   == oraclelinux ]] && [[ 9 == 6 ]]; then yum install -y wget \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-r131-1.el6.x86_64.rpm \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-devel-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-devel-r131-1.el6.x86_64.rpm;  \
+        else yum install -y lz4 lz4-devel; fi
+
+# install build tools and PostgreSQL development files
+RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
+    && [[ -z "epel-release" ]] || yum install -y epel-release) \
+    && yum groupinstall -y 'Development Tools' \
+    && yum install -y \
+        flex \
+        gcc-c++ \
+        hunspell-en \
+        libcurl-devel \
+        libicu-devel \
+        libstdc++-devel \
+        libxml2-devel \
+        libxslt-devel \
+        openssl-devel \
+        pam-devel \
+        readline-devel \
+        rpm-build \
+        rpmlint \
+        tar \
+        libzstd \
+        libzstd-devel \
+        llvm-toolset ccache rpmdevtools krb5-devel \
+    && ( [[ 9 != 8 ]] || dnf -qy module disable postgresql ) \
+    && yum install -y postgresql13-server postgresql13-devel \
+    && yum clean all
+
+# install jq to process JSON API responses
+RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+         -o /usr/bin/jq \
+    && chmod +x /usr/bin/jq
+
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
+    } \
+    && yum clean all
+
+# install sphinx on distros with python3
+RUN { \
+        { yum search python3-pip 2>&1 | grep 'No matches found' ; } \
+        || { \
+            yum install -y python3-pip && \
+            pip3 install sphinx==1.8 \
+            ; \
+        } \
+    } \
+    && yum clean all
+
+# install cmake, devtoolset and its dependencies to build azure sdk
+RUN yum -y install  perl-IPC-Cmd libuuid-devel cmake3
+
+# by default git 1.8.x is being installed in centos 7
+# Git 2.7.1 is minimum requirement for cmake so we remove and reinstall latests git from an up-to-date repo
+# Symbolic link is not being created for cmake from cmake3 by default. Therefore, we need to create the link as well.
+# devtoolset-8-gcc-c++ is required to compile azure sdk in pg azure storage project
+RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
+    yum -y install  perl-IPC-Cmd libuuid-devel cmake3 && \
+    ln -s /usr/bin/cmake3 /usr/bin/cmake  && \
+    yum -y remove git && \
+    yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && \
+    yum -y install git && \
+    yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
+
+RUN touch /rpmlintrc \
+    && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
+
+# set PostgreSQL version, place scripts on path, and declare output volume
+ENV PGVERSION=13 \
+    PATH=/scripts:$PATH
+COPY scripts /scripts
+VOLUME /packages
+
+ENTRYPOINT ["/scripts/fetch_and_build_rpm"]

--- a/dockerfiles/almalinux-9-pg13/scripts/determine_email
+++ b/dockerfiles/almalinux-9-pg13/scripts/determine_email
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# make bash behave
+set -uo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+# fallback to public email
+email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
+
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
+citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
+
+if [ -n "${citusemail}" ]; then
+    email="${citusemail}"
+fi
+
+if [ -z "${email}" ]; then
+    echo "$0: could not determine email" >&2
+    exit $failure
+fi
+
+echo "${email}"
+exit $success

--- a/dockerfiles/almalinux-9-pg13/scripts/determine_name
+++ b/dockerfiles/almalinux-9-pg13/scripts/determine_name
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+fullname=$(curl -sf https://api.github.com/user | jq -r '.name // empty')
+
+if [ -z "${fullname}" ]; then
+    echo "$0: could not determine user name" >&2
+    exit $failure
+fi
+
+echo "${fullname}"
+exit $success

--- a/dockerfiles/almalinux-9-pg13/scripts/fetch_and_build_rpm
+++ b/dockerfiles/almalinux-9-pg13/scripts/fetch_and_build_rpm
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+# In one branch we execute commands inside One Branch steps, since One Branch does not allow executing docker inside
+# docker. Additionally, Onebranch needs containers not to close so we make it hang for OneBranch to be able to
+# execute commands.
+if [ "${CONTAINER_BUILD_RUN_ENABLED:-""}" == "" ]; then
+  echo "INFO: Image working in waiting mode. Not executing build script"
+  tail -f /dev/null
+fi
+
+IFS=$'\n\t'
+
+# constants
+stdout=1
+stderr=2
+success=0
+failure=1
+badusage=64
+noinput=66
+
+nextversion='0.0.0'
+builddir=$(pwd)
+
+# outputs usage message on specified device before exiting with provided status
+usage() {
+    cat << 'E_O_USAGE' >&"$1"
+usage: fetch_and_build_rpm build_type build_directory
+
+    build_type: 'release', 'nightly', or a valid git reference
+
+fetch_and_build_rpm builds Red Hat packages using local build files. The build
+type 'release' builds the latest release tag, 'nightly' builds a nightly from
+the latest 'master' commit, and any other type is interpreted as a git ref to
+facilitate building one-off packages for customers.
+E_O_USAGE
+
+    exit "${2}";
+}
+
+# sets the next version variable used during non-release builds
+setnextversion() {
+    # First line replaces '~' and '_' characters and splits the version by '-' and gets the first
+    # from the array.
+    # Second line strips '.citus' suffix
+    # e.g. input->11.0.0_beta-1.citus; output->11.0.0
+    baseversion=$(echo "$1" | tr '~' '-' | tr '_' '-' | cut -d- -f1)
+    baseversion="${baseversion%.citus}"
+    nextversion=$(echo "$baseversion" | perl -pe 's/^(\d+\.)(\d+)(\.\d+)$/$1.($2+1).".0"/e')
+}
+
+if [ "$#" -ne 1 ]; then
+    usage $stderr $badusage
+fi
+
+if [ "${1}" = '-h' ]; then
+    usage $stdout $success
+fi
+
+# populate variables from packaging metadata file
+# shellcheck source=/dev/null
+source /buildfiles/pkgvars
+
+# set default values for certain packaging variables
+declare pkglatest # to make shellcheck happy
+pkgname="${rpm_pkgname:-${pkgname}}"
+hubproj="${hubproj:-${pkgname}}"
+nightlyref="${nightlyref:-master}"
+releasepg="${releasepg:-11,12,13}"
+nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
+if [[ "${pkglatest}" == *"beta"* ]]; then
+    release_type="beta"
+else
+    release_type="stable"
+fi
+
+if [ -z "${pkglatest}" ]; then
+    echo "$0: pkgvars file must specify a value for pkglatest" >&2
+    exit $noinput
+fi
+
+echo "header=\"Authorization: token ${GITHUB_TOKEN}\"" > ~/.curlrc
+
+name=$(determine_name)
+email=$(determine_email)
+export RPM_PACKAGER="${name} <${email}>"
+
+cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
+repopath="citusdata/${hubproj}"
+
+case "${1}" in
+    release)
+        packageversion=${pkglatest%-*}
+        releasetag="v${packageversion%.citus}"
+
+        # Since the only part of the release version after '-' character is fancy version, package release
+        # will alwayse be empty string. So the releasetag is always equal to packageversion
+        packagerelease=$(echo "${pkglatest#*-}" | sed -E 's/^[0-9.]+//')
+        if [ -n "${packagerelease}" ]; then
+            releasetag="v${packageversion}-${packagerelease}"
+        fi
+
+        conf_extra_version="%{nil}"
+
+        gitsha=$(curl -s "https://api.github.com/repos/${repopath}/git/refs/tags/${releasetag}" | \
+                 jq -r '.object.sha')
+        if [ "${gitsha}" == 'null' ]; then
+            echo "$0: could not determine commit for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+
+        verified=$(curl -sH 'Accept:application/vnd.github.cryptographer-preview+sha' \
+                   "https://api.github.com/repos/${repopath}/git/tags/${gitsha}" | \
+                   jq -r '.verification.verified')
+        if [ "${verified}" != 'true' ]; then
+            echo "$0: could not verify signature for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+        ;;
+    *)
+        if [ "${1}" == 'nightly' ]; then
+            ref=${nightlyref}
+            infix='git'
+        else
+            ref=${1}
+            infix='pre'
+        fi
+
+        setnextversion "${pkglatest}"
+
+        set +e
+        gitsha=$(curl -sfH 'Accept:application/vnd.github.v3.sha' \
+                 "https://api.github.com/repos/${repopath}/commits/${ref}")
+        if [ "${?}" -ne 0 ]; then
+            echo "$0: could not determine commit for git ref ${ref}" >&2
+            exit $failure
+        fi
+        set -e
+
+        packageversion="${nextversion}.citus"
+        timestamp=$(date +'%Y%m%d')
+        packagesuffix="${infix}.${timestamp}.${gitsha:0:7}"
+        packagerelease="0.0.${packagesuffix}"
+        conf_extra_version="+${packagesuffix}"
+
+        sed -i -E -e "/^Version:/s/[^ \\t]*$/${packageversion}/" \
+                  -e "/^Release:/s/[^ \\t]*$/${packagerelease}%{dist}/" \
+            "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# this should all take place in a package-build directory
+rpmbuilddir="${builddir}/citus-rpm-build"
+mkdir -p "${rpmbuilddir}"
+
+pkgsrcdir="${builddir}/${pkgname}-${packageversion}"
+mkdir "${pkgsrcdir}"
+
+download=$(mktemp)
+tarballurl="https://api.github.com/repos/${repopath}/tarball/${gitsha}"
+curl -sL "${tarballurl}" -o "${download}"
+
+tarballpath="${rpmbuilddir}/${gitsha}"
+tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
+
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
+
+# force our URL and expanded folder names into spec
+sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
+          -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \
+          -e "/^%global pgpackageversion/s/[0-9.]+$/${PGVERSION}/" \
+    "${builddir}/${pkgname}.spec"
+
+os_name=$(awk '{print $1}' /etc/system-release)
+os_release=$(awk '{print $4}' /etc/system-release)
+if [ "${os_name}" == 'Oracle' ]; then
+    locale='C'
+elif [ "${os_name}" == 'Fedora' ] || [[ "${os_name}" == 'CentOS'  && "${os_release}" == 8* ]]; then
+    locale='C.utf8'
+else
+    locale='en_US.utf8'
+fi
+
+# add minor/major version to package name if using fancy versioning
+if [ "${versioning}" == 'fancy' ]; then
+  infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+  if [ "${release_type}" == "stable" ]; then
+      package_prefix="${infix}"
+  else
+      package_prefix="${infix}_${release_type}"
+  fi
+  sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+fi
+
+# add a changelog entry into nightly build
+case "${1}" in
+    release)
+        # Changelogs for release builds are being added by packaging scripts and could not be autogenerated
+        # Therefore there is nothing to do for release builds
+        ;;
+    nightly)
+        msg="Nightly package. Built from ${nightlyref} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.git/0.0.git/' "${builddir}/${pkgname}.spec"
+        sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+        ;;
+    *)
+        msg="Custom package. Built from ${gitsha:0:7} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.pre/0.0.pre/' "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
+rpmbuild --define "_sourcedir ${rpmbuilddir}" \
+--define "_specdir ${rpmbuilddir}" \
+--define "_builddir ${rpmbuilddir}" \
+--define "_srcrpmdir ${rpmbuilddir}" \
+--define "_rpmdir ${rpmbuilddir}" \
+--define "conf_extra_version ${conf_extra_version}" \
+-bb "${builddir}/${pkgname}.spec"
+
+cp /citus-rpm-build/x86_64/*.rpm /packages

--- a/dockerfiles/almalinux-9-pg13/scripts/setup_submodules
+++ b/dockerfiles/almalinux-9-pg13/scripts/setup_submodules
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        # submodule.{SUBMODULE_NAME}.url
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
+
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
+    done

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -1,0 +1,117 @@
+# vim:set ft=dockerfile:
+FROM almalinux:9
+
+RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
+    )
+
+RUN yum -y update
+
+# FIXME: Hack around docker/docker#10180
+RUN ( yum install -y yum-plugin-ovl || yum install -y yum-plugin-ovl || touch /var/lib/rpm/* ) \
+    && yum clean all
+
+# Enable some other repos for some dependencies in OL/7 
+# see https://yum.oracle.com/getting-started.html#installing-from-oracle-linux-yum-server
+RUN [[ almalinux != oraclelinux ]] || [[ 9 != 7 ]] || ( \
+       yum install -y oraclelinux-release-el7 oracle-softwarecollection-release-el7 oracle-epel-release-el7  oraclelinux-developer-release-el7 \
+       && yum-config-manager --enable \
+            ol7_software_collections \
+            ol7_developer \
+            ol7_developer_EPEL \
+            ol7_optional_latest \
+            ol7_optional_archive \
+            ol7_u9_base \
+            ol7_security_validation \
+            ol7_addons \
+         )
+
+# lz4 1.8 is preloaded in oracle 7 however, lz4-devel is not loaded and only 1.7.5 version exists
+# in oracle 7 repos. So package from centos repo was used
+# There is no package in oracle repos for lz4. Also it is not preloaded. So both lz4 and lz4-devel packages
+# were downloaded from centos el/6 repos
+RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wget \
+        && wget http://mirror.centos.org/centos/7/os/x86_64/Packages/lz4-devel-1.8.3-1.el7.x86_64.rpm \
+        && rpm -ivh lz4-devel-1.8.3-1.el7.x86_64.rpm ; \
+        elif [[ almalinux   == oraclelinux ]] && [[ 9 == 6 ]]; then yum install -y wget \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-r131-1.el6.x86_64.rpm \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-devel-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-devel-r131-1.el6.x86_64.rpm;  \
+        else yum install -y lz4 lz4-devel; fi
+
+# install build tools and PostgreSQL development files
+RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
+    && [[ -z "epel-release" ]] || yum install -y epel-release) \
+    && yum groupinstall -y 'Development Tools' \
+    && yum install -y \
+        flex \
+        gcc-c++ \
+        hunspell-en \
+        libcurl-devel \
+        libicu-devel \
+        libstdc++-devel \
+        libxml2-devel \
+        libxslt-devel \
+        openssl-devel \
+        pam-devel \
+        readline-devel \
+        rpm-build \
+        rpmlint \
+        tar \
+        libzstd \
+        libzstd-devel \
+        llvm-toolset ccache rpmdevtools krb5-devel \
+    && ( [[ 9 != 8 ]] || dnf -qy module disable postgresql ) \
+    && yum install -y postgresql14-server postgresql14-devel \
+    && yum clean all
+
+# install jq to process JSON API responses
+RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+         -o /usr/bin/jq \
+    && chmod +x /usr/bin/jq
+
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
+    } \
+    && yum clean all
+
+# install sphinx on distros with python3
+RUN { \
+        { yum search python3-pip 2>&1 | grep 'No matches found' ; } \
+        || { \
+            yum install -y python3-pip && \
+            pip3 install sphinx==1.8 \
+            ; \
+        } \
+    } \
+    && yum clean all
+
+# install cmake, devtoolset and its dependencies to build azure sdk
+RUN yum -y install  perl-IPC-Cmd libuuid-devel cmake3
+
+# by default git 1.8.x is being installed in centos 7
+# Git 2.7.1 is minimum requirement for cmake so we remove and reinstall latests git from an up-to-date repo
+# Symbolic link is not being created for cmake from cmake3 by default. Therefore, we need to create the link as well.
+# devtoolset-8-gcc-c++ is required to compile azure sdk in pg azure storage project
+RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
+    yum -y install  perl-IPC-Cmd libuuid-devel cmake3 && \
+    ln -s /usr/bin/cmake3 /usr/bin/cmake  && \
+    yum -y remove git && \
+    yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && \
+    yum -y install git && \
+    yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
+
+RUN touch /rpmlintrc \
+    && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
+
+# set PostgreSQL version, place scripts on path, and declare output volume
+ENV PGVERSION=14 \
+    PATH=/scripts:$PATH
+COPY scripts /scripts
+VOLUME /packages
+
+ENTRYPOINT ["/scripts/fetch_and_build_rpm"]

--- a/dockerfiles/almalinux-9-pg14/scripts/determine_email
+++ b/dockerfiles/almalinux-9-pg14/scripts/determine_email
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# make bash behave
+set -uo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+# fallback to public email
+email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
+
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
+citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
+
+if [ -n "${citusemail}" ]; then
+    email="${citusemail}"
+fi
+
+if [ -z "${email}" ]; then
+    echo "$0: could not determine email" >&2
+    exit $failure
+fi
+
+echo "${email}"
+exit $success

--- a/dockerfiles/almalinux-9-pg14/scripts/determine_name
+++ b/dockerfiles/almalinux-9-pg14/scripts/determine_name
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+fullname=$(curl -sf https://api.github.com/user | jq -r '.name // empty')
+
+if [ -z "${fullname}" ]; then
+    echo "$0: could not determine user name" >&2
+    exit $failure
+fi
+
+echo "${fullname}"
+exit $success

--- a/dockerfiles/almalinux-9-pg14/scripts/fetch_and_build_rpm
+++ b/dockerfiles/almalinux-9-pg14/scripts/fetch_and_build_rpm
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+# In one branch we execute commands inside One Branch steps, since One Branch does not allow executing docker inside
+# docker. Additionally, Onebranch needs containers not to close so we make it hang for OneBranch to be able to
+# execute commands.
+if [ "${CONTAINER_BUILD_RUN_ENABLED:-""}" == "" ]; then
+  echo "INFO: Image working in waiting mode. Not executing build script"
+  tail -f /dev/null
+fi
+
+IFS=$'\n\t'
+
+# constants
+stdout=1
+stderr=2
+success=0
+failure=1
+badusage=64
+noinput=66
+
+nextversion='0.0.0'
+builddir=$(pwd)
+
+# outputs usage message on specified device before exiting with provided status
+usage() {
+    cat << 'E_O_USAGE' >&"$1"
+usage: fetch_and_build_rpm build_type build_directory
+
+    build_type: 'release', 'nightly', or a valid git reference
+
+fetch_and_build_rpm builds Red Hat packages using local build files. The build
+type 'release' builds the latest release tag, 'nightly' builds a nightly from
+the latest 'master' commit, and any other type is interpreted as a git ref to
+facilitate building one-off packages for customers.
+E_O_USAGE
+
+    exit "${2}";
+}
+
+# sets the next version variable used during non-release builds
+setnextversion() {
+    # First line replaces '~' and '_' characters and splits the version by '-' and gets the first
+    # from the array.
+    # Second line strips '.citus' suffix
+    # e.g. input->11.0.0_beta-1.citus; output->11.0.0
+    baseversion=$(echo "$1" | tr '~' '-' | tr '_' '-' | cut -d- -f1)
+    baseversion="${baseversion%.citus}"
+    nextversion=$(echo "$baseversion" | perl -pe 's/^(\d+\.)(\d+)(\.\d+)$/$1.($2+1).".0"/e')
+}
+
+if [ "$#" -ne 1 ]; then
+    usage $stderr $badusage
+fi
+
+if [ "${1}" = '-h' ]; then
+    usage $stdout $success
+fi
+
+# populate variables from packaging metadata file
+# shellcheck source=/dev/null
+source /buildfiles/pkgvars
+
+# set default values for certain packaging variables
+declare pkglatest # to make shellcheck happy
+pkgname="${rpm_pkgname:-${pkgname}}"
+hubproj="${hubproj:-${pkgname}}"
+nightlyref="${nightlyref:-master}"
+releasepg="${releasepg:-11,12,13}"
+nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
+if [[ "${pkglatest}" == *"beta"* ]]; then
+    release_type="beta"
+else
+    release_type="stable"
+fi
+
+if [ -z "${pkglatest}" ]; then
+    echo "$0: pkgvars file must specify a value for pkglatest" >&2
+    exit $noinput
+fi
+
+echo "header=\"Authorization: token ${GITHUB_TOKEN}\"" > ~/.curlrc
+
+name=$(determine_name)
+email=$(determine_email)
+export RPM_PACKAGER="${name} <${email}>"
+
+cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
+repopath="citusdata/${hubproj}"
+
+case "${1}" in
+    release)
+        packageversion=${pkglatest%-*}
+        releasetag="v${packageversion%.citus}"
+
+        # Since the only part of the release version after '-' character is fancy version, package release
+        # will alwayse be empty string. So the releasetag is always equal to packageversion
+        packagerelease=$(echo "${pkglatest#*-}" | sed -E 's/^[0-9.]+//')
+        if [ -n "${packagerelease}" ]; then
+            releasetag="v${packageversion}-${packagerelease}"
+        fi
+
+        conf_extra_version="%{nil}"
+
+        gitsha=$(curl -s "https://api.github.com/repos/${repopath}/git/refs/tags/${releasetag}" | \
+                 jq -r '.object.sha')
+        if [ "${gitsha}" == 'null' ]; then
+            echo "$0: could not determine commit for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+
+        verified=$(curl -sH 'Accept:application/vnd.github.cryptographer-preview+sha' \
+                   "https://api.github.com/repos/${repopath}/git/tags/${gitsha}" | \
+                   jq -r '.verification.verified')
+        if [ "${verified}" != 'true' ]; then
+            echo "$0: could not verify signature for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+        ;;
+    *)
+        if [ "${1}" == 'nightly' ]; then
+            ref=${nightlyref}
+            infix='git'
+        else
+            ref=${1}
+            infix='pre'
+        fi
+
+        setnextversion "${pkglatest}"
+
+        set +e
+        gitsha=$(curl -sfH 'Accept:application/vnd.github.v3.sha' \
+                 "https://api.github.com/repos/${repopath}/commits/${ref}")
+        if [ "${?}" -ne 0 ]; then
+            echo "$0: could not determine commit for git ref ${ref}" >&2
+            exit $failure
+        fi
+        set -e
+
+        packageversion="${nextversion}.citus"
+        timestamp=$(date +'%Y%m%d')
+        packagesuffix="${infix}.${timestamp}.${gitsha:0:7}"
+        packagerelease="0.0.${packagesuffix}"
+        conf_extra_version="+${packagesuffix}"
+
+        sed -i -E -e "/^Version:/s/[^ \\t]*$/${packageversion}/" \
+                  -e "/^Release:/s/[^ \\t]*$/${packagerelease}%{dist}/" \
+            "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# this should all take place in a package-build directory
+rpmbuilddir="${builddir}/citus-rpm-build"
+mkdir -p "${rpmbuilddir}"
+
+pkgsrcdir="${builddir}/${pkgname}-${packageversion}"
+mkdir "${pkgsrcdir}"
+
+download=$(mktemp)
+tarballurl="https://api.github.com/repos/${repopath}/tarball/${gitsha}"
+curl -sL "${tarballurl}" -o "${download}"
+
+tarballpath="${rpmbuilddir}/${gitsha}"
+tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
+
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
+
+# force our URL and expanded folder names into spec
+sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
+          -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \
+          -e "/^%global pgpackageversion/s/[0-9.]+$/${PGVERSION}/" \
+    "${builddir}/${pkgname}.spec"
+
+os_name=$(awk '{print $1}' /etc/system-release)
+os_release=$(awk '{print $4}' /etc/system-release)
+if [ "${os_name}" == 'Oracle' ]; then
+    locale='C'
+elif [ "${os_name}" == 'Fedora' ] || [[ "${os_name}" == 'CentOS'  && "${os_release}" == 8* ]]; then
+    locale='C.utf8'
+else
+    locale='en_US.utf8'
+fi
+
+# add minor/major version to package name if using fancy versioning
+if [ "${versioning}" == 'fancy' ]; then
+  infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+  if [ "${release_type}" == "stable" ]; then
+      package_prefix="${infix}"
+  else
+      package_prefix="${infix}_${release_type}"
+  fi
+  sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+fi
+
+# add a changelog entry into nightly build
+case "${1}" in
+    release)
+        # Changelogs for release builds are being added by packaging scripts and could not be autogenerated
+        # Therefore there is nothing to do for release builds
+        ;;
+    nightly)
+        msg="Nightly package. Built from ${nightlyref} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.git/0.0.git/' "${builddir}/${pkgname}.spec"
+        sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+        ;;
+    *)
+        msg="Custom package. Built from ${gitsha:0:7} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.pre/0.0.pre/' "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
+rpmbuild --define "_sourcedir ${rpmbuilddir}" \
+--define "_specdir ${rpmbuilddir}" \
+--define "_builddir ${rpmbuilddir}" \
+--define "_srcrpmdir ${rpmbuilddir}" \
+--define "_rpmdir ${rpmbuilddir}" \
+--define "conf_extra_version ${conf_extra_version}" \
+-bb "${builddir}/${pkgname}.spec"
+
+cp /citus-rpm-build/x86_64/*.rpm /packages

--- a/dockerfiles/almalinux-9-pg14/scripts/setup_submodules
+++ b/dockerfiles/almalinux-9-pg14/scripts/setup_submodules
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        # submodule.{SUBMODULE_NAME}.url
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
+
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
+    done

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -1,0 +1,117 @@
+# vim:set ft=dockerfile:
+FROM almalinux:9
+
+RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
+    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
+    )
+
+RUN yum -y update
+
+# FIXME: Hack around docker/docker#10180
+RUN ( yum install -y yum-plugin-ovl || yum install -y yum-plugin-ovl || touch /var/lib/rpm/* ) \
+    && yum clean all
+
+# Enable some other repos for some dependencies in OL/7 
+# see https://yum.oracle.com/getting-started.html#installing-from-oracle-linux-yum-server
+RUN [[ almalinux != oraclelinux ]] || [[ 9 != 7 ]] || ( \
+       yum install -y oraclelinux-release-el7 oracle-softwarecollection-release-el7 oracle-epel-release-el7  oraclelinux-developer-release-el7 \
+       && yum-config-manager --enable \
+            ol7_software_collections \
+            ol7_developer \
+            ol7_developer_EPEL \
+            ol7_optional_latest \
+            ol7_optional_archive \
+            ol7_u9_base \
+            ol7_security_validation \
+            ol7_addons \
+         )
+
+# lz4 1.8 is preloaded in oracle 7 however, lz4-devel is not loaded and only 1.7.5 version exists
+# in oracle 7 repos. So package from centos repo was used
+# There is no package in oracle repos for lz4. Also it is not preloaded. So both lz4 and lz4-devel packages
+# were downloaded from centos el/6 repos
+RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wget \
+        && wget http://mirror.centos.org/centos/7/os/x86_64/Packages/lz4-devel-1.8.3-1.el7.x86_64.rpm \
+        && rpm -ivh lz4-devel-1.8.3-1.el7.x86_64.rpm ; \
+        elif [[ almalinux   == oraclelinux ]] && [[ 9 == 6 ]]; then yum install -y wget \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-r131-1.el6.x86_64.rpm \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-devel-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-devel-r131-1.el6.x86_64.rpm;  \
+        else yum install -y lz4 lz4-devel; fi
+
+# install build tools and PostgreSQL development files
+RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
+    && [[ -z "epel-release" ]] || yum install -y epel-release) \
+    && yum groupinstall -y 'Development Tools' \
+    && yum install -y \
+        flex \
+        gcc-c++ \
+        hunspell-en \
+        libcurl-devel \
+        libicu-devel \
+        libstdc++-devel \
+        libxml2-devel \
+        libxslt-devel \
+        openssl-devel \
+        pam-devel \
+        readline-devel \
+        rpm-build \
+        rpmlint \
+        tar \
+        libzstd \
+        libzstd-devel \
+        llvm-toolset ccache rpmdevtools krb5-devel \
+    && ( [[ 9 != 8 ]] || dnf -qy module disable postgresql ) \
+    && yum install -y postgresql15-server postgresql15-devel \
+    && yum clean all
+
+# install jq to process JSON API responses
+RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+         -o /usr/bin/jq \
+    && chmod +x /usr/bin/jq
+
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
+    } \
+    && yum clean all
+
+# install sphinx on distros with python3
+RUN { \
+        { yum search python3-pip 2>&1 | grep 'No matches found' ; } \
+        || { \
+            yum install -y python3-pip && \
+            pip3 install sphinx==1.8 \
+            ; \
+        } \
+    } \
+    && yum clean all
+
+# install cmake, devtoolset and its dependencies to build azure sdk
+RUN yum -y install  perl-IPC-Cmd libuuid-devel cmake3
+
+# by default git 1.8.x is being installed in centos 7
+# Git 2.7.1 is minimum requirement for cmake so we remove and reinstall latests git from an up-to-date repo
+# Symbolic link is not being created for cmake from cmake3 by default. Therefore, we need to create the link as well.
+# devtoolset-8-gcc-c++ is required to compile azure sdk in pg azure storage project
+RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
+    yum -y install  perl-IPC-Cmd libuuid-devel cmake3 && \
+    ln -s /usr/bin/cmake3 /usr/bin/cmake  && \
+    yum -y remove git && \
+    yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && \
+    yum -y install git && \
+    yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
+
+RUN touch /rpmlintrc \
+    && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
+
+# set PostgreSQL version, place scripts on path, and declare output volume
+ENV PGVERSION=15 \
+    PATH=/scripts:$PATH
+COPY scripts /scripts
+VOLUME /packages
+
+ENTRYPOINT ["/scripts/fetch_and_build_rpm"]

--- a/dockerfiles/almalinux-9-pg15/scripts/determine_email
+++ b/dockerfiles/almalinux-9-pg15/scripts/determine_email
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# make bash behave
+set -uo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+# fallback to public email
+email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
+
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
+citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
+
+if [ -n "${citusemail}" ]; then
+    email="${citusemail}"
+fi
+
+if [ -z "${email}" ]; then
+    echo "$0: could not determine email" >&2
+    exit $failure
+fi
+
+echo "${email}"
+exit $success

--- a/dockerfiles/almalinux-9-pg15/scripts/determine_name
+++ b/dockerfiles/almalinux-9-pg15/scripts/determine_name
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+fullname=$(curl -sf https://api.github.com/user | jq -r '.name // empty')
+
+if [ -z "${fullname}" ]; then
+    echo "$0: could not determine user name" >&2
+    exit $failure
+fi
+
+echo "${fullname}"
+exit $success

--- a/dockerfiles/almalinux-9-pg15/scripts/fetch_and_build_rpm
+++ b/dockerfiles/almalinux-9-pg15/scripts/fetch_and_build_rpm
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+# In one branch we execute commands inside One Branch steps, since One Branch does not allow executing docker inside
+# docker. Additionally, Onebranch needs containers not to close so we make it hang for OneBranch to be able to
+# execute commands.
+if [ "${CONTAINER_BUILD_RUN_ENABLED:-""}" == "" ]; then
+  echo "INFO: Image working in waiting mode. Not executing build script"
+  tail -f /dev/null
+fi
+
+IFS=$'\n\t'
+
+# constants
+stdout=1
+stderr=2
+success=0
+failure=1
+badusage=64
+noinput=66
+
+nextversion='0.0.0'
+builddir=$(pwd)
+
+# outputs usage message on specified device before exiting with provided status
+usage() {
+    cat << 'E_O_USAGE' >&"$1"
+usage: fetch_and_build_rpm build_type build_directory
+
+    build_type: 'release', 'nightly', or a valid git reference
+
+fetch_and_build_rpm builds Red Hat packages using local build files. The build
+type 'release' builds the latest release tag, 'nightly' builds a nightly from
+the latest 'master' commit, and any other type is interpreted as a git ref to
+facilitate building one-off packages for customers.
+E_O_USAGE
+
+    exit "${2}";
+}
+
+# sets the next version variable used during non-release builds
+setnextversion() {
+    # First line replaces '~' and '_' characters and splits the version by '-' and gets the first
+    # from the array.
+    # Second line strips '.citus' suffix
+    # e.g. input->11.0.0_beta-1.citus; output->11.0.0
+    baseversion=$(echo "$1" | tr '~' '-' | tr '_' '-' | cut -d- -f1)
+    baseversion="${baseversion%.citus}"
+    nextversion=$(echo "$baseversion" | perl -pe 's/^(\d+\.)(\d+)(\.\d+)$/$1.($2+1).".0"/e')
+}
+
+if [ "$#" -ne 1 ]; then
+    usage $stderr $badusage
+fi
+
+if [ "${1}" = '-h' ]; then
+    usage $stdout $success
+fi
+
+# populate variables from packaging metadata file
+# shellcheck source=/dev/null
+source /buildfiles/pkgvars
+
+# set default values for certain packaging variables
+declare pkglatest # to make shellcheck happy
+pkgname="${rpm_pkgname:-${pkgname}}"
+hubproj="${hubproj:-${pkgname}}"
+nightlyref="${nightlyref:-master}"
+releasepg="${releasepg:-11,12,13}"
+nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
+if [[ "${pkglatest}" == *"beta"* ]]; then
+    release_type="beta"
+else
+    release_type="stable"
+fi
+
+if [ -z "${pkglatest}" ]; then
+    echo "$0: pkgvars file must specify a value for pkglatest" >&2
+    exit $noinput
+fi
+
+echo "header=\"Authorization: token ${GITHUB_TOKEN}\"" > ~/.curlrc
+
+name=$(determine_name)
+email=$(determine_email)
+export RPM_PACKAGER="${name} <${email}>"
+
+cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
+repopath="citusdata/${hubproj}"
+
+case "${1}" in
+    release)
+        packageversion=${pkglatest%-*}
+        releasetag="v${packageversion%.citus}"
+
+        # Since the only part of the release version after '-' character is fancy version, package release
+        # will alwayse be empty string. So the releasetag is always equal to packageversion
+        packagerelease=$(echo "${pkglatest#*-}" | sed -E 's/^[0-9.]+//')
+        if [ -n "${packagerelease}" ]; then
+            releasetag="v${packageversion}-${packagerelease}"
+        fi
+
+        conf_extra_version="%{nil}"
+
+        gitsha=$(curl -s "https://api.github.com/repos/${repopath}/git/refs/tags/${releasetag}" | \
+                 jq -r '.object.sha')
+        if [ "${gitsha}" == 'null' ]; then
+            echo "$0: could not determine commit for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+
+        verified=$(curl -sH 'Accept:application/vnd.github.cryptographer-preview+sha' \
+                   "https://api.github.com/repos/${repopath}/git/tags/${gitsha}" | \
+                   jq -r '.verification.verified')
+        if [ "${verified}" != 'true' ]; then
+            echo "$0: could not verify signature for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+        ;;
+    *)
+        if [ "${1}" == 'nightly' ]; then
+            ref=${nightlyref}
+            infix='git'
+        else
+            ref=${1}
+            infix='pre'
+        fi
+
+        setnextversion "${pkglatest}"
+
+        set +e
+        gitsha=$(curl -sfH 'Accept:application/vnd.github.v3.sha' \
+                 "https://api.github.com/repos/${repopath}/commits/${ref}")
+        if [ "${?}" -ne 0 ]; then
+            echo "$0: could not determine commit for git ref ${ref}" >&2
+            exit $failure
+        fi
+        set -e
+
+        packageversion="${nextversion}.citus"
+        timestamp=$(date +'%Y%m%d')
+        packagesuffix="${infix}.${timestamp}.${gitsha:0:7}"
+        packagerelease="0.0.${packagesuffix}"
+        conf_extra_version="+${packagesuffix}"
+
+        sed -i -E -e "/^Version:/s/[^ \\t]*$/${packageversion}/" \
+                  -e "/^Release:/s/[^ \\t]*$/${packagerelease}%{dist}/" \
+            "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# this should all take place in a package-build directory
+rpmbuilddir="${builddir}/citus-rpm-build"
+mkdir -p "${rpmbuilddir}"
+
+pkgsrcdir="${builddir}/${pkgname}-${packageversion}"
+mkdir "${pkgsrcdir}"
+
+download=$(mktemp)
+tarballurl="https://api.github.com/repos/${repopath}/tarball/${gitsha}"
+curl -sL "${tarballurl}" -o "${download}"
+
+tarballpath="${rpmbuilddir}/${gitsha}"
+tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
+
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
+
+# force our URL and expanded folder names into spec
+sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
+          -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \
+          -e "/^%global pgpackageversion/s/[0-9.]+$/${PGVERSION}/" \
+    "${builddir}/${pkgname}.spec"
+
+os_name=$(awk '{print $1}' /etc/system-release)
+os_release=$(awk '{print $4}' /etc/system-release)
+if [ "${os_name}" == 'Oracle' ]; then
+    locale='C'
+elif [ "${os_name}" == 'Fedora' ] || [[ "${os_name}" == 'CentOS'  && "${os_release}" == 8* ]]; then
+    locale='C.utf8'
+else
+    locale='en_US.utf8'
+fi
+
+# add minor/major version to package name if using fancy versioning
+if [ "${versioning}" == 'fancy' ]; then
+  infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+  if [ "${release_type}" == "stable" ]; then
+      package_prefix="${infix}"
+  else
+      package_prefix="${infix}_${release_type}"
+  fi
+  sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+fi
+
+# add a changelog entry into nightly build
+case "${1}" in
+    release)
+        # Changelogs for release builds are being added by packaging scripts and could not be autogenerated
+        # Therefore there is nothing to do for release builds
+        ;;
+    nightly)
+        msg="Nightly package. Built from ${nightlyref} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.git/0.0.git/' "${builddir}/${pkgname}.spec"
+        sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+        ;;
+    *)
+        msg="Custom package. Built from ${gitsha:0:7} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.pre/0.0.pre/' "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
+rpmbuild --define "_sourcedir ${rpmbuilddir}" \
+--define "_specdir ${rpmbuilddir}" \
+--define "_builddir ${rpmbuilddir}" \
+--define "_srcrpmdir ${rpmbuilddir}" \
+--define "_rpmdir ${rpmbuilddir}" \
+--define "conf_extra_version ${conf_extra_version}" \
+-bb "${builddir}/${pkgname}.spec"
+
+cp /citus-rpm-build/x86_64/*.rpm /packages

--- a/dockerfiles/almalinux-9-pg15/scripts/setup_submodules
+++ b/dockerfiles/almalinux-9-pg15/scripts/setup_submodules
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        # submodule.{SUBMODULE_NAME}.url
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
+
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
+    done

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-release centos-release-scl-rh) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 7 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 7 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql10-server postgresql10-devel \
     && yum clean all
 

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-release centos-release-scl-rh) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 7 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 7 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql11-server postgresql11-devel \
     && yum clean all
 

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-release centos-release-scl-rh) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 7 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 7 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql12-server postgresql12-devel \
     && yum clean all
 

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-release centos-release-scl-rh) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 7 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 7 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql13-server postgresql13-devel \
     && yum clean all
 

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-release centos-release-scl-rh) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 7 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 7 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql14-server postgresql14-devel \
     && yum clean all
 

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-release centos-release-scl-rh) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 7 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 7 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql15-server postgresql15-devel \
     && yum clean all
 

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset ccache \
-    && ( [[ 8 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset ccache spectool curl \
+    && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql10-server postgresql10-devel \
     && yum clean all
 

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset ccache \
-    && ( [[ 8 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset ccache spectool curl \
+    && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql11-server postgresql11-devel \
     && yum clean all
 

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset ccache \
-    && ( [[ 8 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset ccache spectool curl \
+    && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql12-server postgresql12-devel \
     && yum clean all
 

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset ccache \
-    && ( [[ 8 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset ccache spectool curl \
+    && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql13-server postgresql13-devel \
     && yum clean all
 

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset ccache \
-    && ( [[ 8 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset ccache spectool curl \
+    && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql14-server postgresql14-devel \
     && yum clean all
 

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset ccache \
-    && ( [[ 8 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset ccache spectool curl \
+    && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql15-server postgresql15-devel \
     && yum clean all
 

--- a/dockerfiles/centos-9-pg15/Dockerfile
+++ b/dockerfiles/centos-9-pg15/Dockerfile
@@ -1,0 +1,122 @@
+# vim:set ft=dockerfile:
+FROM quay.io/centos/centos:stream9
+
+#RUN [[ centos != centos ]] || [[ 9 != 8 ]] || ( \
+#    cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+#    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
+#    )
+
+RUN yum -y update
+
+# FIXME: Hack around docker/docker#10180
+RUN ( yum install -y yum-plugin-ovl || yum install -y yum-plugin-ovl || touch /var/lib/rpm/* ) \
+    && yum clean all
+
+# Enable some other repos for some dependencies in OL/7 
+# see https://yum.oracle.com/getting-started.html#installing-from-oracle-linux-yum-server
+RUN [[ centos != oraclelinux ]] || [[ 9 != 7 ]] || ( \
+       yum install -y oraclelinux-release-el7 oracle-softwarecollection-release-el7 oracle-epel-release-el7  oraclelinux-developer-release-el7 \
+       && yum-config-manager --enable \
+            ol7_software_collections \
+            ol7_developer \
+            ol7_developer_EPEL \
+            ol7_optional_latest \
+            ol7_optional_archive \
+            ol7_u9_base \
+            ol7_security_validation \
+            ol7_addons \
+         )
+
+# lz4 1.8 is preloaded in oracle 7 however, lz4-devel is not loaded and only 1.7.5 version exists
+# in oracle 7 repos. So package from centos repo was used
+# There is no package in oracle repos for lz4. Also it is not preloaded. So both lz4 and lz4-devel packages
+# were downloaded from centos el/6 repos
+RUN if [[ centos   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wget \
+        && wget http://mirror.centos.org/centos/7/os/x86_64/Packages/lz4-devel-1.8.3-1.el7.x86_64.rpm \
+        && rpm -ivh lz4-devel-1.8.3-1.el7.x86_64.rpm ; \
+        elif [[ centos   == oraclelinux ]] && [[ 9 == 6 ]]; then yum install -y wget \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-r131-1.el6.x86_64.rpm \
+        && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-devel-r131-1.el6.x86_64.rpm \
+        && rpm -ivh lz4-devel-r131-1.el6.x86_64.rpm;  \
+        else yum install -y lz4 lz4-devel; fi
+
+# install build tools and PostgreSQL development files
+RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
+    && [[ -z "epel-release" ]] || yum install -y epel-release) \
+    && yum groupinstall -y 'Development Tools' \
+    && yum install -y \
+#        curl \
+        flex \
+        gcc-c++ \
+        hunspell-en \
+        libcurl-devel \
+        libicu-devel \
+        libstdc++-devel \
+        libxml2-devel \
+        libxslt-devel \
+        openssl-devel \
+        pam-devel \
+        readline-devel \
+        rpm-build \
+        rpmlint \
+#        spectool \
+        tar \
+        libzstd \
+        libzstd-devel \
+        llvm-toolset ccache \
+#    && ( [[ 9 < 8 ]] || dnf -qy module disable postgresql ) \
+    && yum install -y postgresql15-server postgresql15-devel \
+    && yum clean all
+
+# install jq to process JSON API responses
+RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+         -o /usr/bin/jq \
+    && chmod +x /usr/bin/jq
+
+# install devtoolset-8-gcc on distros where it is available
+RUN { \
+        { yum search devtoolset-8-gcc 2>&1 | grep 'No matches found' ; } \
+        || yum install -y devtoolset-8-gcc devtoolset-8-libstdc++-devel; \
+    } \
+    && yum clean all
+
+# install sphinx on distros with python3
+RUN { \
+        { yum search python3-pip 2>&1 | grep 'No matches found' ; } \
+        || { \
+            yum install -y python3-pip && \
+            pip3 install sphinx==1.8 \
+            ; \
+        } \
+    } \
+    && yum clean all
+
+# install cmake, devtoolset and its dependencies to build azure sdk
+RUN yum -y install  perl-IPC-Cmd libuuid-devel cmake3
+
+# by default git 1.8.x is being installed in centos 7
+# Git 2.7.1 is minimum requirement for cmake so we remove and reinstall latests git from an up-to-date repo
+# Symbolic link is not being created for cmake from cmake3 by default. Therefore, we need to create the link as well.
+# devtoolset-8-gcc-c++ is required to compile azure sdk in pg azure storage project
+RUN [[ centos != centos ]] || [[ 9 != 7 ]] || ( \
+    yum -y install  perl-IPC-Cmd libuuid-devel cmake3 && \
+    ln -s /usr/bin/cmake3 /usr/bin/cmake  && \
+    yum -y remove git && \
+    yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && \
+    yum -y install git && \
+    yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
+
+RUN touch /rpmlintrc \
+    && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
+
+# set PostgreSQL version, place scripts on path, and declare output volume
+ENV PGVERSION=15 \
+    PATH=/scripts:$PATH
+COPY scripts /scripts
+VOLUME /packages
+
+RUN dnf install rpmdevtools -y
+RUN dnf install -y krb5-devel
+
+ENTRYPOINT ["/scripts/fetch_and_build_rpm"]

--- a/dockerfiles/centos-9-pg15/scripts/determine_email
+++ b/dockerfiles/centos-9-pg15/scripts/determine_email
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# make bash behave
+set -uo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+# fallback to public email
+email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
+
+# first try to find Microsoft email, if fails, then it must be the
+# case that bots@citusdata.com is building nightly packages for us
+jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
+citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
+
+if [ -n "${citusemail}" ]; then
+    email="${citusemail}"
+fi
+
+if [ -z "${email}" ]; then
+    echo "$0: could not determine email" >&2
+    exit $failure
+fi
+
+echo "${email}"
+exit $success

--- a/dockerfiles/centos-9-pg15/scripts/determine_name
+++ b/dockerfiles/centos-9-pg15/scripts/determine_name
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+IFS=$'\n\t'
+
+# constants
+success=0
+failure=1
+
+fullname=$(curl -sf https://api.github.com/user | jq -r '.name // empty')
+
+if [ -z "${fullname}" ]; then
+    echo "$0: could not determine user name" >&2
+    exit $failure
+fi
+
+echo "${fullname}"
+exit $success

--- a/dockerfiles/centos-9-pg15/scripts/fetch_and_build_rpm
+++ b/dockerfiles/centos-9-pg15/scripts/fetch_and_build_rpm
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+# make bash behave
+set -euo pipefail
+# In one branch we execute commands inside One Branch steps, since One Branch does not allow executing docker inside
+# docker. Additionally, Onebranch needs containers not to close so we make it hang for OneBranch to be able to
+# execute commands.
+if [ "${CONTAINER_BUILD_RUN_ENABLED:-""}" == "" ]; then
+  echo "INFO: Image working in waiting mode. Not executing build script"
+  tail -f /dev/null
+fi
+
+IFS=$'\n\t'
+
+# constants
+stdout=1
+stderr=2
+success=0
+failure=1
+badusage=64
+noinput=66
+
+nextversion='0.0.0'
+builddir=$(pwd)
+
+# outputs usage message on specified device before exiting with provided status
+usage() {
+    cat << 'E_O_USAGE' >&"$1"
+usage: fetch_and_build_rpm build_type build_directory
+
+    build_type: 'release', 'nightly', or a valid git reference
+
+fetch_and_build_rpm builds Red Hat packages using local build files. The build
+type 'release' builds the latest release tag, 'nightly' builds a nightly from
+the latest 'master' commit, and any other type is interpreted as a git ref to
+facilitate building one-off packages for customers.
+E_O_USAGE
+
+    exit "${2}";
+}
+
+# sets the next version variable used during non-release builds
+setnextversion() {
+    # First line replaces '~' and '_' characters and splits the version by '-' and gets the first
+    # from the array.
+    # Second line strips '.citus' suffix
+    # e.g. input->11.0.0_beta-1.citus; output->11.0.0
+    baseversion=$(echo "$1" | tr '~' '-' | tr '_' '-' | cut -d- -f1)
+    baseversion="${baseversion%.citus}"
+    nextversion=$(echo "$baseversion" | perl -pe 's/^(\d+\.)(\d+)(\.\d+)$/$1.($2+1).".0"/e')
+}
+
+if [ "$#" -ne 1 ]; then
+    usage $stderr $badusage
+fi
+
+if [ "${1}" = '-h' ]; then
+    usage $stdout $success
+fi
+
+# populate variables from packaging metadata file
+# shellcheck source=/dev/null
+source /buildfiles/pkgvars
+
+# set default values for certain packaging variables
+declare pkglatest # to make shellcheck happy
+pkgname="${rpm_pkgname:-${pkgname}}"
+hubproj="${hubproj:-${pkgname}}"
+nightlyref="${nightlyref:-master}"
+releasepg="${releasepg:-11,12,13}"
+nightlypg="${nightlypg:-${releasepg}}"
+versioning="${versioning:-simple}"
+if [[ "${pkglatest}" == *"beta"* ]]; then
+    release_type="beta"
+else
+    release_type="stable"
+fi
+
+if [ -z "${pkglatest}" ]; then
+    echo "$0: pkgvars file must specify a value for pkglatest" >&2
+    exit $noinput
+fi
+
+echo "header=\"Authorization: token ${GITHUB_TOKEN}\"" > ~/.curlrc
+
+name=$(determine_name)
+email=$(determine_email)
+export RPM_PACKAGER="${name} <${email}>"
+
+cp "/buildfiles/${pkgname}.spec" /buildfiles/rpmlintrc "${builddir}"
+repopath="citusdata/${hubproj}"
+
+case "${1}" in
+    release)
+        packageversion=${pkglatest%-*}
+        releasetag="v${packageversion%.citus}"
+
+        # Since the only part of the release version after '-' character is fancy version, package release
+        # will alwayse be empty string. So the releasetag is always equal to packageversion
+        packagerelease=$(echo "${pkglatest#*-}" | sed -E 's/^[0-9.]+//')
+        if [ -n "${packagerelease}" ]; then
+            releasetag="v${packageversion}-${packagerelease}"
+        fi
+
+        conf_extra_version="%{nil}"
+
+        gitsha=$(curl -s "https://api.github.com/repos/${repopath}/git/refs/tags/${releasetag}" | \
+                 jq -r '.object.sha')
+        if [ "${gitsha}" == 'null' ]; then
+            echo "$0: could not determine commit for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+
+        verified=$(curl -sH 'Accept:application/vnd.github.cryptographer-preview+sha' \
+                   "https://api.github.com/repos/${repopath}/git/tags/${gitsha}" | \
+                   jq -r '.verification.verified')
+        if [ "${verified}" != 'true' ]; then
+            echo "$0: could not verify signature for git tag ${releasetag}" >&2
+            exit $failure
+        fi
+        ;;
+    *)
+        if [ "${1}" == 'nightly' ]; then
+            ref=${nightlyref}
+            infix='git'
+        else
+            ref=${1}
+            infix='pre'
+        fi
+
+        setnextversion "${pkglatest}"
+
+        set +e
+        gitsha=$(curl -sfH 'Accept:application/vnd.github.v3.sha' \
+                 "https://api.github.com/repos/${repopath}/commits/${ref}")
+        if [ "${?}" -ne 0 ]; then
+            echo "$0: could not determine commit for git ref ${ref}" >&2
+            exit $failure
+        fi
+        set -e
+
+        packageversion="${nextversion}.citus"
+        timestamp=$(date +'%Y%m%d')
+        packagesuffix="${infix}.${timestamp}.${gitsha:0:7}"
+        packagerelease="0.0.${packagesuffix}"
+        conf_extra_version="+${packagesuffix}"
+
+        sed -i -E -e "/^Version:/s/[^ \\t]*$/${packageversion}/" \
+                  -e "/^Release:/s/[^ \\t]*$/${packagerelease}%{dist}/" \
+            "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# this should all take place in a package-build directory
+rpmbuilddir="${builddir}/citus-rpm-build"
+mkdir -p "${rpmbuilddir}"
+
+pkgsrcdir="${builddir}/${pkgname}-${packageversion}"
+mkdir "${pkgsrcdir}"
+
+download=$(mktemp)
+tarballurl="https://api.github.com/repos/${repopath}/tarball/${gitsha}"
+curl -sL "${tarballurl}" -o "${download}"
+
+tarballpath="${rpmbuilddir}/${gitsha}"
+tar xf "${download}" -C "${pkgsrcdir}" --strip-components 1
+
+# git metadata needs to be setup to initialize submodules
+# in repos which rely on git submodules
+if [[ -f "${pkgsrcdir}/.gitmodules" ]]; then
+    setup_submodules "${pkgsrcdir}"
+fi
+
+tar czf "${tarballpath}" "${pkgsrcdir}"
+
+# force our URL and expanded folder names into spec
+sed -i -E -e "\\|^Source0:|s|https:.*|${tarballurl}|" \
+          -e "/^%global pgmajorversion/s/[0-9]+$/${PGVERSION//'.'/}/" \
+          -e "/^%global pgpackageversion/s/[0-9.]+$/${PGVERSION}/" \
+    "${builddir}/${pkgname}.spec"
+
+os_name=$(awk '{print $1}' /etc/system-release)
+os_release=$(awk '{print $4}' /etc/system-release)
+if [ "${os_name}" == 'Oracle' ]; then
+    locale='C'
+elif [ "${os_name}" == 'Fedora' ] || [[ "${os_name}" == 'CentOS'  && "${os_release}" == 8* ]]; then
+    locale='C.utf8'
+else
+    locale='en_US.utf8'
+fi
+
+# add minor/major version to package name if using fancy versioning
+if [ "${versioning}" == 'fancy' ]; then
+  infix=$(echo "${packageversion}" | grep -oE '^[0-9]+\.[0-9]+' | tr -d '.')
+  if [ "${release_type}" == "stable" ]; then
+      package_prefix="${infix}"
+  else
+      package_prefix="${infix}_${release_type}"
+  fi
+  sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+fi
+
+# add a changelog entry into nightly build
+case "${1}" in
+    release)
+        # Changelogs for release builds are being added by packaging scripts and could not be autogenerated
+        # Therefore there is nothing to do for release builds
+        ;;
+    nightly)
+        msg="Nightly package. Built from ${nightlyref} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.git/0.0.git/' "${builddir}/${pkgname}.spec"
+        sed -i -E "1i %global pkginfix ${package_prefix}" "${builddir}/${pkgname}.spec"
+        ;;
+    *)
+        msg="Custom package. Built from ${gitsha:0:7} "
+        msg+=$(date +'on %l:%M %p (%Z) on %A, %B %Y' | tr -s ' ')
+        LC_ALL=${locale} rpmdev-bumpspec -c "${msg}" "${builddir}/${pkgname}.spec"
+        sed -i -E 's/0.1.pre/0.0.pre/' "${builddir}/${pkgname}.spec"
+        ;;
+esac
+
+# Enable gcc8 on distros that have it
+if [ -f /opt/rh/devtoolset-8/enable ]; then
+    set +u
+    # shellcheck source=/dev/null
+    source /opt/rh/devtoolset-8/enable
+    set -u
+fi
+
+rpmbuild --define "_sourcedir ${rpmbuilddir}" \
+--define "_specdir ${rpmbuilddir}" \
+--define "_builddir ${rpmbuilddir}" \
+--define "_srcrpmdir ${rpmbuilddir}" \
+--define "_rpmdir ${rpmbuilddir}" \
+--define "conf_extra_version ${conf_extra_version}" \
+-bb "${builddir}/${pkgname}.spec"
+
+cp /citus-rpm-build/x86_64/*.rpm /packages

--- a/dockerfiles/centos-9-pg15/scripts/setup_submodules
+++ b/dockerfiles/centos-9-pg15/scripts/setup_submodules
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# slightly modified from: https://stackoverflow.com/a/53899440/15053670
+
+set -euxo pipefail
+
+REPO_PATH=${1:-.}
+cd $REPO_PATH
+
+git init
+
+# extracts
+# submodule.{SUBMODULE_NAME}.path {SUBMODULE_PATH}
+# for each submodule in .gitsubmodules 
+git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+    while read -r KEY MODULE_PATH
+    do
+        # If the module's path exists, remove it.
+        # This is done b/c the module's path is currently 
+        # not a valid git repo and adding the submodule will cause an error.
+        [ -d "${MODULE_PATH}" ] && rm -rf "${MODULE_PATH}"
+
+        NAME="$(echo "${KEY}" | sed 's/^submodule\.\(.*\)\.path$/\1/')"
+
+        # submodule.{SUBMODULE_NAME}.url
+        url_key="$(echo "${KEY}" | sed 's/\.path$/.url/')"
+
+        # submodule.{SUBMODULE_NAME}.branch
+        branch_key="$(echo "${KEY}" | sed 's/\.path$/.branch/')"
+
+        URL="$(git config -f .gitmodules --get "${url_key}")"
+        BRANCH="$(git config -f .gitmodules --get "${branch_key}" || echo "-")"
+
+        if [[ "$BRANCH" = "-" ]]; then
+            git submodule add --force --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        else
+            git submodule add --force -b "${BRANCH}" --name "${NAME}" "${URL}" "${MODULE_PATH}" || continue
+        fi
+    done

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 6 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 6 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql10-server postgresql10-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 6 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 6 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql11-server postgresql11-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 6 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 6 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql12-server postgresql12-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 6 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 6 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql14-server postgresql14-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 6 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 6 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql15-server postgresql15-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 7 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 7 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql10-server postgresql10-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 7 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 7 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql11-server postgresql11-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 7 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 7 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql12-server postgresql12-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 7 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 7 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql13-server postgresql13-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 7 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 7 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql14-server postgresql14-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset-7-clang llvm5.0 \
-    && ( [[ 7 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset-7-clang llvm5.0 spectool curl \
+    && ( [[ 7 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql15-server postgresql15-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset ccache \
-    && ( [[ 8 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset ccache spectool curl \
+    && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql10-server postgresql10-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset ccache \
-    && ( [[ 8 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset ccache spectool curl \
+    && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql11-server postgresql11-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset ccache \
-    && ( [[ 8 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset ccache spectool curl \
+    && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql12-server postgresql12-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset ccache \
-    && ( [[ 8 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset ccache spectool curl \
+    && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql13-server postgresql13-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset ccache \
-    && ( [[ 8 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset ccache spectool curl \
+    && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql14-server postgresql14-devel \
     && yum clean all
 

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -46,7 +46,6 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset ccache \
-    && ( [[ 8 < 8 ]] || dnf -qy module disable postgresql ) \
+        llvm-toolset ccache spectool curl \
+    && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql15-server postgresql15-devel \
     && yum clean all
 

--- a/os-list.csv
+++ b/os-list.csv
@@ -1,3 +1,4 @@
+almalinux,9
 centos,8
 centos,7
 debian,buster

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -46,7 +46,6 @@ RUN ( yum install -y https://%%rpm_url%%  \
     && [[ -z "%%extra-repositories%%" ]] || yum install -y %%extra-repositories%%) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
-        curl \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -60,12 +59,11 @@ RUN ( yum install -y https://%%rpm_url%%  \
         readline-devel \
         rpm-build \
         rpmlint \
-        spectool \
         tar \
         libzstd \
         libzstd-devel \
         %%extra-packages%% \
-    && ( [[ %%release%% < 8 ]] || dnf -qy module disable postgresql ) \
+    && ( [[ %%release%% != 8 ]] || dnf -qy module disable postgresql ) \
     && yum install -y postgresql%%pgshort%%-server postgresql%%pgshort%%-devel \
     && yum clean all
 

--- a/update_dockerfiles
+++ b/update_dockerfiles
@@ -35,6 +35,7 @@ function update_extra_repositories_and_packages {
             extra_repositories='oracle-epel-release-el8'
             extra_packages='llvm-toolset ccache spectool curl'
             ;;
+        # almalinux already has curl installed and installing it again causes conflicting installation error
         almalinux+9)
             extra_repositories='epel-release'
             extra_packages='llvm-toolset ccache rpmdevtools krb5-devel'

--- a/update_dockerfiles
+++ b/update_dockerfiles
@@ -21,19 +21,23 @@ function update_extra_repositories_and_packages {
     case ${os}+${release} in
         centos+6|centos+7)
             extra_repositories='epel-release centos-release-scl-rh'
-            extra_packages='llvm-toolset-7-clang llvm5.0'
+            extra_packages='llvm-toolset-7-clang llvm5.0 spectool curl'
             ;;
         centos+8)
             extra_repositories='epel-release'
-            extra_packages='llvm-toolset ccache'
+            extra_packages='llvm-toolset ccache spectool curl'
             ;;
         oraclelinux+6|oraclelinux+7)
             extra_repositories=''
-            extra_packages='llvm-toolset-7-clang llvm5.0'
+            extra_packages='llvm-toolset-7-clang llvm5.0 spectool curl'
             ;;
         oraclelinux+8)
             extra_repositories='oracle-epel-release-el8'
-            extra_packages='llvm-toolset ccache'
+            extra_packages='llvm-toolset ccache spectool curl'
+            ;;
+        almalinux+9)
+            extra_repositories='epel-release'
+            extra_packages='llvm-toolset ccache rpmdevtools krb5-devel'
             ;;
     esac
 }
@@ -46,7 +50,7 @@ function update_rpm_dockerfile {
     pgshort=${pgversion//./}
     target_subdir="${dockerfiles_dir}/${os}-${release}-pg${pgshort}"
 
-    if ! [[ "${os}" =~ centos|oraclelinux ]]; then
+    if ! [[ "${os}" =~ centos|oraclelinux|almalinux ]]; then
         echo "$0: unrecognized OS -- ${os}" >&2
         exit $badusage
     fi
@@ -86,7 +90,8 @@ while read -r line; do
         cp -R make_pg_buildext_parallel.patch scripts "${target_subdir}"
         rm "${target_subdir}/scripts/fetch_and_build_rpm" \
            "${target_subdir}/scripts/fetch_and_build_pgxn"
-    elif [[ "${os}" = 'centos' ]] || [[ "${os}" = 'fedora' ]] || [[ "${os}" = 'oraclelinux' ]]; then
+    elif [[ "${os}" = 'centos' ]]  || [[ "${os}" = 'fedora' ]] || [[ "${os}" = 'oraclelinux' ]] || \
+         [[ "${os}" = 'almalinux' ]]; then
         # redhat variants need a Dockerfile for each PostgreSQL version
         IFS=' '
         for pgversion in ${pgversions}; do

--- a/update_image
+++ b/update_image
@@ -31,7 +31,7 @@ IFS=',' read -r os release <<< "${TARGET_PLATFORM}"
 if [[ "${os}" = 'debian' ]] || [[ "${os}" = 'ubuntu' ]]; then
     tag="${os}-${release}-all"
     args+="build --pull --no-cache -t citus/${image_name}:${tag} -f ${dockerfiles_dir}/${tag}/Dockerfile .\n"
-elif [[ "${os}" = 'centos' ]] || [[ "${os}" = 'oraclelinux' ]]; then
+elif [[ "${os}" = 'centos' ]] || [[ "${os}" = 'oraclelinux' ]] || [[ "${os}" = 'almalinux' ]]; then
     # redhat variants need an image for each PostgreSQL version
     IFS=' '
     for pgversion in ${pgversions}; do


### PR DESCRIPTION
Previously, we were using centos docker images as our container image to build el and ol packages
However, after centos 9 stream we can not build our packages since it has a whole new structure, upstream, which prevents us to use as base build image
I used almalinux as build image. You can get details from the issue below 
https://github.com/citusdata/citus/issues/6467