### PR TITLE
Packaging: GH App token migration (phase 2) - app-token mint + tools 0.8.36 pin

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -40,6 +40,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export App token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       # This step is to fetch the images unanonymously to have higher bandwidth
       - name: Login to Docker Hub
         uses: docker/login-action@v4
@@ -48,7 +61,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36-dev2 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev3 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Clone build branch
         run: git clone -b "${MAIN_BRANCH}" --depth=1  https://github.com/citusdata/packaging.git packaging

--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -44,7 +44,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -61,7 +61,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36-dev3 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev5 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Clone build branch
         run: git clone -b "${MAIN_BRANCH}" --depth=1  https://github.com/citusdata/packaging.git packaging

--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -61,7 +61,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36-dev5 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Clone build branch
         run: git clone -b "${MAIN_BRANCH}" --depth=1  https://github.com/citusdata/packaging.git packaging

--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -91,7 +91,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev4 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -91,7 +91,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev3 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev4 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |
@@ -99,6 +99,7 @@ jobs:
           python -m pytest -q tools/packaging_automation/tests/test_citus_package.py -k 'test_build_packages'
         env:
           PACKAGING_IMAGE_PLATFORM: "${{matrix.TARGET_PLATFORM}}"
+          POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Push images
         run: |

--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -60,6 +60,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export App token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Install package dependencies
         run: |
           sudo apt-get update
@@ -78,7 +91,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev2 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev3 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -64,7 +64,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -91,7 +91,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -91,7 +91,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev4 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -91,7 +91,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev3 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev4 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |
@@ -99,6 +99,7 @@ jobs:
           python -m pytest -q tools/packaging_automation/tests/test_citus_package.py -k 'test_build_packages'
         env:
           PACKAGING_IMAGE_PLATFORM: "${{matrix.TARGET_PLATFORM}}"
+          POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Push images
         run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -60,6 +60,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export App token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Install package dependencies
         run: |
           sudo apt-get update
@@ -78,7 +91,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev2 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev3 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -64,7 +64,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -91,7 +91,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -41,6 +41,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export App token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       # This step is to fetch the images unanonymously to have higher bandwidth
       - name: Login to Docker Hub
         uses: docker/login-action@v4
@@ -49,7 +62,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36-dev2 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev3 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Clone build branch
         run: git clone -b "${MAIN_BRANCH}" --depth=1  https://github.com/citusdata/packaging.git packaging

--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -62,7 +62,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36-dev3 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev5 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Clone build branch
         run: git clone -b "${MAIN_BRANCH}" --depth=1  https://github.com/citusdata/packaging.git packaging

--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -45,7 +45,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -62,7 +62,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36-dev5 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Clone build branch
         run: git clone -b "${MAIN_BRANCH}" --depth=1  https://github.com/citusdata/packaging.git packaging

--- a/.github/workflows/image-health-check.yml
+++ b/.github/workflows/image-health-check.yml
@@ -93,7 +93,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev4 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/image-health-check.yml
+++ b/.github/workflows/image-health-check.yml
@@ -93,7 +93,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/image-health-check.yml
+++ b/.github/workflows/image-health-check.yml
@@ -93,7 +93,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev3 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev4 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |
@@ -101,4 +101,5 @@ jobs:
           python -m pytest -q tools/packaging_automation/tests/test_citus_package.py -k 'test_build_packages'
         env:
           PACKAGING_IMAGE_PLATFORM: "${{matrix.TARGET_PLATFORM}}"
+          POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 

--- a/.github/workflows/image-health-check.yml
+++ b/.github/workflows/image-health-check.yml
@@ -62,6 +62,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export App token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Install package dependencies
         run: |
           sudo apt-get update
@@ -80,7 +93,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev2 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev3 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/image-health-check.yml
+++ b/.github/workflows/image-health-check.yml
@@ -66,7 +66,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/update-pgxn-version.yml
+++ b/.github/workflows/update-pgxn-version.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev libssl-dev
 
       - name: Clone Tools branch
-        run: git clone --branch v0.8.35 https://github.com/citusdata/tools.git
+        run: git clone --branch v0.8.36-dev3 https://github.com/citusdata/tools.git
 
       - name: Install Python requirements
         run: python -m pip install -r tools/packaging_automation/requirements.txt

--- a/.github/workflows/update-pgxn-version.yml
+++ b/.github/workflows/update-pgxn-version.yml
@@ -18,6 +18,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export App token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/update-pgxn-version.yml
+++ b/.github/workflows/update-pgxn-version.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev libssl-dev
 
       - name: Clone Tools branch
-        run: git clone --branch v0.8.36-dev5 https://github.com/citusdata/tools.git
+        run: git clone --branch v0.8.36 https://github.com/citusdata/tools.git
 
       - name: Install Python requirements
         run: python -m pip install -r tools/packaging_automation/requirements.txt

--- a/.github/workflows/update-pgxn-version.yml
+++ b/.github/workflows/update-pgxn-version.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev libssl-dev
 
       - name: Clone Tools branch
-        run: git clone --branch v0.8.36-dev3 https://github.com/citusdata/tools.git
+        run: git clone --branch v0.8.36-dev5 https://github.com/citusdata/tools.git
 
       - name: Install Python requirements
         run: python -m pip install -r tools/packaging_automation/requirements.txt

--- a/.github/workflows/update-pgxn-version.yml
+++ b/.github/workflows/update-pgxn-version.yml
@@ -22,7 +22,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -23,7 +23,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Clone Tools branch
-        run: git clone --depth 1 --branch v0.8.36-dev5 https://github.com/citusdata/tools.git
+        run: git clone --depth 1 --branch v0.8.36 https://github.com/citusdata/tools.git
 
       # Runs a set of commands using the runners shell
       - name: Execute Package Properties Update

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -23,7 +23,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Clone Tools branch
-        run: git clone --depth 1 --branch v0.8.35 https://github.com/citusdata/tools.git
+        run: git clone --depth 1 --branch v0.8.36-dev3 https://github.com/citusdata/tools.git
 
       # Runs a set of commands using the runners shell
       - name: Execute Package Properties Update

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -23,7 +23,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Clone Tools branch
-        run: git clone --depth 1 --branch v0.8.36-dev3 https://github.com/citusdata/tools.git
+        run: git clone --depth 1 --branch v0.8.36-dev5 https://github.com/citusdata/tools.git
 
       # Runs a set of commands using the runners shell
       - name: Execute Package Properties Update

--- a/scripts/determine_email
+++ b/scripts/determine_email
@@ -6,23 +6,28 @@ IFS=$'\n\t'
 
 # constants
 success=0
-failure=1
 
-# fallback to public email
-email=$(curl -sf https://api.github.com/user | jq -r '.email // empty')
+# Resolve the packager email WITHOUT contacting api.github.com/user or
+# /user/emails, which are incompatible with GitHub App installation tokens (the
+# App identity has no user endpoint and returns 403). Precedence: explicit env,
+# then the address embedded in RPM_PACKAGER, then a fixed bot identity.
+email="${PACKAGER_EMAIL:-}"
 
-# first try to find Microsoft email, if fails, then it must be the
-# case that bots@citusdata.com is building nightly packages for us
-jqfilter='map(select(.verified and (.email | test("@microsoft.com$|^bots@citusdata.com$")))) | first | .email // empty'
-citusemail=$(curl -sf https://api.github.com/user/emails | jq -r "${jqfilter}")
+if [ -z "${email}" ]; then
+    email="${DEBEMAIL:-}"
+fi
 
-if [ -n "${citusemail}" ]; then
-    email="${citusemail}"
+if [ -z "${email}" ] && [ -n "${RPM_PACKAGER:-}" ]; then
+    # Extract the address from "Full Name <email@example.com>" if present.
+    case "${RPM_PACKAGER}" in
+        *"<"*">"*)
+            email="$(printf '%s' "${RPM_PACKAGER}" | sed -E 's/^.*<([^>]*)>.*$/\1/')"
+            ;;
+    esac
 fi
 
 if [ -z "${email}" ]; then
-    echo "$0: could not determine email" >&2
-    exit $failure
+    email="bots@citusdata.com"
 fi
 
 echo "${email}"

--- a/scripts/determine_name
+++ b/scripts/determine_name
@@ -6,14 +6,25 @@ IFS=$'\n\t'
 
 # constants
 success=0
-failure=1
 
-fullname=$(curl -sf https://api.github.com/user | jq -r '.name // empty')
+# Resolve the packager name WITHOUT contacting api.github.com/user, which is
+# incompatible with GitHub App installation tokens (the App identity has no user
+# endpoint and returns 403). Precedence: explicit env, then the name portion of
+# RPM_PACKAGER, then DEBFULLNAME, then a fixed bot identity.
+name="${PACKAGER_NAME:-}"
 
-if [ -z "${fullname}" ]; then
-    echo "$0: could not determine user name" >&2
-    exit $failure
+if [ -z "${name}" ] && [ -n "${RPM_PACKAGER:-}" ]; then
+    # RPM_PACKAGER is typically "Full Name <email@example.com>"; drop the address.
+    name="$(printf '%s' "${RPM_PACKAGER}" | sed -E 's/[[:space:]]*<[^>]*>[[:space:]]*$//')"
 fi
 
-echo "${fullname}"
+if [ -z "${name}" ]; then
+    name="${DEBFULLNAME:-}"
+fi
+
+if [ -z "${name}" ]; then
+    name="Citus Bot"
+fi
+
+echo "${name}"
 exit $success


### PR DESCRIPTION
## Summary

Phase 2 of the citusdata CI migration from the org PAT secret `GH_TOKEN` to a GitHub App installation token, for the packaging workflows. Three coordinated parts plus the script fix the App token exposed:

### 1. App-token mint (replaces org PAT)
Replace the `GH_TOKEN` org-PAT secret with a per-run GitHub App installation token via `actions/create-github-app-token@v3` in all token-consuming workflows:
- `app-id: ${{ vars.GH_APP_ID }}` (GH_APP_ID is an **org variable**, not a secret -- no secrets fallback)
- `private-key: ${{ secrets.GH_APP_KEY }}` (real secret, retained)
- token exported to `$GITHUB_ENV` (`GH_TOKEN` + `GITHUB_TOKEN`) so downstream steps/containers receive the App token
- paired with `docker/login-action@v4` where a DockerHub login exists (the 2 nightly workflows)

### 2. Tools-clone pin -> v0.8.36-dev5
Pin all 7 workflow tools-clones to `v0.8.36-dev5` (adds `build_packages` per-pg-version filter + pytest harness fixes: filtered-count assertion + graceful skip for out-of-set pg versions). The dev3->dev5 delta is behaviorally inert for callers that don't pass `postgres_version` (guarded by `if postgres_version:`), so nightly/write workflows iterate identically to before.

### 3. R1 fix -- drop /user from bot identity resolution
`scripts/determine_name` / `scripts/determine_email` previously curled `https://api.github.com/user`, which **403s under an App installation token** (the App identity has no `/user` endpoint) and, under `set -euo pipefail`, aborted the build with empty output. Fixed to resolve the packager identity from env first (`PACKAGER_NAME`/`PACKAGER_EMAIL` -> `RPM_PACKAGER`/`DEBFULLNAME`/`DEBEMAIL`) with a fixed `Citus Bot <bots@citusdata.com>` fallback -- no `/user` call. The R1-fixed images have been reseeded into the `citus/packaging-test:*` registry tags.

## Validation
All 4 push-event workflows **GREEN** on `ae12aad`:

| Workflow | Run | Result |
|---|---|---|
| Build package for test images | 27846085803 | 22/22 |
| Build Package | 27846085807 | 22/22 |
| Image Health Check | 27846085809 | 22/22 |
| Build & publish citus community nightlies | 27846085815 | 6/6 |

- **MINT = 207/207 success** across all legs -> `vars.GH_APP_ID` resolves with no fallback.
- **Nightly publish skipped** on every leg (`Package publishing skipped since current branch is not equal to develop`) -- nothing published from the feature branch.
- `GH_TOKEN` retained live throughout (zero-downtime; shadowed PAT removal deferred to a later decommission phase).

## Dependency
Relies on tools tag **`v0.8.36-dev5`** (citusdata/tools PR #410) being merged/stable before this is re-pinned to a stable tag.

## Notes
- Benign `app-id` deprecation annotation (`app-id` -> `client-id`) is a deferred stable-phase org-secret item; intentionally keeping `app-id: vars.GH_APP_ID` for now.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
