### PR TITLE
Add PostgreSQL 18 support

### DIFF
--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -50,6 +50,7 @@ jobs:
           - 15
           - 16
           - 17
+          - 18
         include:
           - TARGET_PLATFORM: debian,bullseye
           - TARGET_PLATFORM: debian,bookworm

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -50,6 +50,7 @@ jobs:
           - 15
           - 16
           - 17
+          - 18
         include:
           - TARGET_PLATFORM: debian,bullseye
           - TARGET_PLATFORM: debian,bookworm

--- a/.github/workflows/image-health-check.yml
+++ b/.github/workflows/image-health-check.yml
@@ -52,6 +52,7 @@ jobs:
           - 15
           - 16
           - 17
+          - 18
         include:
           - TARGET_PLATFORM: debian,bullseye
           - TARGET_PLATFORM: debian,bookworm

--- a/ci/push_images
+++ b/ci/push_images
@@ -4,7 +4,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-pgversions='12 13 14 15 16 17'
+pgversions='12 13 14 15 16 17 18'
 topdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 dockerfiles_dir="${topdir}/dockerfiles"
 

--- a/dockerfiles/almalinux-8-pg11/Dockerfile
+++ b/dockerfiles/almalinux-8-pg11/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 11  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-8-pg12/Dockerfile
+++ b/dockerfiles/almalinux-8-pg12/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 12  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-8-pg13/Dockerfile
+++ b/dockerfiles/almalinux-8-pg13/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 13  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-8-pg14/Dockerfile
+++ b/dockerfiles/almalinux-8-pg14/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 14  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-8-pg15/Dockerfile
+++ b/dockerfiles/almalinux-8-pg15/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 15  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-8-pg16/Dockerfile
+++ b/dockerfiles/almalinux-8-pg16/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 16  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-8-pg17/Dockerfile
+++ b/dockerfiles/almalinux-8-pg17/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 17  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-8-pg18/Dockerfile
+++ b/dockerfiles/almalinux-8-pg18/Dockerfile
@@ -1,13 +1,13 @@
 # vim:set ft=dockerfile:
-FROM oraclelinux:8
-RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
+FROM almalinux:8
+RUN [[ almalinux != centos ]] || [[ 8 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update
 
-RUN  [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
+RUN  [[ almalinux != centos ]] || [[ 8 != 8 ]] || ( \
     dnf install epel-release -y && \
     dnf install dnf-plugins-core -y && \
     dnf install epel-release -y && \
@@ -15,7 +15,7 @@ RUN  [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     dnf install -y perl-IPC-Run \
     )
 
-RUN  [[ oraclelinux != almalinux ]] || [[ 8 != 8 ]] || ( \
+RUN  [[ almalinux != almalinux ]] || [[ 8 != 8 ]] || ( \
     dnf install epel-release -y && \
     dnf install dnf-plugins-core -y && \
     dnf install epel-release -y && \
@@ -23,7 +23,7 @@ RUN  [[ oraclelinux != almalinux ]] || [[ 8 != 8 ]] || ( \
     dnf install -y perl-IPC-Run \
     )
 
-RUN  [[ oraclelinux != oraclelinux ]] || [[ 8 != 8 ]] || ( \
+RUN  [[ almalinux != oraclelinux ]] || [[ 8 != 8 ]] || ( \
     curl -sO  https://vault.centos.org/centos/8/PowerTools/x86_64/os/Packages/perl-IO-Tty-1.12-11.el8.x86_64.rpm && \
     curl -sO  https://vault.centos.org/centos/8/PowerTools/x86_64/os/Packages/perl-IPC-Run-0.99-1.el8.noarch.rpm && \
     dnf install perl-IO-Tty-1.12-11.el8.x86_64.rpm -y  && \
@@ -32,7 +32,7 @@ RUN  [[ oraclelinux != oraclelinux ]] || [[ 8 != 8 ]] || ( \
     rm -f perl-IO-Tty-1.12-11.el8.x86_64.rpm \
     )
 
-RUN  [[ oraclelinux != almalinux ]] || [[ 8 != 9 ]] || ( \
+RUN  [[ almalinux != almalinux ]] || [[ 8 != 9 ]] || ( \
     dnf install epel-release -y && \
     dnf -y install dnf-plugins-core && \
     dnf config-manager --enable epel && \
@@ -46,7 +46,7 @@ RUN ( yum install -y yum-plugin-ovl || yum install -y yum-plugin-ovl || touch /v
 
 # Enable some other repos for some dependencies in OL/7 
 # see https://yum.oracle.com/getting-started.html#installing-from-oracle-linux-yum-server
-RUN [[ oraclelinux != oraclelinux ]] || [[ 8 != 7 ]] || ( \
+RUN [[ almalinux != oraclelinux ]] || [[ 8 != 7 ]] || ( \
        yum install -y oraclelinux-release-el7 oracle-softwarecollection-release-el7 oracle-epel-release-el7  oraclelinux-developer-release-el7 \
        && yum-config-manager --enable \
             ol7_software_collections \
@@ -63,10 +63,10 @@ RUN [[ oraclelinux != oraclelinux ]] || [[ 8 != 7 ]] || ( \
 # in oracle 7 repos. So package from centos repo was used
 # There is no package in oracle repos for lz4. Also it is not preloaded. So both lz4 and lz4-devel packages
 # were downloaded from centos el/6 repos
-RUN if [[ oraclelinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y wget \
+RUN if [[ almalinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y wget \
         && wget http://mirror.centos.org/centos/7/os/x86_64/Packages/lz4-devel-1.8.3-1.el7.x86_64.rpm \
         && rpm -ivh lz4-devel-1.8.3-1.el7.x86_64.rpm ; \
-        elif [[ oraclelinux   == oraclelinux ]] && [[ 8 == 6 ]]; then yum install -y wget \
+        elif [[ almalinux   == oraclelinux ]] && [[ 8 == 6 ]]; then yum install -y wget \
         && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-r131-1.el6.x86_64.rpm \
         && rpm -ivh lz4-r131-1.el6.x86_64.rpm \
         && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-devel-r131-1.el6.x86_64.rpm \
@@ -75,7 +75,7 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y w
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
+    && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
         bzip2-devel \
@@ -99,7 +99,7 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         libzstd-devel \
         llvm-toolset ccache spectool curl \
     && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
-    && yum install -y postgresql12-server postgresql12-devel \
+    && yum install -y postgresql18-server postgresql18-devel \
     && yum clean all
 
 # install jq to process JSON API responses
@@ -132,7 +132,7 @@ RUN yum -y install  perl-IPC-Cmd libuuid-devel cmake3
 # Git 2.7.1 is minimum requirement for cmake so we remove and reinstall latests git from an up-to-date repo
 # Symbolic link is not being created for cmake from cmake3 by default. Therefore, we need to create the link as well.
 # devtoolset-8-gcc-c++ is required to compile azure sdk in pg azure storage project
-RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
+RUN [[ almalinux != centos ]] || [[ 8 != 7 ]] || ( \
     yum -y install  perl-IPC-Cmd libuuid-devel cmake3 && \
     ln -s /usr/bin/cmake3 /usr/bin/cmake  && \
     yum -y remove git && \
@@ -165,7 +165,7 @@ RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 
 # set PostgreSQL version, place scripts on path, and declare output volume
-ENV PGVERSION=12 \
+ENV PGVERSION=18 \
     PATH=/scripts:$PATH
 COPY scripts /scripts
 VOLUME /packages

--- a/dockerfiles/almalinux-9-pg11/Dockerfile
+++ b/dockerfiles/almalinux-9-pg11/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 11  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-9-pg12/Dockerfile
+++ b/dockerfiles/almalinux-9-pg12/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 12  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-9-pg13/Dockerfile
+++ b/dockerfiles/almalinux-9-pg13/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 13  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-9-pg14/Dockerfile
+++ b/dockerfiles/almalinux-9-pg14/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 14  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-9-pg15/Dockerfile
+++ b/dockerfiles/almalinux-9-pg15/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 15  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-9-pg16/Dockerfile
+++ b/dockerfiles/almalinux-9-pg16/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 16  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-9-pg17/Dockerfile
+++ b/dockerfiles/almalinux-9-pg17/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wge
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 17  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/almalinux-9-pg18/Dockerfile
+++ b/dockerfiles/almalinux-9-pg18/Dockerfile
@@ -1,13 +1,13 @@
 # vim:set ft=dockerfile:
-FROM oraclelinux:8
-RUN [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
+FROM almalinux:9
+RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update
 
-RUN  [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
+RUN  [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     dnf install epel-release -y && \
     dnf install dnf-plugins-core -y && \
     dnf install epel-release -y && \
@@ -15,7 +15,7 @@ RUN  [[ oraclelinux != centos ]] || [[ 8 != 8 ]] || ( \
     dnf install -y perl-IPC-Run \
     )
 
-RUN  [[ oraclelinux != almalinux ]] || [[ 8 != 8 ]] || ( \
+RUN  [[ almalinux != almalinux ]] || [[ 9 != 8 ]] || ( \
     dnf install epel-release -y && \
     dnf install dnf-plugins-core -y && \
     dnf install epel-release -y && \
@@ -23,7 +23,7 @@ RUN  [[ oraclelinux != almalinux ]] || [[ 8 != 8 ]] || ( \
     dnf install -y perl-IPC-Run \
     )
 
-RUN  [[ oraclelinux != oraclelinux ]] || [[ 8 != 8 ]] || ( \
+RUN  [[ almalinux != oraclelinux ]] || [[ 9 != 8 ]] || ( \
     curl -sO  https://vault.centos.org/centos/8/PowerTools/x86_64/os/Packages/perl-IO-Tty-1.12-11.el8.x86_64.rpm && \
     curl -sO  https://vault.centos.org/centos/8/PowerTools/x86_64/os/Packages/perl-IPC-Run-0.99-1.el8.noarch.rpm && \
     dnf install perl-IO-Tty-1.12-11.el8.x86_64.rpm -y  && \
@@ -32,7 +32,7 @@ RUN  [[ oraclelinux != oraclelinux ]] || [[ 8 != 8 ]] || ( \
     rm -f perl-IO-Tty-1.12-11.el8.x86_64.rpm \
     )
 
-RUN  [[ oraclelinux != almalinux ]] || [[ 8 != 9 ]] || ( \
+RUN  [[ almalinux != almalinux ]] || [[ 9 != 9 ]] || ( \
     dnf install epel-release -y && \
     dnf -y install dnf-plugins-core && \
     dnf config-manager --enable epel && \
@@ -46,7 +46,7 @@ RUN ( yum install -y yum-plugin-ovl || yum install -y yum-plugin-ovl || touch /v
 
 # Enable some other repos for some dependencies in OL/7 
 # see https://yum.oracle.com/getting-started.html#installing-from-oracle-linux-yum-server
-RUN [[ oraclelinux != oraclelinux ]] || [[ 8 != 7 ]] || ( \
+RUN [[ almalinux != oraclelinux ]] || [[ 9 != 7 ]] || ( \
        yum install -y oraclelinux-release-el7 oracle-softwarecollection-release-el7 oracle-epel-release-el7  oraclelinux-developer-release-el7 \
        && yum-config-manager --enable \
             ol7_software_collections \
@@ -63,10 +63,10 @@ RUN [[ oraclelinux != oraclelinux ]] || [[ 8 != 7 ]] || ( \
 # in oracle 7 repos. So package from centos repo was used
 # There is no package in oracle repos for lz4. Also it is not preloaded. So both lz4 and lz4-devel packages
 # were downloaded from centos el/6 repos
-RUN if [[ oraclelinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y wget \
+RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wget \
         && wget http://mirror.centos.org/centos/7/os/x86_64/Packages/lz4-devel-1.8.3-1.el7.x86_64.rpm \
         && rpm -ivh lz4-devel-1.8.3-1.el7.x86_64.rpm ; \
-        elif [[ oraclelinux   == oraclelinux ]] && [[ 8 == 6 ]]; then yum install -y wget \
+        elif [[ almalinux   == oraclelinux ]] && [[ 9 == 6 ]]; then yum install -y wget \
         && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-r131-1.el6.x86_64.rpm \
         && rpm -ivh lz4-r131-1.el6.x86_64.rpm \
         && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-devel-r131-1.el6.x86_64.rpm \
@@ -74,8 +74,8 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y w
         else yum install -y lz4 lz4-devel; fi
 
 # install build tools and PostgreSQL development files
-RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
+RUN yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+    && [[ -z "epel-release" ]] || yum install -y epel-release \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
         bzip2-devel \
@@ -97,10 +97,11 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         tar \
         libzstd \
         libzstd-devel \
-        llvm-toolset ccache spectool curl \
-    && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
-    && yum install -y postgresql12-server postgresql12-devel \
+        llvm-toolset ccache rpmdevtools krb5-devel \
+    && ( [[ 9 != 8 ]] || dnf -qy module disable postgresql ) \
+    && yum install -y postgresql18-server postgresql18-devel \
     && yum clean all
+
 
 # install jq to process JSON API responses
 RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
@@ -132,7 +133,7 @@ RUN yum -y install  perl-IPC-Cmd libuuid-devel cmake3
 # Git 2.7.1 is minimum requirement for cmake so we remove and reinstall latests git from an up-to-date repo
 # Symbolic link is not being created for cmake from cmake3 by default. Therefore, we need to create the link as well.
 # devtoolset-8-gcc-c++ is required to compile azure sdk in pg azure storage project
-RUN [[ oraclelinux != centos ]] || [[ 8 != 7 ]] || ( \
+RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  perl-IPC-Cmd libuuid-devel cmake3 && \
     ln -s /usr/bin/cmake3 /usr/bin/cmake  && \
     yum -y remove git && \
@@ -165,7 +166,7 @@ RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 
 # set PostgreSQL version, place scripts on path, and declare output volume
-ENV PGVERSION=12 \
+ENV PGVERSION=18 \
     PATH=/scripts:$PATH
 COPY scripts /scripts
 VOLUME /packages

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -44,7 +44,7 @@ RUN ( [ debian != debian ] || [ bookworm != buster ] ) || ( \
 
 # install build tools and PostgreSQL development files
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main 17' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main 18' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main 17' > 
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
-        postgresql-server-dev-17 \
+        postgresql-server-dev-18 \
         wget \
         zlib1g-dev \
         python3-pip \
@@ -104,9 +104,8 @@ RUN curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
-COPY make_pg_buildext_parallel.patch /
-RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
-
+# COPY make_pg_buildext_parallel.patch /
+# RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
 
 # install cmake from source
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \
@@ -131,8 +130,8 @@ RUN set -ex \
     && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
-# Added for pg17 beta package support.
-ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15 16 17"
+# Added for pg18  package support.
+ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15 16 17 18"
 
 # place scripts on path and declare output volume
 ENV PATH /scripts:$PATH

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -44,7 +44,7 @@ RUN ( [ debian != debian ] || [ bullseye != buster ] ) || ( \
 
 # install build tools and PostgreSQL development files
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main 17' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main 18' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main 17' > 
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
-        postgresql-server-dev-17 \
+        postgresql-server-dev-18 \
         wget \
         zlib1g-dev \
         python3-pip \
@@ -104,8 +104,8 @@ RUN curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
-COPY make_pg_buildext_parallel.patch /
-RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
+#COPY make_pg_buildext_parallel.patch /
+#RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
 
 
 # install cmake from source
@@ -131,8 +131,8 @@ RUN set -ex \
     && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
-# Added for pg17 beta package support.
-ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15 16 17"
+# Added for pg18  package support.
+ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15 16 17 18"
 
 # place scripts on path and declare output volume
 ENV PATH /scripts:$PATH

--- a/dockerfiles/debian-trixie-all/Dockerfile
+++ b/dockerfiles/debian-trixie-all/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex; \
     gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/postgres.gpg; \
     command -v gpgconf > /dev/null && gpgconf --kill all; \
     rm -rf "$GNUPGHOME"; \
-    apt-key list
+    apt-key list || true
 
 # add buster backports repo to be able to download missing packages in buster main repo
 RUN ( [ debian != debian ] || [ trixie != buster ] ) || ( \
@@ -44,7 +44,7 @@ RUN ( [ debian != debian ] || [ trixie != buster ] ) || ( \
 
 # install build tools and PostgreSQL development files
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ trixie-pgdg main 17' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ trixie-pgdg main 18' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ trixie-pgdg main 17' > /e
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
-        postgresql-server-dev-17 \
+        postgresql-server-dev-18 \
         wget \
         zlib1g-dev \
         python3-pip \
@@ -104,8 +104,8 @@ RUN curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
-COPY make_pg_buildext_parallel.patch /
-RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
+# COPY make_pg_buildext_parallel.patch /
+# RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
 
 
 # install cmake from source
@@ -131,8 +131,8 @@ RUN set -ex \
     && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
-# Added for pg17 beta package support.
-ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15 16 17"
+# Added for pg18  package support.
+ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15 16 17 18"
 
 # place scripts on path and declare output volume
 ENV PATH /scripts:$PATH

--- a/dockerfiles/oraclelinux-6-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg11/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 6 == 7 ]]; then yum install -y w
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 11  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/oraclelinux-6-pg12/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg12/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 6 == 7 ]]; then yum install -y w
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 12  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/oraclelinux-6-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg14/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 6 == 7 ]]; then yum install -y w
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 14  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/oraclelinux-6-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg15/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 6 == 7 ]]; then yum install -y w
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 15  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/oraclelinux-6-pg16/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg16/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 6 == 7 ]]; then yum install -y w
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 16  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/oraclelinux-6-pg17/Dockerfile
+++ b/dockerfiles/oraclelinux-6-pg17/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 6 == 7 ]]; then yum install -y w
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 17  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "" ]] || yum install -y ) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/oraclelinux-8-pg11/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg11/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y w
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 11  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/oraclelinux-8-pg13/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg13/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y w
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 13  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/oraclelinux-8-pg14/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg14/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y w
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 14  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/oraclelinux-8-pg15/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg15/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y w
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 15  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/oraclelinux-8-pg16/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg16/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y w
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 16  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/oraclelinux-8-pg17/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg17/Dockerfile
@@ -75,7 +75,6 @@ RUN if [[ oraclelinux   == oraclelinux ]] && [[ 8 == 7 ]]; then yum install -y w
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
-    && ( [[ 17  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "oracle-epel-release-el8" ]] || yum install -y oracle-epel-release-el8) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/dockerfiles/oraclelinux-8-pg18/Dockerfile
+++ b/dockerfiles/oraclelinux-8-pg18/Dockerfile
@@ -99,7 +99,7 @@ RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8
         libzstd-devel \
         llvm-toolset ccache spectool curl \
     && ( [[ 8 != 8 ]] || dnf -qy module disable postgresql ) \
-    && yum install -y postgresql12-server postgresql12-devel \
+    && yum install -y postgresql18-server postgresql18-devel \
     && yum clean all
 
 # install jq to process JSON API responses
@@ -165,7 +165,7 @@ RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 
 # set PostgreSQL version, place scripts on path, and declare output volume
-ENV PGVERSION=12 \
+ENV PGVERSION=18 \
     PATH=/scripts:$PATH
 COPY scripts /scripts
 VOLUME /packages

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -44,7 +44,7 @@ RUN ( [ ubuntu != debian ] || [ focal != buster ] ) || ( \
 
 # install build tools and PostgreSQL development files
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main 17' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main 18' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main 17' > /et
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
-        postgresql-server-dev-17 \
+        postgresql-server-dev-18 \
         wget \
         zlib1g-dev \
         python3-pip \
@@ -104,8 +104,8 @@ RUN curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
-COPY make_pg_buildext_parallel.patch /
-RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
+# COPY make_pg_buildext_parallel.patch /
+#RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
 
 
 # install cmake from source

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -104,8 +104,8 @@ RUN curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
-COPY make_pg_buildext_parallel.patch /
-RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
+# COPY make_pg_buildext_parallel.patch /
+# RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
 
 
 # install cmake from source

--- a/dockerfiles/ubuntu-noble-all/Dockerfile
+++ b/dockerfiles/ubuntu-noble-all/Dockerfile
@@ -104,8 +104,8 @@ RUN curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors
-COPY make_pg_buildext_parallel.patch /
-RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
+# COPY make_pg_buildext_parallel.patch /
+# RUN patch `which pg_buildext` < /make_pg_buildext_parallel.patch
 
 
 # install cmake from source

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -44,7 +44,7 @@ RUN ( [ %%os%% != debian ] || [ %%release%% != buster ] ) || ( \
 
 # install build tools and PostgreSQL development files
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main 17' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main 18' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main 17'
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
-        postgresql-server-dev-17 \
+        postgresql-server-dev-18 \
         wget \
         zlib1g-dev \
         python3-pip \
@@ -131,8 +131,8 @@ RUN set -ex \
     && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
-# Added for pg17 beta package support.
-ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15 16 17"
+# Added for pg18  package support.
+ENV DEB_PG_SUPPORTED_VERSIONS="10 11 12 13 14 15 16 17 18"
 
 # place scripts on path and declare output volume
 ENV PATH /scripts:$PATH

--- a/templates/Dockerfile-rpm.tmpl
+++ b/templates/Dockerfile-rpm.tmpl
@@ -75,7 +75,6 @@ RUN if [[ %%os%%   == oraclelinux ]] && [[ %%release%% == 7 ]]; then yum install
 
 # install build tools and PostgreSQL development files
 RUN ( yum install -y https://%%rpm_url%%  \
-    && ( [[ %%pgshort%%  != 17 ]] || sed -i '/\[pgdg17-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
     && [[ -z "%%extra-repositories%%" ]] || yum install -y %%extra-repositories%%) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \

--- a/update_dockerfiles
+++ b/update_dockerfiles
@@ -4,7 +4,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-pgversions='11 12 13 14 15 16 17'
+pgversions='11 12 13 14 15 16 17 18'
 topdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 dockerfiles_dir="${topdir}/dockerfiles"
 templates_dir="${topdir}"/templates

--- a/update_image
+++ b/update_image
@@ -9,7 +9,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-pgversions='11 12 13 14 15 16 17'
+pgversions='11 12 13 14 15 16 17 18'
 topdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 dockerfiles_dir="${topdir}/dockerfiles"
 


### PR DESCRIPTION
This PR adds support for PostgreSQL 18.1 across the packaging images and CI pipelines.

Key changes:

* Enable building and testing against PostgreSQL 18 for supported RPM- and DEB-based distributions.

* Update CI matrices to account for PostgreSQL 18.

This brings the packaging repo in line with Citus compatibility for PostgreSQL 18.1.
