### PR TITLE
Stop using repos.citusdata.com as we have ssl problems

### DIFF
--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -255,7 +255,7 @@ main ()
   echo "done."
 
   repo_name="community-nightlies"
-  gpg_key_url="https://packagecloud.io/install/repositories/citusdata/${repo_name}/gpgkey"
+  gpg_key_url="https://packagecloud.io/citusdata/${repo_name}/gpgkey"
   apt_config_url="https://packagecloud.io/install/repositories/citusdata/${repo_name}/config_file.list?os=${os}&dist=${dist}&source=script"
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_${repo_name}.list"

--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -313,7 +313,6 @@ main ()
     [ -e $apt_source_path ] && rm $apt_source_path
     exit 1
   else
-    sed -i 's#packagecloud.io/citusdata#repos.citusdata.com#g' "${apt_source_path}"
     echo "done."
   fi
 

--- a/community-nightlies/deb.sh
+++ b/community-nightlies/deb.sh
@@ -255,8 +255,8 @@ main ()
   echo "done."
 
   repo_name="community-nightlies"
-  gpg_key_url="https://repos.citusdata.com/${repo_name}/gpgkey"
-  apt_config_url="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${dist}&source=script"
+  gpg_key_url="https://packagecloud.io/install/repositories/citusdata/${repo_name}/gpgkey"
+  apt_config_url="https://packagecloud.io/install/repositories/citusdata/${repo_name}/config_file.list?os=${os}&dist=${dist}&source=script"
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_${repo_name}.list"
   apt_keyrings_dir="/etc/apt/keyrings"
@@ -275,7 +275,7 @@ main ()
   # version_id does not work. Since both can be used in /etc/version file, we need to try both in case of missing
   # definition of version_id in PackageCloud system.
   if [ "${os}" = "debian" ] && [ "$curl_exit_code" -ne "0" ]; then
-    apt_config_url_with_code_name="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${codename}&source=script"
+    apt_config_url_with_code_name="https://packagecloud.io/install/repositories/citusdata/${repo_name}/config_file.list?os=${os}&dist=${codename}&source=script"
     curl -sSf "${apt_config_url_with_code_name}" > "$apt_source_path"
     echo "Using fallback url: ${apt_config_url_with_code_name}"
     curl_exit_code=$?

--- a/community-nightlies/rpm.sh
+++ b/community-nightlies/rpm.sh
@@ -271,7 +271,6 @@ main ()
     [ -e $yum_repo_path ] && rm $yum_repo_path
     exit 1
   else
-    sed -i 's#packagecloud.io/citusdata#repos.citusdata.com#g' "${yum_repo_path}"
     echo "done."
   fi
 

--- a/community-nightlies/rpm.sh
+++ b/community-nightlies/rpm.sh
@@ -224,7 +224,7 @@ main ()
   pgdg_check
   epel_check
 
-  yum_repo_config_url="https://repos.citusdata.com/community-nightlies/config_file.repo?os=${os}&dist=${dist}&source=script"
+  yum_repo_config_url="https://packagecloud.io/install/repositories/citusdata/community-nightlies/config_file.repo?os=${os}&dist=${dist}&source=script"
 
   if [ "${os}" = "sles" ] || [ "${os}" = "opensuse" ]; then
     yum_repo_path=/etc/zypp/repos.d/citusdata_community-nightlies.repo

--- a/community-nightlies/rpm96.sh
+++ b/community-nightlies/rpm96.sh
@@ -250,7 +250,6 @@ main ()
     [ -e $yum_repo_path ] && rm $yum_repo_path
     exit 1
   else
-    sed -i 's#packagecloud.io/citusdata#repos.citusdata.com#g' "${yum_repo_path}"
     echo "done."
   fi
 

--- a/community-nightlies/rpm96.sh
+++ b/community-nightlies/rpm96.sh
@@ -203,7 +203,7 @@ main ()
   curl_check
   pgdg_check
 
-  yum_repo_config_url="https://repos.citusdata.com/community-nightlies/config_file.repo?os=${os}&dist=${dist}&source=script"
+  yum_repo_config_url="https://packagecloud.io/install/repositories/citusdata/community-nightlies/config_file.repo?os=${os}&dist=${dist}&source=script"
 
   if [ "${os}" = "sles" ] || [ "${os}" = "opensuse" ]; then
     yum_repo_path=/etc/zypp/repos.d/citusdata_community-nightlies.repo

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -255,7 +255,7 @@ main ()
   echo "done."
 
   repo_name="community"
-  gpg_key_url="https://packagecloud.io/install/repositories/citusdata/${repo_name}/gpgkey"
+  gpg_key_url="https://packagecloud.io/citusdata/${repo_name}/gpgkey"
   apt_config_url="https://packagecloud.io/install/repositories/citusdata/${repo_name}/config_file.list?os=${os}&dist=${dist}&source=script"
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_${repo_name}.list"

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -255,8 +255,8 @@ main ()
   echo "done."
 
   repo_name="community"
-  gpg_key_url="https://repos.citusdata.com/${repo_name}/gpgkey"
-  apt_config_url="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${dist}&source=script"
+  gpg_key_url="https://packagecloud.io/install/repositories/citusdata/${repo_name}/gpgkey"
+  apt_config_url="https://packagecloud.io/install/repositories/citusdata/${repo_name}/config_file.list?os=${os}&dist=${dist}&source=script"
 
   apt_source_path="/etc/apt/sources.list.d/citusdata_${repo_name}.list"
   apt_keyrings_dir="/etc/apt/keyrings"
@@ -275,7 +275,7 @@ main ()
   # version_id does not work. Since both can be used in /etc/version file, we need to try both in case of missing
   # definition of version_id in PackageCloud system.
   if [ "${os}" = "debian" ] && [ "$curl_exit_code" -ne "0" ]; then
-    apt_config_url_with_code_name="https://repos.citusdata.com/${repo_name}/config_file.list?os=${os}&dist=${codename}&source=script"
+    apt_config_url_with_code_name="https://packagecloud.io/install/repositories/citusdata/${repo_name}/config_file.list?os=${os}&dist=${codename}&source=script"
     echo "${apt_config_url_with_code_name}"
     curl -sSf "${apt_config_url_with_code_name}" > "${apt_source_path}"
     echo "Using fallback url: ${apt_config_url_with_code_name}"

--- a/community/deb.sh
+++ b/community/deb.sh
@@ -314,7 +314,6 @@ main ()
     [ -e $apt_source_path ] && rm $apt_source_path
     exit 1
   else
-    sed -i 's#packagecloud.io/citusdata#repos.citusdata.com#g' "${apt_source_path}"
     echo "done."
   fi
 

--- a/community/rpm.sh
+++ b/community/rpm.sh
@@ -224,7 +224,7 @@ main ()
   pgdg_check
   epel_check
 
-  yum_repo_config_url="https://repos.citusdata.com/community/config_file.repo?os=${os}&dist=${dist}&source=script"
+  yum_repo_config_url="https://packagecloud.io/install/repositories/citusdata/community/config_file.repo?os=${os}&dist=${dist}&source=script"
 
   if [ "${os}" = "sles" ] || [ "${os}" = "opensuse" ]; then
     yum_repo_path=/etc/zypp/repos.d/citusdata_community.repo

--- a/community/rpm.sh
+++ b/community/rpm.sh
@@ -271,7 +271,6 @@ main ()
     [ -e $yum_repo_path ] && rm $yum_repo_path
     exit 1
   else
-    sed -i 's#packagecloud.io/citusdata#repos.citusdata.com#g' "${yum_repo_path}"
     echo "done."
   fi
 

--- a/community/rpm96.sh
+++ b/community/rpm96.sh
@@ -250,7 +250,6 @@ main ()
     [ -e $yum_repo_path ] && rm $yum_repo_path
     exit 1
   else
-    sed -i 's#packagecloud.io/citusdata#repos.citusdata.com#g' "${yum_repo_path}"
     echo "done."
   fi
 

--- a/community/rpm96.sh
+++ b/community/rpm96.sh
@@ -203,7 +203,7 @@ main ()
   curl_check
   pgdg_check
 
-  yum_repo_config_url="https://repos.citusdata.com/community/config_file.repo?os=${os}&dist=${dist}&source=script"
+  yum_repo_config_url="https://packagecloud.io/install/repositories/citusdata/community/config_file.repo?os=${os}&dist=${dist}&source=script"
 
   if [ "${os}" = "sles" ] || [ "${os}" = "opensuse" ]; then
     yum_repo_path=/etc/zypp/repos.d/citusdata_community.repo

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -301,7 +301,7 @@ main ()
 
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
   repo_name="enterprise-nightlies"
-  gpg_key_install_url="https://repos.citusdata.com/${repo_name}/gpg_key_url.list?os=${os}&dist=${dist}"
+  gpg_key_install_url="https://packagecloud.io/install/repositories/citusdata/${repo_name}/gpg_key_url.list?os=${os}&dist=${dist}"
   apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/${repo_name}/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
 
   gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`

--- a/enterprise-nightlies/deb.sh
+++ b/enterprise-nightlies/deb.sh
@@ -363,7 +363,6 @@ main ()
     [ -e $apt_source_path ] && rm $apt_source_path
     exit 1
   else
-    sed -i 's#packagecloud.io/citusdata#repos.citusdata.com#g' "${apt_source_path}"
     echo "done."
   fi
 

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -318,7 +318,6 @@ main ()
     [ -e $yum_repo_path ] && rm $yum_repo_path
     exit 1
   else
-    sed -i 's#packagecloud.io/citusdata#repos.citusdata.com#g' "${yum_repo_path}"
     echo "done."
   fi
 

--- a/enterprise-nightlies/rpm.sh
+++ b/enterprise-nightlies/rpm.sh
@@ -270,7 +270,7 @@ main ()
   # escape any colons in repo token (they separate it from empty password)
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
-  yum_repo_config_url="https://repos.citusdata.com/enterprise-nightlies/config_file.repo?os=${os}&dist=${dist}&source=script"
+  yum_repo_config_url="https://packagecloud.io/install/repositories/citusdata/enterprise-nightlies/config_file.repo?os=${os}&dist=${dist}&source=script"
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
 
   if [ "${os}" = "sles" ] || [ "${os}" = "opensuse" ]; then

--- a/enterprise-nightlies/rpm96.sh
+++ b/enterprise-nightlies/rpm96.sh
@@ -296,7 +296,6 @@ main ()
     [ -e $yum_repo_path ] && rm $yum_repo_path
     exit 1
   else
-    sed -i 's#packagecloud.io/citusdata#repos.citusdata.com#g' "${yum_repo_path}"
     echo "done."
   fi
 

--- a/enterprise-nightlies/rpm96.sh
+++ b/enterprise-nightlies/rpm96.sh
@@ -248,7 +248,7 @@ main ()
   # escape any colons in repo token (they separate it from empty password)
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
-  yum_repo_config_url="https://repos.citusdata.com/enterprise-nightlies/config_file.repo?os=${os}&dist=${dist}&source=script"
+  yum_repo_config_url="https://packagecloud.io/install/repositories/citusdata/enterprise-nightlies/config_file.repo?os=${os}&dist=${dist}&source=script"
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
 
   if [ "${os}" = "sles" ] || [ "${os}" = "opensuse" ]; then

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -367,7 +367,6 @@ main ()
     [ -e $apt_source_path ] && rm $apt_source_path
     exit 1
   else
-    sed -i 's#packagecloud.io/citusdata#repos.citusdata.com#g' "${apt_source_path}"
     echo "done."
   fi
 

--- a/enterprise/deb.sh
+++ b/enterprise/deb.sh
@@ -301,7 +301,7 @@ main ()
 
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
   repo_name="enterprise"
-  gpg_key_install_url="https://repos.citusdata.com/${repo_name}/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
+  gpg_key_install_url="https://packagecloud.io/install/repositories/citusdata/${repo_name}/gpg_key_url.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}"
   apt_config_url="https://${CITUS_REPO_TOKEN}:@packagecloud.io/install/repositories/citusdata/${repo_name}/config_file.list?os=${os}&dist=${dist}&name=${CITUS_REPO_HOST_ID}&source=script"
 
   gpg_key_url=`curl -GL -u "${CITUS_REPO_TOKEN}:" --data-urlencode "name=${CITUS_REPO_HOST_ID}" "${gpg_key_install_url}"`

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -37,7 +37,7 @@ pgdg_check ()
     echo "Detected postgresql15-server..."
   else
     echo -n "Installing pgdg repo... "
-    
+
     if [ "${dist}" = "8" ]; then
       dnf -qy module disable postgresql
     fi
@@ -270,7 +270,7 @@ main ()
   # escape any colons in repo token (they separate it from empty password)
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
-  yum_repo_config_url="https://repos.citusdata.com/enterprise/config_file.repo?os=${os}&dist=${dist}&source=script"
+  yum_repo_config_url="https://packagecloud.io/install/repositories/citusdata/enterprise/config_file.repo?os=${os}&dist=${dist}&source=script"
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
 
   if [ "${os}" = "sles" ] || [ "${os}" = "opensuse" ]; then

--- a/enterprise/rpm.sh
+++ b/enterprise/rpm.sh
@@ -318,7 +318,6 @@ main ()
     [ -e $yum_repo_path ] && rm $yum_repo_path
     exit 1
   else
-    sed -i 's#packagecloud.io/citusdata#repos.citusdata.com#g' "${yum_repo_path}"
     echo "done."
   fi
 

--- a/enterprise/rpm96.sh
+++ b/enterprise/rpm96.sh
@@ -296,7 +296,6 @@ main ()
     [ -e $yum_repo_path ] && rm $yum_repo_path
     exit 1
   else
-    sed -i 's#packagecloud.io/citusdata#repos.citusdata.com#g' "${yum_repo_path}"
     echo "done."
   fi
 

--- a/enterprise/rpm96.sh
+++ b/enterprise/rpm96.sh
@@ -248,7 +248,7 @@ main ()
   # escape any colons in repo token (they separate it from empty password)
   CITUS_REPO_TOKEN="${CITUS_REPO_TOKEN//:/%3A}"
 
-  yum_repo_config_url="https://repos.citusdata.com/enterprise/config_file.repo?os=${os}&dist=${dist}&source=script"
+  yum_repo_config_url="https://packagecloud.io/install/repositories/citusdata/enterprise/config_file.repo?os=${os}&dist=${dist}&source=script"
   echo "Found host ID: ${CITUS_REPO_HOST_ID}"
 
   if [ "${os}" = "sles" ] || [ "${os}" = "opensuse" ]; then


### PR DESCRIPTION
Our ssl certificates expired for `repos.citusdata.com`. As a workaround, we can consider using packagecloud domains and their ssl certificates instead.