### PR TITLE
Bump to Citus 12.1.3

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -48,7 +48,7 @@ jobs:
         run: git clone -b v0.8.27 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
-        run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources
+        run: sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources
 
       - name: Install python requirements
         run: python -m pip install -r tools/packaging_automation/requirements.txt

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -42,7 +42,7 @@ jobs:
         run: git clone -b v0.8.27 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
-        run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources
+        run: sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources
 
       - name: Install python requirements
         run: python -m pip install -r tools/packaging_automation/requirements.txt

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources
+        run: sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources
 
       - name: Clone tools branch
         run: git clone -b v0.8.26 --depth=1  https://github.com/citusdata/tools.git tools

--- a/citus.spec
+++ b/citus.spec
@@ -8,11 +8,11 @@ Summary:	PostgreSQL-based distributed RDBMS
 Name:		%{sname}%{?pkginfix}_%{pgmajorversion}
 Provides:	%{sname}_%{pgmajorversion}
 Conflicts:	%{sname}_%{pgmajorversion}
-Version:	11.0.10.citus
+Version:	12.1.3.citus
 Release:	1%{dist}
 License:	AGPLv3
 Group:		Applications/Databases
-Source0:	https://github.com/citusdata/citus/archive/v11.0.10.tar.gz
+Source0:	https://github.com/citusdata/citus/archive/v12.1.3.tar.gz
 URL:		https://github.com/citusdata/citus
 BuildRequires:	postgresql%{pgmajorversion}-devel libcurl-devel
 Requires:	postgresql%{pgmajorversion}-server
@@ -112,6 +112,9 @@ fi
 %doc %{pginstdir}/doc/extension/NOTICE-%{sname}
 
 %changelog
+* Wed Apr 24 2024 - Gurkan Indibay <gindibay@microsoft.com> 12.1.3.citus-1
+- Official 12.1.3 release of Citus
+
 * Fri Feb 16 2024 - Gurkan Indibay <gindibay@microsoft.com> 11.0.10.citus-1
 - Official 11.0.10 release of Citus
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+citus (12.1.3.citus-1) stable; urgency=low
+
+  * Official 12.1.3 release of Citus
+
+ -- Gurkan Indibay <gindibay@microsoft.com>  Wed, 24 Apr 2024 11:17:35 +0000
+
 citus (11.0.10.citus-1) stable; urgency=low
 
   * Official 11.0.10 release of Citus

--- a/pkgvars
+++ b/pkgvars
@@ -1,5 +1,5 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
-pkglatest=11.0.10.citus-1
+pkglatest=12.1.3.citus-1
 nightlyref=main
 versioning=fancy


### PR DESCRIPTION
Other than regular version changes, I needed to remove sudo apt-get update commands from pipeline files since weird errors appeared releated to microsoft packages. I suppose that there may be changes in repositories of stock images of Github runners. 
 Here you can sess the error:
 https://github.com/citusdata/packaging/actions/runs/8813807672/job/24192341550#step:4:37