### PR TITLE
Parameterizing orgname, Updating Patch, and Removing Debian Buster

### DIFF
--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -53,7 +53,8 @@ jobs:
           - 15
           - 16
         include:
-          - TARGET_PLATFORM: debian,buster
+          # - TARGET_PLATFORM: debian,buster
+          # removing due to EOL of debian buster
           - TARGET_PLATFORM: debian,bullseye
           - TARGET_PLATFORM: debian,bookworm
           # removing temporarily since postgres 16 packages does not exist for ubuntu bionic

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -53,7 +53,7 @@ jobs:
           - 15
           - 16
         include:
-          # removing due to EOL of debian, buster
+          # removing due to EOL of debian buster
           # - TARGET_PLATFORM: debian,buster
           - TARGET_PLATFORM: debian,bullseye
           - TARGET_PLATFORM: debian,bookworm

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -53,7 +53,8 @@ jobs:
           - 15
           - 16
         include:
-          - TARGET_PLATFORM: debian,buster
+          # removing due to EOL of debian buster
+          # - TARGET_PLATFORM: debian,buster
           - TARGET_PLATFORM: debian,bullseye
           - TARGET_PLATFORM: debian,bookworm
           # removing temporarily since postgres 16 packages does not exist for ubuntu bionic

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -53,7 +53,7 @@ jobs:
           - 15
           - 16
         include:
-          # removing due to EOL of debian buster
+          # removing due to EOL of debian, buster
           # - TARGET_PLATFORM: debian,buster
           - TARGET_PLATFORM: debian,bullseye
           - TARGET_PLATFORM: debian,bookworm

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -53,7 +53,7 @@ jobs:
           - 15
           - 16
         include:
-          # removing due to EOL of debian buster
+          # removing due to EOL of debian,buster
           # - TARGET_PLATFORM: debian,buster
           - TARGET_PLATFORM: debian,bullseye
           - TARGET_PLATFORM: debian,bookworm

--- a/make_pg_buildext_parallel.patch
+++ b/make_pg_buildext_parallel.patch
@@ -1,17 +1,29 @@
---- /usr/bin/pg_buildext	2020-11-27 12:41:34.000000000 +0300
-+++ /usr/bin/pg_buildext	2023-03-01 12:51:34.000000000 +0300
-@@ -107,11 +107,13 @@ substvars() {
- install() {
-     prepare_env $1
-     package=`echo $opt | sed -e "s:%v:$1:g"`
-+    procs="$(nproc)"
-+    mjobs="$(expr $procs + 1)"
- 
-     mkdir -p $vtarget
-     # if a Makefile was created by configure, use it, else the top level Makefile
-     [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
--    make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
-+    make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 $MAKEVARS || return $?
-     substvars "$1" "$package"
- }
- 
+*** usr/bin/pg_buildext	Mon Dec 16 11:43:17 2024
+--- usr/bin/pg_buildext	Mon Dec 16 11:48:46 2024
+***************
+*** 107,117 ****
+  install() {
+      prepare_env $1
+      package=`echo $opt | sed -e "s:%v:$1:g"`
+  
+      mkdir -p $vtarget
+      # if a Makefile was created by configure, use it, else the top level Makefile
+      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
+!     make -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 ${MAKEVARS:-} || return $?
+      substvars "$1" "$package"
+  }
+  
+--- 107,119 ----
+  install() {
+      prepare_env $1
+      package=`echo $opt | sed -e "s:%v:$1:g"`
++     procs="$(nproc)"
++     mjobs="$(expr $procs + 1)"
+  
+      mkdir -p $vtarget
+      # if a Makefile was created by configure, use it, else the top level Makefile
+      [ -f $vtarget/Makefile ] || makefile="-f $srcdir/Makefile"
+!     make -j${mjobs} -C $vtarget ${makefile:-} install DESTDIR="$PWD/debian/$package" PG_CONFIG="$pgc" VPATH="$srcdir" USE_PGXS=1 ${MAKEVARS:-} || return $?
+      substvars "$1" "$package"
+  }
+  

--- a/scripts/fetch_and_build_deb
+++ b/scripts/fetch_and_build_deb
@@ -66,6 +66,7 @@ source /buildfiles/pkgvars
 declare pkglatest # to make shellcheck happy
 pkgname="${deb_pkgname:-${pkgname}}"
 hubproj="${hubproj:-${pkgname}}"
+orgname="${orgname:-citusdata}" # Default to citusdata if not set in pkgvars
 nightlyref="${nightlyref:-master}"
 versioning="${versioning:-simple}"
 if [[ "${pkglatest}" == *"beta"* ]]; then
@@ -97,7 +98,8 @@ export EMAIL
 EMAIL=$(determine_email)
 
 cp -R /buildfiles/debian "${builddir}"
-repopath="citusdata/${hubproj}"
+repopath="${orgname}/${hubproj}"
+echo "Repository path: ${repopath}" # to see whether correct or not
 
 case "${1}" in
     release)


### PR DESCRIPTION
- Added orgname as a parameter sourced from the pkgvars file.
- Incorporated new content into the make_pg_buildext_parallel.patch file to align with the latest build requirements.
- Removed Debian Buster due to its EOL.