### PR TITLE
Add token for crates io mirror feed

### DIFF
--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -9,6 +9,7 @@ env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   DOCKERHUB_USER_NAME: ${{ secrets.DOCKERHUB_USER_NAME }}
   DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+  CRATES_IO_MIRROR_FEED_TOKEN: ${{ secrets.CRATES_IO_MIRROR_FEED_TOKEN }}
 on:
   schedule:
     - cron: "30 1 * * *"


### PR DESCRIPTION
This PR aims to accommodate all changes in https://github.com/citusdata/packaging/pull/1076

The develop branch did not really have valid credentials for MSCodeHub, and I fail to understand how the nightly tests used to pass. This PR aimed to replace MSCodeHub mirror with the new Azure Artifacts Rust Mirror feed credentials but the former were missing and I ended up introducing a new secret here instead of replacing some deprecated ones. 