### PR TITLE
Migrate all-citus build to GitHub App token

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -34,6 +34,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+      - name: Export app token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+
       # This step is to fetch the images unanonymously to have higher bandwidth
       - name: Login to Docker Hub
         uses: docker/login-action@v4
@@ -42,7 +53,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.35 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -37,8 +37,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+      - name: Export app token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+
       - name: Clone tools branch
-        run: git clone -b v0.8.35 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: |
@@ -76,6 +87,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
       - name: Set citus version
         id: set_version
         run: |
@@ -88,4 +105,4 @@ jobs:
           --repo citusdata/tools \
           -f project_version="${{ steps.set_version.outputs.version }}"
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -31,17 +31,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Export app token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libcurl4-openssl-dev libssl-dev python3-testresources
 
       - name: Clone tools branch
-        run: git clone -b v0.8.35 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Set git name and email
         run: |


### PR DESCRIPTION
## Summary
Phase 5 of migrating GitHub Actions workflows off PAT tokens (`secrets.GH_TOKEN`) onto GitHub App tokens (`actions/create-github-app-token@v3`) for the **all-citus** build branch.

Migrates the 3 token-needing workflows to mint and use a GitHub App token, while retaining the existing PAT env vars as a rollback shadow (zero-downtime rollback). Also bumps the tools clone pin `v0.8.35` -> `v0.8.36` in each file.

## Migrated workflows
- **build-package.yml** (2 jobs): `build_package` mints an app token + exports `GH_TOKEN`/`GITHUB_TOKEN` to `$GITHUB_ENV` after checkout; `trigger_package_tests` mints an app token and uses it directly for the `gh` dispatch `env.GITHUB_TOKEN`.
- **build-citus-community-nightlies.yml** (1 job): `build_package` mints an app token + exports `GH_TOKEN`/`GITHUB_TOKEN` to `$GITHUB_ENV` after checkout.
- **update_package_properties.yml** (1 job, `workflow_dispatch`-only): app-token mint is the FIRST step (checkout consumes the token via its `token:` input, so mint must precede checkout); checkout `token:` swapped to the minted token; export step added after checkout.

## Pattern
Follows the canonical, already-validated pattern from `ac801cb` (PR #1188):
- Per-job app-token mint: `actions/create-github-app-token@v3` with `app-id: ${{ vars.GH_APP_ID }}`, `private-key: ${{ secrets.GH_APP_KEY }}`, `owner: citusdata`.
- `$GITHUB_ENV` export of `GH_TOKEN`/`GITHUB_TOKEN` for jobs that use the shell var `${GH_TOKEN}` (e.g. `--gh_token`).
- Direct `${{ steps.app-token.outputs.token }}` substitution for `env:`/`token:` references.
- **PAT shadow retained** — top-level `env` `GH_TOKEN`/`GITHUB_TOKEN` are intentionally kept for zero-downtime rollback.
- Tools pin bumped `v0.8.35` -> `v0.8.36`.

## Validation
- **Build Package** (run `28505518289`): GREEN ✅ (auto-triggered on push)
- **Nightlies** (run `28505518378`): GREEN ✅ (auto-triggered on push)
- **update_package_properties.yml**: `workflow_dispatch`-only, does not auto-fire on push. Manual dispatch pending (requires a `tag_name` input; note this workflow carries a pre-existing `pkg-update-pkgprops-broken` flag).

> Do not merge — merge is separately gated.