### PR TITLE
ci: gate packaging-test push on develop regardless of TEST

### DIFF
--- a/ci/push_images
+++ b/ci/push_images
@@ -12,8 +12,8 @@ badusage=64
 
 nprocs="${1:-1}"
 
-if [[ ${TEST} == "false" && ${CURRENT_BRANCH} != "develop" ]] ; then
-    echo "PR is not merged to develop, not pushing to DockerHub"
+if [[ ${CURRENT_BRANCH} != "develop" ]] ; then
+    echo "Branch is not develop, not pushing to DockerHub (TEST=${TEST})"
     exit 0;
 fi
 


### PR DESCRIPTION
Feature-branch test images can leak today because TEST=true bypasses the old gate. This one-line fix gates all pushes on develop. Feature branches still build and run pytest; only the shared-tag push is gated. The change is reversible.