### PR TITLE
Adds python3.8 installations in Docker files

### DIFF
--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Push images
         run: |
-          export CURRENT_BRANCH=${GITHUB_REF##*/}
+          export CURRENT_BRANCH=develop
           ./ci/push_images
         env:
           TARGET_PLATFORM: ${{ matrix.TARGET_PLATFORM }}

--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Push images
         run: |
-          export CURRENT_BRANCH=develop
+          export CURRENT_BRANCH=${GITHUB_REF##*/}
           ./ci/push_images
         env:
           TARGET_PLATFORM: ${{ matrix.TARGET_PLATFORM }}

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM almalinux:9
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = centos ] && [ 9 = 8 ] ) || \
-       ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
+       ( [ almalinux = centos ] && [ 9 = 8 ] ) ||
+       ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
+       ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = centos ] && [ 9 = 8 ] ) ||
+       ( [ almalinux = centos ] && [ 9 = 8 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM almalinux:9
-SHELL ["/bin/bash", "-c"]
 RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg10/Dockerfile
+++ b/dockerfiles/almalinux-9-pg10/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM almalinux:9
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = centos ] && [ 9 = 8 ] ) || \
-       ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
+       ( [ almalinux = centos ] && [ 9 = 8 ] ) ||
+       ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
+       ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = centos ] && [ 9 = 8 ] ) ||
+       ( [ almalinux = centos ] && [ 9 = 8 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM almalinux:9
-SHELL ["/bin/bash", "-c"]
 RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM almalinux:9
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = centos ] && [ 9 = 8 ] ) || \
-       ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
+       ( [ almalinux = centos ] && [ 9 = 8 ] ) ||
+       ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
+       ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = centos ] && [ 9 = 8 ] ) ||
+       ( [ almalinux = centos ] && [ 9 = 8 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM almalinux:9
-SHELL ["/bin/bash", "-c"]
 RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM almalinux:9
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = centos ] && [ 9 = 8 ] ) || \
-       ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
+       ( [ almalinux = centos ] && [ 9 = 8 ] ) ||
+       ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
+       ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = centos ] && [ 9 = 8 ] ) ||
+       ( [ almalinux = centos ] && [ 9 = 8 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM almalinux:9
-SHELL ["/bin/bash", "-c"]
 RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM almalinux:9
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = centos ] && [ 9 = 8 ] ) || \
-       ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
+       ( [ almalinux = centos ] && [ 9 = 8 ] ) ||
+       ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
+       ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = centos ] && [ 9 = 8 ] ) ||
+       ( [ almalinux = centos ] && [ 9 = 8 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM almalinux:9
-SHELL ["/bin/bash", "-c"]
 RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM almalinux:9
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = centos ] && [ 9 = 8 ] ) || \
-       ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
+       ( [ almalinux = centos ] && [ 9 = 8 ] ) ||
+       ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
+       ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
-       ( [ almalinux = centos ] && [ 9 = 8 ] ) ||
+       ( [ almalinux = centos ] && [ 9 = 8 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM almalinux:9
-SHELL ["/bin/bash", "-c"]
 RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ almalinux = centos ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 7 ] ) || \
        ( [ almalinux = oraclelinux ] && [ 9 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
-       ( [ centos = centos ] && [ 7 = 8 ] ) ||
+       ( [ centos = centos ] && [ 7 = 8 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM centos:7
-SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-release centos-release-scl-rh) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
+       ( [ centos = centos ] && [ 7 = 8 ] ) ||
+       ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
+       ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM centos:7
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
-       ( [ centos = centos ] && [ 7 = 8 ] ) || \
-       ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
-       ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg10/Dockerfile
+++ b/dockerfiles/centos-7-pg10/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
-       ( [ centos = centos ] && [ 7 = 8 ] ) ||
+       ( [ centos = centos ] && [ 7 = 8 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM centos:7
-SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-release centos-release-scl-rh) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
+       ( [ centos = centos ] && [ 7 = 8 ] ) ||
+       ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
+       ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM centos:7
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
-       ( [ centos = centos ] && [ 7 = 8 ] ) || \
-       ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
-       ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg11/Dockerfile
+++ b/dockerfiles/centos-7-pg11/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
-       ( [ centos = centos ] && [ 7 = 8 ] ) ||
+       ( [ centos = centos ] && [ 7 = 8 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM centos:7
-SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-release centos-release-scl-rh) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
+       ( [ centos = centos ] && [ 7 = 8 ] ) ||
+       ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
+       ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM centos:7
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
-       ( [ centos = centos ] && [ 7 = 8 ] ) || \
-       ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
-       ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg12/Dockerfile
+++ b/dockerfiles/centos-7-pg12/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
-       ( [ centos = centos ] && [ 7 = 8 ] ) ||
+       ( [ centos = centos ] && [ 7 = 8 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM centos:7
-SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-release centos-release-scl-rh) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
+       ( [ centos = centos ] && [ 7 = 8 ] ) ||
+       ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
+       ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM centos:7
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
-       ( [ centos = centos ] && [ 7 = 8 ] ) || \
-       ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
-       ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg13/Dockerfile
+++ b/dockerfiles/centos-7-pg13/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
-       ( [ centos = centos ] && [ 7 = 8 ] ) ||
+       ( [ centos = centos ] && [ 7 = 8 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM centos:7
-SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-release centos-release-scl-rh) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
+       ( [ centos = centos ] && [ 7 = 8 ] ) ||
+       ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
+       ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM centos:7
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
-       ( [ centos = centos ] && [ 7 = 8 ] ) || \
-       ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
-       ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg14/Dockerfile
+++ b/dockerfiles/centos-7-pg14/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
-       ( [ centos = centos ] && [ 7 = 8 ] ) ||
+       ( [ centos = centos ] && [ 7 = 8 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM centos:7
-SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "epel-release centos-release-scl-rh" ]] || yum install -y epel-release centos-release-scl-rh) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
+       ( [ centos = centos ] && [ 7 = 8 ] ) ||
+       ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
+       ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM centos:7
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
-       ( [ centos = centos ] && [ 7 = 8 ] ) || \
-       ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
-       ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ centos != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-7-pg15/Dockerfile
+++ b/dockerfiles/centos-7-pg15/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ centos = centos ] && [ 7 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM centos:8
-SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM centos:8
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
-       ( [ centos = centos ] && [ 8 = 8 ] ) || \
-       ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
-       ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
-       ( [ centos = centos ] && [ 8 = 8 ] ) ||
+       ( [ centos = centos ] && [ 8 = 8 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
+       ( [ centos = centos ] && [ 8 = 8 ] ) ||
+       ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
+       ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg10/Dockerfile
+++ b/dockerfiles/centos-8-pg10/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM centos:8
-SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM centos:8
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
-       ( [ centos = centos ] && [ 8 = 8 ] ) || \
-       ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
-       ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
-       ( [ centos = centos ] && [ 8 = 8 ] ) ||
+       ( [ centos = centos ] && [ 8 = 8 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
+       ( [ centos = centos ] && [ 8 = 8 ] ) ||
+       ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
+       ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg11/Dockerfile
+++ b/dockerfiles/centos-8-pg11/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM centos:8
-SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM centos:8
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
-       ( [ centos = centos ] && [ 8 = 8 ] ) || \
-       ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
-       ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
-       ( [ centos = centos ] && [ 8 = 8 ] ) ||
+       ( [ centos = centos ] && [ 8 = 8 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
+       ( [ centos = centos ] && [ 8 = 8 ] ) ||
+       ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
+       ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg12/Dockerfile
+++ b/dockerfiles/centos-8-pg12/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM centos:8
-SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM centos:8
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
-       ( [ centos = centos ] && [ 8 = 8 ] ) || \
-       ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
-       ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
-       ( [ centos = centos ] && [ 8 = 8 ] ) ||
+       ( [ centos = centos ] && [ 8 = 8 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
+       ( [ centos = centos ] && [ 8 = 8 ] ) ||
+       ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
+       ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg13/Dockerfile
+++ b/dockerfiles/centos-8-pg13/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM centos:8
-SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM centos:8
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
-       ( [ centos = centos ] && [ 8 = 8 ] ) || \
-       ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
-       ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
-       ( [ centos = centos ] && [ 8 = 8 ] ) ||
+       ( [ centos = centos ] && [ 8 = 8 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
+       ( [ centos = centos ] && [ 8 = 8 ] ) ||
+       ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
+       ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg14/Dockerfile
+++ b/dockerfiles/centos-8-pg14/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM centos:8
-SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM centos:8
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ centos != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
-       ( [ centos = centos ] && [ 8 = 8 ] ) || \
-       ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
-       ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
-       ( [ centos = centos ] && [ 8 = 8 ] ) ||
+       ( [ centos = centos ] && [ 8 = 8 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
+       ( [ centos = centos ] && [ 8 = 8 ] ) ||
+       ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
+       ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ centos = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ centos = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ centos != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/centos-8-pg15/Dockerfile
+++ b/dockerfiles/centos-8-pg15/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -124,6 +124,9 @@ RUN !( ( [ debian = debian ] && [ bookworm = buster ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -119,7 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -120,12 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ debian = debian ] && [ bookworm = buster ] ) || \
         ( [ debian = ubuntu ] && [ bookworm = bionic ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -125,7 +125,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -1,7 +1,6 @@
 # vim:set ft=dockerfile:
 FROM debian:bookworm
 ARG DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -120,6 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -120,12 +120,6 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ debian = debian ] && [ bookworm = buster ] ) || \
         ( [ debian = ubuntu ] && [ bookworm = bionic ] ) \
      ) || ( \
-        apt-get install -y  libncurses5-dev  \
-                            libgdbm-dev \
-                            libnss3-dev \
-                            libsqlite3-dev \
-                            libffi-dev \
-                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -120,6 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ debian = debian ] && [ bookworm = buster ] ) || \
         ( [ debian = ubuntu ] && [ bookworm = bionic ] ) \
      ) || ( \
+        apt-get install -y  libncurses5-dev  \
+                            libgdbm-dev \
+                            libnss3-dev \
+                            libsqlite3-dev \
+                            libffi-dev \
+                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -55,6 +55,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' > /et
         devscripts \
         fakeroot \
         flex \
+        libbz2-dev \
+        libffi-dev \
         libcurl4-openssl-dev \
         libdistro-info-perl \
         libedit-dev \

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -123,12 +123,13 @@ RUN !( ( [ debian = debian ] && [ bookworm = buster ] ) || \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
-        ./configure --enable-optimizations && \
+        ./configure && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16  && \
+        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
      )
 
 

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -122,7 +122,10 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
     echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
+# therefore I need to export the path explicitly here.
+RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
+    pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -115,6 +115,19 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
+# install python 3.8 to be able to execute tools scripts
+# if os/release in (debian/buster,ubuntu/bionic)
+RUN !( ( [ debian = debian ] && [ bookworm = buster ] ) || \
+        ( [ debian = ubuntu ] && [ bookworm = bionic ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -1,6 +1,7 @@
 # vim:set ft=dockerfile:
 FROM debian:bookworm
 ARG DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -115,22 +116,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
-# install python 3.8 to be able to execute tools scripts
-# if os/release in (debian/buster,ubuntu/bionic)
-RUN !( ( [ debian = debian ] && [ bookworm = buster ] ) || \
-        ( [ debian = ubuntu ] && [ bookworm = bionic ] ) \
-     ) || ( \
-        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  && \
-        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
-     )
+# install pyenv and python 3.8 to be able to execute tools scripts
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -117,16 +117,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
-# therefore I need to export the path explicitly here.
-RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
-    pyenv install 3.8.16 && pyenv global 3.8.16
-
+RUN ARG PYTHON_VERSION=3.8.16
+RUN set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -117,7 +117,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && pyenv update \

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -1,6 +1,7 @@
 # vim:set ft=dockerfile:
 FROM debian:bullseye
 ARG DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -115,22 +116,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
-# install python 3.8 to be able to execute tools scripts
-# if os/release in (debian/buster,ubuntu/bionic)
-RUN !( ( [ debian = debian ] && [ bullseye = buster ] ) || \
-        ( [ debian = ubuntu ] && [ bullseye = bionic ] ) \
-     ) || ( \
-        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  && \
-        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
-     )
+# install pyenv and python 3.8 to be able to execute tools scripts
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -120,6 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ debian = debian ] && [ bullseye = buster ] ) || \
         ( [ debian = ubuntu ] && [ bullseye = bionic ] ) \
      ) || ( \
+        apt-get install -y  libncurses5-dev  \
+                            libgdbm-dev \
+                            libnss3-dev \
+                            libsqlite3-dev \
+                            libffi-dev \
+                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -119,7 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -120,12 +120,6 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ debian = debian ] && [ bullseye = buster ] ) || \
         ( [ debian = ubuntu ] && [ bullseye = bionic ] ) \
      ) || ( \
-        apt-get install -y  libncurses5-dev  \
-                            libgdbm-dev \
-                            libnss3-dev \
-                            libsqlite3-dev \
-                            libffi-dev \
-                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -125,7 +125,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -124,6 +124,9 @@ RUN !( ( [ debian = debian ] && [ bullseye = buster ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -1,7 +1,6 @@
 # vim:set ft=dockerfile:
 FROM debian:bullseye
 ARG DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -120,6 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -55,6 +55,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /et
         devscripts \
         fakeroot \
         flex \
+        libbz2-dev \
+        libffi-dev \
         libcurl4-openssl-dev \
         libdistro-info-perl \
         libedit-dev \

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -120,12 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ debian = debian ] && [ bullseye = buster ] ) || \
         ( [ debian = ubuntu ] && [ bullseye = bionic ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -122,7 +122,10 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
     echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
+# therefore I need to export the path explicitly here.
+RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
+    pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -123,12 +123,13 @@ RUN !( ( [ debian = debian ] && [ bullseye = buster ] ) || \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
-        ./configure --enable-optimizations && \
+        ./configure && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16  && \
+        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
      )
 
 

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -115,6 +115,19 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
+# install python 3.8 to be able to execute tools scripts
+# if os/release in (debian/buster,ubuntu/bionic)
+RUN !( ( [ debian = debian ] && [ bullseye = buster ] ) || \
+        ( [ debian = ubuntu ] && [ bullseye = bionic ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -117,16 +117,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
-# therefore I need to export the path explicitly here.
-RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
-    pyenv install 3.8.16 && pyenv global 3.8.16
-
+RUN ARG PYTHON_VERSION=3.8.16
+RUN set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -117,7 +117,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && pyenv update \

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -115,6 +115,19 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
+# install python 3.8 to be able to execute tools scripts
+# if os/release in (debian/buster,ubuntu/bionic)
+RUN !( ( [ debian = debian ] && [ buster = buster ] ) || \
+        ( [ debian = ubuntu ] && [ buster = bionic ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -55,6 +55,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' > /etc/
         devscripts \
         fakeroot \
         flex \
+        libbz2-dev \
+        libffi-dev \
         libcurl4-openssl-dev \
         libdistro-info-perl \
         libedit-dev \

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -119,7 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -1,7 +1,6 @@
 # vim:set ft=dockerfile:
 FROM debian:buster
 ARG DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -120,6 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -125,7 +125,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -120,6 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ debian = debian ] && [ buster = buster ] ) || \
         ( [ debian = ubuntu ] && [ buster = bionic ] ) \
      ) || ( \
+        apt-get install -y  libncurses5-dev  \
+                            libgdbm-dev \
+                            libnss3-dev \
+                            libsqlite3-dev \
+                            libffi-dev \
+                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -124,6 +124,9 @@ RUN !( ( [ debian = debian ] && [ buster = buster ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -1,6 +1,7 @@
 # vim:set ft=dockerfile:
 FROM debian:buster
 ARG DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -115,22 +116,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
-# install python 3.8 to be able to execute tools scripts
-# if os/release in (debian/buster,ubuntu/bionic)
-RUN !( ( [ debian = debian ] && [ buster = buster ] ) || \
-        ( [ debian = ubuntu ] && [ buster = bionic ] ) \
-     ) || ( \
-        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  && \
-        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
-     )
+# install pyenv and python 3.8 to be able to execute tools scripts
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -120,12 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ debian = debian ] && [ buster = buster ] ) || \
         ( [ debian = ubuntu ] && [ buster = bionic ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -122,7 +122,10 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
     echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
+# therefore I need to export the path explicitly here.
+RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
+    pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -120,12 +120,6 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ debian = debian ] && [ buster = buster ] ) || \
         ( [ debian = ubuntu ] && [ buster = bionic ] ) \
      ) || ( \
-        apt-get install -y  libncurses5-dev  \
-                            libgdbm-dev \
-                            libnss3-dev \
-                            libsqlite3-dev \
-                            libffi-dev \
-                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -123,12 +123,13 @@ RUN !( ( [ debian = debian ] && [ buster = buster ] ) || \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
-        ./configure --enable-optimizations && \
+        ./configure && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16  && \
+        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
      )
 
 

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -117,16 +117,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
-# therefore I need to export the path explicitly here.
-RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
-    pyenv install 3.8.16 && pyenv global 3.8.16
-
+RUN ARG PYTHON_VERSION=3.8.16
+RUN set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -117,7 +117,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && pyenv update \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-6-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg10/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 6 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 6 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:6
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 6 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 6 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 6 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-7-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg10/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-7-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg11/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-7-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg12/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-7-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg13/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-7-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg14/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:7
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 7 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 7 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 7 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 7 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 7 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 7 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-7-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-7-pg15/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg10/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg10/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg12/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -45,6 +45,9 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -106,6 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -112,12 +112,12 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -112,7 +112,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -113,7 +113,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -118,7 +118,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM oraclelinux:8
-SHELL ["/bin/bash", "-c"]
 RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -106,7 +106,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -114,7 +114,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -115,15 +115,15 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -105,6 +105,21 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
+       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) ||
+       ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
+       ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -108,7 +108,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
-       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) ||
+       ( [ oraclelinux = centos ] && [ 8 = 8 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -111,7 +111,7 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -116,6 +116,9 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -106,16 +106,15 @@ RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -112,6 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -123,7 +123,8 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -112,7 +112,7 @@ RUN !( ( [ oraclelinux = centos ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 7 ] ) || \
        ( [ oraclelinux = oraclelinux ] && [ 8 = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -120,12 +120,6 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ ubuntu = debian ] && [ bionic = buster ] ) || \
         ( [ ubuntu = ubuntu ] && [ bionic = bionic ] ) \
      ) || ( \
-        apt-get install -y  libncurses5-dev  \
-                            libgdbm-dev \
-                            libnss3-dev \
-                            libsqlite3-dev \
-                            libffi-dev \
-                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -115,6 +115,19 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
+# install python 3.8 to be able to execute tools scripts
+# if os/release in (debian/buster,ubuntu/bionic)
+RUN !( ( [ ubuntu = debian ] && [ bionic = buster ] ) || \
+        ( [ ubuntu = ubuntu ] && [ bionic = bionic ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -119,7 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -120,12 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ ubuntu = debian ] && [ bionic = buster ] ) || \
         ( [ ubuntu = ubuntu ] && [ bionic = bionic ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -125,7 +125,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -123,12 +123,13 @@ RUN !( ( [ ubuntu = debian ] && [ bionic = buster ] ) || \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
-        ./configure --enable-optimizations && \
+        ./configure && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16  && \
+        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
      )
 
 

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -1,7 +1,6 @@
 # vim:set ft=dockerfile:
 FROM ubuntu:bionic
 ARG DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -120,6 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -124,6 +124,9 @@ RUN !( ( [ ubuntu = debian ] && [ bionic = buster ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -122,7 +122,10 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
     echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
+# therefore I need to export the path explicitly here.
+RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
+    pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -55,6 +55,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main' > /etc/
         devscripts \
         fakeroot \
         flex \
+        libbz2-dev \
+        libffi-dev \
         libcurl4-openssl-dev \
         libdistro-info-perl \
         libedit-dev \

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -120,6 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ ubuntu = debian ] && [ bionic = buster ] ) || \
         ( [ ubuntu = ubuntu ] && [ bionic = bionic ] ) \
      ) || ( \
+        apt-get install -y  libncurses5-dev  \
+                            libgdbm-dev \
+                            libnss3-dev \
+                            libsqlite3-dev \
+                            libffi-dev \
+                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -1,6 +1,7 @@
 # vim:set ft=dockerfile:
 FROM ubuntu:bionic
 ARG DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -115,22 +116,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
-# install python 3.8 to be able to execute tools scripts
-# if os/release in (debian/buster,ubuntu/bionic)
-RUN !( ( [ ubuntu = debian ] && [ bionic = buster ] ) || \
-        ( [ ubuntu = ubuntu ] && [ bionic = bionic ] ) \
-     ) || ( \
-        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  && \
-        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
-     )
+# install pyenv and python 3.8 to be able to execute tools scripts
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -117,16 +117,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
-# therefore I need to export the path explicitly here.
-RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
-    pyenv install 3.8.16 && pyenv global 3.8.16
-
+RUN ARG PYTHON_VERSION=3.8.16
+RUN set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -117,7 +117,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && pyenv update \

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -123,12 +123,13 @@ RUN !( ( [ ubuntu = debian ] && [ focal = buster ] ) || \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
-        ./configure --enable-optimizations && \
+        ./configure && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16  && \
+        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
      )
 
 

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -119,7 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -1,6 +1,7 @@
 # vim:set ft=dockerfile:
 FROM ubuntu:focal
 ARG DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -115,22 +116,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
-# install python 3.8 to be able to execute tools scripts
-# if os/release in (debian/buster,ubuntu/bionic)
-RUN !( ( [ ubuntu = debian ] && [ focal = buster ] ) || \
-        ( [ ubuntu = ubuntu ] && [ focal = bionic ] ) \
-     ) || ( \
-        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  && \
-        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
-     )
+# install pyenv and python 3.8 to be able to execute tools scripts
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -120,6 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ ubuntu = debian ] && [ focal = buster ] ) || \
         ( [ ubuntu = ubuntu ] && [ focal = bionic ] ) \
      ) || ( \
+        apt-get install -y  libncurses5-dev  \
+                            libgdbm-dev \
+                            libnss3-dev \
+                            libsqlite3-dev \
+                            libffi-dev \
+                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -125,7 +125,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -120,12 +120,6 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ ubuntu = debian ] && [ focal = buster ] ) || \
         ( [ ubuntu = ubuntu ] && [ focal = bionic ] ) \
      ) || ( \
-        apt-get install -y  libncurses5-dev  \
-                            libgdbm-dev \
-                            libnss3-dev \
-                            libsqlite3-dev \
-                            libffi-dev \
-                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -120,12 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ ubuntu = debian ] && [ focal = buster ] ) || \
         ( [ ubuntu = ubuntu ] && [ focal = bionic ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -122,7 +122,10 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
     echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
+# therefore I need to export the path explicitly here.
+RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
+    pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -115,6 +115,19 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
+# install python 3.8 to be able to execute tools scripts
+# if os/release in (debian/buster,ubuntu/bionic)
+RUN !( ( [ ubuntu = debian ] && [ focal = buster ] ) || \
+        ( [ ubuntu = ubuntu ] && [ focal = bionic ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -124,6 +124,9 @@ RUN !( ( [ ubuntu = debian ] && [ focal = buster ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -55,6 +55,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/a
         devscripts \
         fakeroot \
         flex \
+        libbz2-dev \
+        libffi-dev \
         libcurl4-openssl-dev \
         libdistro-info-perl \
         libedit-dev \

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -1,7 +1,6 @@
 # vim:set ft=dockerfile:
 FROM ubuntu:focal
 ARG DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -120,6 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -117,16 +117,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
-# therefore I need to export the path explicitly here.
-RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
-    pyenv install 3.8.16 && pyenv global 3.8.16
-
+RUN ARG PYTHON_VERSION=3.8.16
+RUN set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -117,7 +117,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && pyenv update \

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -115,6 +115,19 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
+# install python 3.8 to be able to execute tools scripts
+# if os/release in (debian/buster,ubuntu/bionic)
+RUN !( ( [ ubuntu = debian ] && [ jammy = buster ] ) || \
+        ( [ ubuntu = ubuntu ] && [ jammy = bionic ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -124,6 +124,9 @@ RUN !( ( [ ubuntu = debian ] && [ jammy = buster ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -120,6 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ ubuntu = debian ] && [ jammy = buster ] ) || \
         ( [ ubuntu = ubuntu ] && [ jammy = bionic ] ) \
      ) || ( \
+        apt-get install -y  libncurses5-dev  \
+                            libgdbm-dev \
+                            libnss3-dev \
+                            libsqlite3-dev \
+                            libffi-dev \
+                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -119,7 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -123,12 +123,13 @@ RUN !( ( [ ubuntu = debian ] && [ jammy = buster ] ) || \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
-        ./configure --enable-optimizations && \
+        ./configure && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16  && \
+        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
      )
 
 

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -125,7 +125,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -120,12 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ ubuntu = debian ] && [ jammy = buster ] ) || \
         ( [ ubuntu = ubuntu ] && [ jammy = bionic ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -1,6 +1,7 @@
 # vim:set ft=dockerfile:
 FROM ubuntu:jammy
 ARG DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -115,22 +116,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
-# install python 3.8 to be able to execute tools scripts
-# if os/release in (debian/buster,ubuntu/bionic)
-RUN !( ( [ ubuntu = debian ] && [ jammy = buster ] ) || \
-        ( [ ubuntu = ubuntu ] && [ jammy = bionic ] ) \
-     ) || ( \
-        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  && \
-        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
-     )
+# install pyenv and python 3.8 to be able to execute tools scripts
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -120,12 +120,6 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ ubuntu = debian ] && [ jammy = buster ] ) || \
         ( [ ubuntu = ubuntu ] && [ jammy = bionic ] ) \
      ) || ( \
-        apt-get install -y  libncurses5-dev  \
-                            libgdbm-dev \
-                            libnss3-dev \
-                            libsqlite3-dev \
-                            libffi-dev \
-                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -1,7 +1,6 @@
 # vim:set ft=dockerfile:
 FROM ubuntu:jammy
 ARG DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -120,6 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -122,7 +122,10 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
     echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
+# therefore I need to export the path explicitly here.
+RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
+    pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -55,6 +55,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main' > /etc/a
         devscripts \
         fakeroot \
         flex \
+        libbz2-dev \
+        libffi-dev \
         libcurl4-openssl-dev \
         libdistro-info-perl \
         libedit-dev \

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -117,16 +117,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
-# therefore I need to export the path explicitly here.
-RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
-    pyenv install 3.8.16 && pyenv global 3.8.16
-
+RUN ARG PYTHON_VERSION=3.8.16
+RUN set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -117,7 +117,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && pyenv update \

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -120,12 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ ubuntu = debian ] && [ kinetic = buster ] ) || \
         ( [ ubuntu = ubuntu ] && [ kinetic = bionic ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -119,7 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -1,7 +1,6 @@
 # vim:set ft=dockerfile:
 FROM ubuntu:kinetic
 ARG DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -120,6 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -125,7 +125,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -124,6 +124,9 @@ RUN !( ( [ ubuntu = debian ] && [ kinetic = buster ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -1,6 +1,7 @@
 # vim:set ft=dockerfile:
 FROM ubuntu:kinetic
 ARG DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -115,22 +116,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
-# install python 3.8 to be able to execute tools scripts
-# if os/release in (debian/buster,ubuntu/bionic)
-RUN !( ( [ ubuntu = debian ] && [ kinetic = buster ] ) || \
-        ( [ ubuntu = ubuntu ] && [ kinetic = bionic ] ) \
-     ) || ( \
-        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  && \
-        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
-     )
+# install pyenv and python 3.8 to be able to execute tools scripts
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -120,6 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ ubuntu = debian ] && [ kinetic = buster ] ) || \
         ( [ ubuntu = ubuntu ] && [ kinetic = bionic ] ) \
      ) || ( \
+        apt-get install -y  libncurses5-dev  \
+                            libgdbm-dev \
+                            libnss3-dev \
+                            libsqlite3-dev \
+                            libffi-dev \
+                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -123,12 +123,13 @@ RUN !( ( [ ubuntu = debian ] && [ kinetic = buster ] ) || \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
-        ./configure --enable-optimizations && \
+        ./configure && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16  && \
+        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
      )
 
 

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -120,12 +120,6 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ ubuntu = debian ] && [ kinetic = buster ] ) || \
         ( [ ubuntu = ubuntu ] && [ kinetic = bionic ] ) \
      ) || ( \
-        apt-get install -y  libncurses5-dev  \
-                            libgdbm-dev \
-                            libnss3-dev \
-                            libsqlite3-dev \
-                            libffi-dev \
-                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -122,7 +122,10 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
     echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
+# therefore I need to export the path explicitly here.
+RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
+    pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -115,6 +115,19 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
+# install python 3.8 to be able to execute tools scripts
+# if os/release in (debian/buster,ubuntu/bionic)
+RUN !( ( [ ubuntu = debian ] && [ kinetic = buster ] ) || \
+        ( [ ubuntu = ubuntu ] && [ kinetic = bionic ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -55,6 +55,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ kinetic-pgdg main' > /etc
         devscripts \
         fakeroot \
         flex \
+        libbz2-dev \
+        libffi-dev \
         libcurl4-openssl-dev \
         libdistro-info-perl \
         libedit-dev \

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -117,16 +117,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
-# therefore I need to export the path explicitly here.
-RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
-    pyenv install 3.8.16 && pyenv global 3.8.16
-
+RUN ARG PYTHON_VERSION=3.8.16
+RUN set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 
 # Added for pg15 beta package support.

--- a/dockerfiles/ubuntu-kinetic-all/Dockerfile
+++ b/dockerfiles/ubuntu-kinetic-all/Dockerfile
@@ -117,7 +117,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && pyenv update \

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -124,6 +124,9 @@ RUN !( ( [ %%os%% = debian ] && [ %%release%% = buster ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -119,7 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -125,7 +125,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
 # Added for pg15 beta package support.

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -120,12 +120,6 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ %%os%% = debian ] && [ %%release%% = buster ] ) || \
         ( [ %%os%% = ubuntu ] && [ %%release%% = bionic ] ) \
      ) || ( \
-        apt-get install -y  libncurses5-dev  \
-                            libgdbm-dev \
-                            libnss3-dev \
-                            libsqlite3-dev \
-                            libffi-dev \
-                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -120,6 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ %%os%% = debian ] && [ %%release%% = buster ] ) || \
         ( [ %%os%% = ubuntu ] && [ %%release%% = bionic ] ) \
      ) || ( \
+        apt-get install -y  libncurses5-dev  \
+                            libgdbm-dev \
+                            libnss3-dev \
+                            libsqlite3-dev \
+                            libffi-dev \
+                            libbz2-dev \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -122,7 +122,10 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
     echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
+# therefore I need to export the path explicitly here.
+RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
+    pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -1,6 +1,7 @@
 # vim:set ft=dockerfile:
 FROM %%os%%:%%release%%
 ARG DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -115,22 +116,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
-# install python 3.8 to be able to execute tools scripts
-# if os/release in (debian/buster,ubuntu/bionic)
-RUN !( ( [ %%os%% = debian ] && [ %%release%% = buster ] ) || \
-        ( [ %%os%% = ubuntu ] && [ %%release%% = bionic ] ) \
-     ) || ( \
-        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  && \
-        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
-     )
+# install pyenv and python 3.8 to be able to execute tools scripts
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 
 

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -1,7 +1,6 @@
 # vim:set ft=dockerfile:
 FROM %%os%%:%%release%%
 ARG DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-c"]
 
 # See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
 #
@@ -120,6 +119,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -115,6 +115,19 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -f cmake-3.22.2.tar.gz && \
     rm -rf cmake-3.22.2
 
+# install python 3.8 to be able to execute tools scripts
+# if os/release in (debian/buster,ubuntu/bionic)
+RUN !( ( [ %%os%% = debian ] && [ %%release%% = buster ] ) || \
+        ( [ %%os%% = ubuntu ] && [ %%release%% = bionic ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 
 
 # Added for pg15 beta package support.

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -117,16 +117,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-# install python 3.8 and set it as default. Reloading the bashrc did not worked for ubuntu \
-# therefore I need to export the path explicitly here.
-RUN source ~/.bashrc && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" && \
-    pyenv install 3.8.16 && pyenv global 3.8.16
-
+RUN ARG PYTHON_VERSION=3.8.16
+RUN set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 
 # Added for pg15 beta package support.

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -55,6 +55,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main' > 
         devscripts \
         fakeroot \
         flex \
+        libbz2-dev \
+        libffi-dev \
         libcurl4-openssl-dev \
         libdistro-info-perl \
         libedit-dev \

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -123,12 +123,13 @@ RUN !( ( [ %%os%% = debian ] && [ %%release%% = buster ] ) || \
         wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
-        ./configure --enable-optimizations && \
+        ./configure && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16  && \
+        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1 \
      )
 
 

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -120,12 +120,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
 RUN !( ( [ %%os%% = debian ] && [ %%release%% = buster ] ) || \
         ( [ %%os%% = ubuntu ] && [ %%release%% = bionic ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        wget https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -117,7 +117,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2
     rm -rf cmake-3.22.2
 
 # install pyenv and python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && pyenv update \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -112,7 +112,7 @@ RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
        ( [ %%os%% = oraclelinux ] && [ %%release%% = 7 ] ) || \
        ( [ %%os%% = oraclelinux ] && [ %%release%% = 8 ] ) \
      ) || ( \
-        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
         ./configure --enable-optimizations && \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -123,7 +123,8 @@ RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
         make altinstall && \
         cd .. && \
         rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -rf Python-3.8.16 && \
+        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
      )
 
 RUN touch /rpmlintrc \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -111,7 +111,7 @@ RUN [[ %%os%% != centos ]] || [[ %%release%% != 7 ]] || ( \
 ARG PYTHON_VERSION=3.8.16
 RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -115,15 +115,15 @@ RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -106,6 +106,7 @@ RUN [[ %%os%% != centos ]] || [[ %%release%% != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
+RUN ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -116,6 +116,9 @@ RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
+        make -j 8 && \
+        make altinstall && \
+        cd .. && \
         rm -f Python-3.8.16.tar.xz && \
         rm -rf Python-3.8.16  \
      )

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -114,7 +114,7 @@ RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
      ) || ( \
         yum -y install  bzip2-devel \
                         libffi-devel \
-                        xz-devel \
+                        xz-devel && \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -108,7 +108,7 @@ RUN [[ %%os%% != centos ]] || [[ %%release%% != 7 ]] || ( \
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
 RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
-       ( [ %%os%% = centos ] && [ %%release%% = 8 ] ) ||
+       ( [ %%os%% = centos ] && [ %%release%% = 8 ] ) || \
        ( [ %%os%% = oraclelinux ] && [ %%release%% = 7 ] ) || \
        ( [ %%os%% = oraclelinux ] && [ %%release%% = 8 ] ) \
      ) || ( \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -112,7 +112,9 @@ RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
        ( [ %%os%% = oraclelinux ] && [ %%release%% = 7 ] ) || \
        ( [ %%os%% = oraclelinux ] && [ %%release%% = 8 ] ) \
      ) || ( \
-        yum -y install bzip2-devel libffi-devel xz-devel
+        yum -y install  bzip2-devel \
+                        libffi-devel
+                        xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -105,6 +105,21 @@ RUN [[ %%os%% != centos ]] || [[ %%release%% != 7 ]] || ( \
     yum -y install git && \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
+# install python 3.8 to be able to execute tools scripts
+# if os in (centos, oraclelinux) and release in (7, 8)
+RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
+       ( [ %%os%% = centos ] && [ %%release%% = 8 ] ) ||
+       ( [ %%os%% = oraclelinux ] && [ %%release%% = 7 ] ) || \
+       ( [ %%os%% = oraclelinux ] && [ %%release%% = 8 ] ) \
+     ) || ( \
+        wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
+        ./configure --enable-optimizations && \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
+     )
+
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -118,7 +118,7 @@ RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
         curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
         tar -xvf Python-3.8.12.tar.xz && \
         cd Python-3.8.12 && \
-        ./configure --enable-optimizations && \
+        ./configure  && \
         make -j 8 && \
         make altinstall && \
         cd .. && \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -115,15 +115,15 @@ RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
         yum -y install  bzip2-devel \
                         libffi-devel \
                         xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
+        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
+        tar -xvf Python-3.8.12.tar.xz && \
+        cd Python-3.8.12 && \
         ./configure --enable-optimizations && \
         make -j 8 && \
         make altinstall && \
         cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16  \
+        rm -f Python-3.8.12.tar.xz && \
+        rm -rf Python-3.8.12  \
      )
 
 RUN touch /rpmlintrc \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -1,6 +1,5 @@
 # vim:set ft=dockerfile:
 FROM %%os%%:%%release%%
-SHELL ["/bin/bash", "-c"]
 RUN [[ %%os%% != centos ]] || [[ %%release%% != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -112,6 +111,7 @@ RUN yum -y install  bzip2-devel \
                 xz-devel && \
     set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -106,16 +106,15 @@ RUN [[ %%os%% != centos ]] || [[ %%release%% != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-# if os in (centos, oraclelinux) and release in (7, 8)
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \
-    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
-    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-
-RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
+    set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -112,6 +112,7 @@ RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
        ( [ %%os%% = oraclelinux ] && [ %%release%% = 7 ] ) || \
        ( [ %%os%% = oraclelinux ] && [ %%release%% = 8 ] ) \
      ) || ( \
+        yum -y install bzip2-devel libffi-devel xz-devel
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \
         cd Python-3.8.16 && \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -106,7 +106,7 @@ RUN [[ %%os%% != centos ]] || [[ %%release%% != 7 ]] || ( \
     yum -y install  devtoolset-8-gcc-c++ && scl enable devtoolset-8 bash )
 
 # install python 3.8 to be able to execute tools scripts
-RUN ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.8.16
 RUN yum -y install  bzip2-devel \
                 libffi-devel \
                 xz-devel && \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -113,7 +113,7 @@ RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
        ( [ %%os%% = oraclelinux ] && [ %%release%% = 8 ] ) \
      ) || ( \
         yum -y install  bzip2-devel \
-                        libffi-devel
+                        libffi-devel \
                         xz-devel \
         curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
         tar -xvf Python-3.8.16.tar.xz && \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -112,12 +112,12 @@ RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
        ( [ %%os%% = oraclelinux ] && [ %%release%% = 7 ] ) || \
        ( [ %%os%% = oraclelinux ] && [ %%release%% = 8 ] ) \
      ) || ( \
-        curl -O https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-        tar -xvf Python-3.8.12.tar.xz && \
-        cd Python-3.8.12 && \
+        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
+        tar -xvf Python-3.8.16.tar.xz && \
+        cd Python-3.8.16 && \
         ./configure --enable-optimizations && \
-        rm -f Python-3.8.12.tar.xz && \
-        rm -rf Python-3.8.12  \
+        rm -f Python-3.8.16.tar.xz && \
+        rm -rf Python-3.8.16  \
      )
 
 RUN touch /rpmlintrc \

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 FROM %%os%%:%%release%%
-
+SHELL ["/bin/bash", "-c"]
 RUN [[ %%os%% != centos ]] || [[ %%release%% != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
@@ -107,25 +107,15 @@ RUN [[ %%os%% != centos ]] || [[ %%release%% != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 # if os in (centos, oraclelinux) and release in (7, 8)
-RUN !( ( [ %%os%% = centos ] && [ %%release%% = 7 ] ) || \
-       ( [ %%os%% = centos ] && [ %%release%% = 8 ] ) || \
-       ( [ %%os%% = oraclelinux ] && [ %%release%% = 7 ] ) || \
-       ( [ %%os%% = oraclelinux ] && [ %%release%% = 8 ] ) \
-     ) || ( \
-        yum -y install  bzip2-devel \
-                        libffi-devel \
-                        xz-devel && \
-        curl -O https://www.python.org/ftp/python/3.8.16/Python-3.8.16.tar.xz && \
-        tar -xvf Python-3.8.16.tar.xz && \
-        cd Python-3.8.16 && \
-        ./configure  && \
-        make -j 8 && \
-        make altinstall && \
-        cd .. && \
-        rm -f Python-3.8.16.tar.xz && \
-        rm -rf Python-3.8.16 && \
-        ln -fs /usr/local/bin/python3.8 /usr/bin/python3 \
-     )
+RUN yum -y install  bzip2-devel \
+                libffi-devel \
+                xz-devel && \
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+RUN source ~/.bashrc && pyenv install 3.8.16 && pyenv global 3.8.16
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -115,7 +115,10 @@ RUN set -ex \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
-    && pyenv rehash
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -45,6 +45,9 @@ RUN ( yum install -y https://%%rpm_url%%  \
     && [[ -z "%%extra-repositories%%" ]] || yum install -y %%extra-repositories%%) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
+        bzip2-devel \
+        libffi-devel \
+        xz-devel \
         flex \
         gcc-c++ \
         hunspell-en \
@@ -106,10 +109,7 @@ RUN [[ %%os%% != centos ]] || [[ %%release%% != 7 ]] || ( \
 
 # install python 3.8 to be able to execute tools scripts
 ARG PYTHON_VERSION=3.8.16
-RUN yum -y install  bzip2-devel \
-                libffi-devel \
-                xz-devel && \
-    set -ex \
+RUN set -ex \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && export PYENV_ROOT="$HOME/.pyenv" && export PATH="$PYENV_ROOT/bin:$PATH" \
     && pyenv update \


### PR DESCRIPTION
Python3.8 is minimum requirement for tools scripts. However, ubuntu bionic, debian buster, centos and oraclelinux releases have python releases lower than 3.8. 
In citus pipelines we are executing tools scripts inside image scripts. Therefore, python 3.8 installation is a must for above release pairs