### PR TITLE
Packaging Phase 4: app-token write-path (update-pgxn-version / update_package_properties)

### DIFF
--- a/.github/workflows/update-pgxn-version.yml
+++ b/.github/workflows/update-pgxn-version.yml
@@ -16,8 +16,11 @@ jobs:
     name: Update pgxn configuration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-
+      # Mint the App token BEFORE checkout so checkout can persist it as the
+      # credential used by the in-repo `git push` (the pgxn PR branch push lives
+      # in the checked-out working dir under --pipeline mode). Without this, the
+      # push would be authenticated by the default ephemeral Actions GITHUB_TOKEN
+      # rather than the App token that opens the PR.
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -25,6 +28,13 @@ jobs:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
+
+      - uses: actions/checkout@v6
+        with:
+          # Persist the App token as the push credential so the write-path
+          # (git push of the pgxn-citus PR branch) is authenticated by the App,
+          # consistent with the App-token PR creation below.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Export App token to environment
         run: |


### PR DESCRIPTION
## Phase 4 — App-token write-path (R4)

Part of the CI migration from the org PAT `secrets.GH_TOKEN` to the GitHub App ("cituspackagingapp", app-id `vars.GH_APP_ID` / key `secrets.GH_APP_KEY`). Phase 0 proved the App has `contents:write` + `pull_requests:write` on `citusdata/packaging` and `citusdata/pgazure` (smoke run create 201 / delete 204 both repos). This phase ensures the **`git push`** legs of the write-path workflows are authenticated by the App token, not the ephemeral Actions `GITHUB_TOKEN`.

### R4 trace per workflow

**`update-pgxn-version.yml` — real gap, fixed here.**
- Runs `python -m tools.packaging_automation.update_pgxn --pipeline --gh_token $GH_TOKEN`, which does `git push --set-upstream origin <pr_branch>` inside the **checked-out working dir** (pipeline mode), then `create_pr(gh_token=app token)`.
- Before this change, `actions/checkout@v6` had **no `token:` override**, so it persisted the default ephemeral Actions `GITHUB_TOKEN` as the push credential. Result: the **push** ran on the ephemeral token (dependent on default workflow-token permissions) while the **PR** was opened by the App — an inconsistent, fragile split. (Note: it was **not** the old PAT — the prior `token:` was never set to `secrets.GH_TOKEN`.)
- **Fix (minimal):** mint the App token **before** checkout and pass `token: ${{ steps.app-token.outputs.token }}` to `actions/checkout@v6`. The persisted push credential is now the App token, end-to-end consistent with `create_pr`. No reliance on default `GITHUB_TOKEN` permissions. Diff = +12 / -2 (comments + reorder).

**`update_package_properties.yml` — no change; reported separately.**
- This workflow does **not** mint any App token and invokes `./tools/bash/update_package_properties.sh`, a path that **does not exist** in `citusdata/tools@v0.8.36` (no `bash/` dir; the real implementation is `packaging_automation/update_package_properties.py`). It is therefore **broken independent of the token migration** and has no functioning push leg to migrate. Repairing it requires fixing the invocation (correct entrypoint + add the mint + `--gh_token`), a larger change to sequence as its own op. **No code change here**; flagged for follow-up.

### Validation
- YAML parses; step order is `mint -> checkout(token: app) -> export -> ... -> push/PR`.
- Top-level `GH_TOKEN` retained (zero-downtime; removed only in Phase 6).
- No force-push. **Draft - do not merge.**

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
