### PR TITLE
Redhat HLL - Update build pipeline to add postgres version 17

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -22,10 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - el/7
           - el/8
           - el/9
-          - ol/7
           - ol/8
           - ol/9
     steps:
@@ -33,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Clone tools branch
-        run: git clone -b v0.8.27 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.31 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/postgres-matrix.yml
+++ b/postgres-matrix.yml
@@ -7,4 +7,4 @@ version_matrix:
   - 2.17:
       postgres_versions: [ 10, 11, 12, 13, 14, 15 ]
   - 2.18:
-      postgres_versions: [ 11, 12, 13, 14, 15, 16 ]
+      postgres_versions: [ 11, 12, 13, 14, 15, 16, 17 ]


### PR DESCRIPTION
Since no code changes are required to support PostgreSQL 17 for HLL, the PR only adds PostgreSQL 17 support and does not introduce a new release.