### PR TITLE
Adds fallback address for debian releases 

### DIFF
--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -187,6 +187,15 @@ detect_codename ()
       11)
         codename='bullseye'
         ;;
+      12)
+        codename='bookworm'
+        ;;
+      13)
+        codename='trixie'
+        ;;
+      14)
+        codename='forky'
+        ;;
       wheezy)
         codename="${dist}"
         ;;
@@ -252,6 +261,16 @@ main ()
   # create an apt config file for this repository
   curl -sSf "${apt_config_url}" > $apt_source_path
   curl_exit_code=$?
+
+  # Packagecloud uses both the codename and the version_id in their scripts. However, in some cases
+  # version_id does not work. Since both can be used in /etc/version file, we need to try both in case of missing
+  # definition of version_id in PackageCloud system.
+  if [ "${os}" = "debian" ] && [ "$curl_exit_code" -ne "0" ]; then
+    apt_config_url_with_code_name="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${codename}&source=script"
+    curl -sSf "${apt_config_url_with_code_name}" > "$apt_source_path"
+    echo "Using fallback url: ${apt_config_url_with_code_name}"
+    curl_exit_code=$?
+  fi
 
   if [ "$curl_exit_code" = "22" ]; then
     echo

--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -211,6 +211,15 @@ detect_codename ()
       bullseye)
         codename="${dist}"
         ;;
+      bookworm)
+        codename="${dist}"
+        ;;
+      trixy)
+        codename="${dist}"
+        ;;
+      forky)
+        codename="${dist}"
+        ;;
       *)
         unknown_os
         ;;

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -258,9 +258,15 @@ main ()
 
   echo -n "Installing $apt_source_path... "
 
-  # create an apt config file for this repository
   curl -sSf "${apt_config_url}" > $apt_source_path
   curl_exit_code=$?
+  if [ "${os}" = "debian" ] && [ "$curl_exit_code" -ne "0" ]; then
+    apt_config_url_with_code_name=("https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${codename}&source=script"
+    curl -sSf "${apt_config_url_with_code_name}" > "$apt_source_path"
+    echo "Using fallback url: ${apt_config_url_with_code_name}"
+    curl_exit_code=$?
+  fi
+
 
   if [ "$curl_exit_code" = "22" ]; then
     echo

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -266,8 +266,9 @@ main ()
   # version_id does not work. Since both can be used in /etc/version file, we need to try both in case of missing
   # definition of version_id in PackageCloud system.
   if [ "${os}" = "debian" ] && [ "$curl_exit_code" -ne "0" ]; then
-    apt_config_url_with_code_name=("https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${codename}&source=script"
-    curl -sSf "${apt_config_url_with_code_name}" > "$apt_source_path"
+    apt_config_url_with_code_name="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${codename}&source=script"
+    echo "${apt_config_url_with_code_name}"
+    curl -sSf "${apt_config_url_with_code_name}" > "${apt_source_path}"
     echo "Using fallback url: ${apt_config_url_with_code_name}"
     curl_exit_code=$?
   fi

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -258,15 +258,19 @@ main ()
 
   echo -n "Installing $apt_source_path... "
 
+  # create an apt config file for this repository
   curl -sSf "${apt_config_url}" > $apt_source_path
   curl_exit_code=$?
+
+  # Packagecloud uses both the codename and the version_id in their scripts. However, in some cases
+  # version_id does not work. Since both can be used in /etc/version file, we need to try both in case of missing
+  # definition of version_id in PackageCloud system.
   if [ "${os}" = "debian" ] && [ "$curl_exit_code" -ne "0" ]; then
     apt_config_url_with_code_name=("https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${codename}&source=script"
     curl -sSf "${apt_config_url_with_code_name}" > "$apt_source_path"
     echo "Using fallback url: ${apt_config_url_with_code_name}"
     curl_exit_code=$?
   fi
-
 
   if [ "$curl_exit_code" = "22" ]; then
     echo

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -187,6 +187,15 @@ detect_codename ()
       11)
         codename='bullseye'
         ;;
+      12)
+        codename='bookworm'
+        ;;
+      13)
+        codename='trixie'
+        ;;
+      14)
+        codename='forky'
+        ;;
       wheezy)
         codename="${dist}"
         ;;

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -211,6 +211,15 @@ detect_codename ()
       bullseye)
         codename="${dist}"
         ;;
+      bookworm)
+        codename="${dist}"
+        ;;
+      trixy)
+        codename="${dist}"
+        ;;
+      forky)
+        codename="${dist}"
+        ;;
       *)
         unknown_os
         ;;

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -217,6 +217,15 @@ detect_codename ()
       11)
         codename='bullseye'
         ;;
+      12)
+        codename='bookworm'
+        ;;
+      13)
+        codename='trixie'
+        ;;
+      14)
+        codename='forky'
+        ;;
       wheezy)
         codename="${dist}"
         ;;
@@ -301,6 +310,16 @@ main ()
   # create an apt config file for this repository
   curl -sSf "${apt_config_url}" > $apt_source_path
   curl_exit_code=$?
+
+  # Packagecloud uses both the codename and the version_id in their scripts. However, in some cases
+  # version_id does not work. Since both can be used in /etc/version file, we need to try both in case of missing
+  # definition of version_id in PackageCloud system.
+  if [ "${os}" = "debian" ] && [ "$curl_exit_code" -ne "0" ]; then
+    apt_config_url_with_code_name="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${codename}&source=script"
+    curl -sSf "${apt_config_url_with_code_name}" > "$apt_source_path"
+    echo "Using fallback url: ${apt_config_url_with_code_name}"
+    curl_exit_code=$?
+  fi
 
   if [ "$curl_exit_code" = "22" ]; then
     echo

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -293,7 +293,7 @@ main ()
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
   repo_name="enterprise-nightlies"
   gpg_key_install_url="https://repos.citusdata.com/${repo_name}/gpg_key_url.list?os=${os}&dist=${dist}"
-  apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/enterprise-nightlies/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+  apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/${repo_name}/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
 
   gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then
@@ -316,7 +316,7 @@ main ()
   # version_id does not work. Since both can be used in /etc/version file, we need to try both in case of missing
   # definition of version_id in PackageCloud system.
   if [ "${os}" = "debian" ] && [ "$curl_exit_code" -ne "0" ]; then
-    apt_config_url_with_code_name="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${codename}&source=script"
+    apt_config_url_with_code_name="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/${repo_name}/config_file.list?os=${os}&dist=${codename}&name=${CITUS_REPO_HOST_ID}&source=script"
     curl -sSf "${apt_config_url_with_code_name}" > "$apt_source_path"
     echo "Using fallback url: ${apt_config_url_with_code_name}"
     curl_exit_code=$?

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -291,7 +291,8 @@ main ()
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
-  gpg_key_install_url="https://repos.citusdata.com/enterprise-nightlies/gpg_key_url.list?os=${os}&dist=${dist}"
+  repo_name="enterprise-nightlies"
+  gpg_key_install_url="https://repos.citusdata.com/${repo_name}/gpg_key_url.list?os=${os}&dist=${dist}"
   apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/enterprise-nightlies/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
 
   gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -241,6 +241,15 @@ detect_codename ()
       bullseye)
         codename="${dist}"
         ;;
+      bookworm)
+        codename="${dist}"
+        ;;
+      trixy)
+        codename="${dist}"
+        ;;
+      forky)
+        codename="${dist}"
+        ;;
       *)
         unknown_os
         ;;

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -292,8 +292,8 @@ main ()
 
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
   gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
-
-  apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/enterprise/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
+  repo_name="enterprise"
+  apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/${repo_name}/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
 
   gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`
   if [ "${gpg_key_url}" = "" ]; then

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -217,6 +217,15 @@ detect_codename ()
       11)
         codename='bullseye'
         ;;
+      12)
+        codename='bookworm'
+        ;;
+      13)
+        codename='trixie'
+        ;;
+      14)
+        codename='forky'
+        ;;
       wheezy)
         codename="${dist}"
         ;;
@@ -306,6 +315,16 @@ main ()
   # create an apt config file for this repository
   curl -sSf "${apt_config_url}" > $apt_source_path
   curl_exit_code=$?
+
+  # Packagecloud uses both the codename and the version_id in their scripts. However, in some cases
+  # version_id does not work. Since both can be used in /etc/version file, we need to try both in case of missing
+  # definition of version_id in PackageCloud system.
+  if [ "${os}" = "debian" ] && [ "$curl_exit_code" -ne "0" ]; then
+    apt_config_url_with_code_name="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${codename}&source=script"
+    curl -sSf "${apt_config_url_with_code_name}" > "$apt_source_path"
+    echo "Using fallback url: ${apt_config_url_with_code_name}"
+    curl_exit_code=$?
+  fi
 
   if [ "$curl_exit_code" = "22" ]; then
     echo

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -241,6 +241,15 @@ detect_codename ()
       bullseye)
         codename="${dist}"
         ;;
+      bookworm)
+        codename="${dist}"
+        ;;
+      trixie)
+        codename="${dist}"
+        ;;
+      forky)
+        codename="${dist}"
+        ;;
       *)
         unknown_os
         ;;

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -291,8 +291,8 @@ main ()
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
-  gpg_key_install_url="https://repos.citusdata.com/enterprise/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
   repo_name="enterprise"
+  gpg_key_install_url="https://repos.citusdata.com/${repo_name}/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
   apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/${repo_name}/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
 
   gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`
@@ -320,7 +320,7 @@ main ()
   # version_id does not work. Since both can be used in /etc/version file, we need to try both in case of missing
   # definition of version_id in PackageCloud system.
   if [ "${os}" = "debian" ] && [ "$curl_exit_code" -ne "0" ]; then
-    apt_config_url_with_code_name="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${codename}&source=script"
+    apt_config_url_with_code_name="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/${repo_name}/config_file.list?os=${os}&dist=${codename}&name=${CITUS_REPO_HOST_ID}&source=script"
     curl -sSf "${apt_config_url_with_code_name}" > "$apt_source_path"
     echo "Using fallback url: ${apt_config_url_with_code_name}"
     curl_exit_code=$?


### PR DESCRIPTION
Recently, we have problems to download debian/bookworm 
packages from packagecloud, since packagecloud repository 
config file does not work with release number but works 
with release code name. 
The one that is not working
https://packagecloud.io/install/repositories/citusdata/community/config_file.list?os=debian&dist=12&source=script
The one that is working
https://packagecloud.io/install/repositories/citusdata/community/config_file.list?os=debian&dist=bookworm&source=script

There are two fixes in this PR to handle this problem
1. Adds new debian releases in the codename matrix for debian
2. Adds fallback address for debian releases which 
includes code names instead of release numbers. 
