### PR TITLE
Migrate all-citus-unit-tests build to GitHub App token

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -36,8 +36,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+      - name: Export app token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+
       - name: Clone tools branch
-        run: git clone -b v0.8.33-dev2 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources
@@ -73,6 +84,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
       - name: Set citus version
         id: set_version
         run: |
@@ -85,4 +102,4 @@ jobs:
           --repo citusdata/tools \
           -f project_version="${{ steps.set_version.outputs.version }}"
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Migrates the `all-citus-unit-tests` build branch from the org PAT (`secrets.GH_TOKEN`) to a GitHub App installation token, matching the pattern already merged on `develop`.

## What changed (`.github/workflows/build-package.yml` only, +19 −2)
- **`build_package` job:** added `actions/create-github-app-token@v3` mint step (app-id `${{ vars.GH_APP_ID }}`, key `${{ secrets.GH_APP_KEY }}`, owner `citusdata`) after Checkout; export step writes **both** `GH_TOKEN` and `GITHUB_TOKEN` to `$GITHUB_ENV` (so the app token overrides the retained PAT shadow at job runtime). `--gh_token "${GH_TOKEN}"` unchanged.
- **`trigger_package_tests` job:** own mint step (same config); `Trigger package tests` step env `GITHUB_TOKEN` swapped `secrets.GH_TOKEN` → `${{ steps.app-token.outputs.token }}`. (`$GITHUB_ENV` does not cross jobs, so each job mints its own.)
- **Tools pin bump:** `v0.8.33-dev2` → `v0.8.36` (carries the R1 `/user`-avoidance fix required under the app token).
- **Zero-downtime:** top-level `GH_TOKEN` / `GITHUB_TOKEN` PAT shadows are **retained** (removed later in Phase 6).

## Validation
Pushed to this branch (`on: push: "**"`) → run [`28454741315`](https://github.com/citusdata/packaging/actions/runs/28454741315) = **SUCCESS**. All 8 build legs (noble/bookworm/ol8/bullseye/ol9/jammy/el9/el8) + Trigger package tests green; app-token mint succeeded on every leg.

Do not merge yet — opening for review.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>