### PR TITLE
Migrate all-pg-azure-storage build to GitHub App token

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -53,7 +53,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.28 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update -y && sudo apt-get install -y libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -53,7 +53,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.28 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update -y && sudo apt-get install -y libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -34,6 +34,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+      - name: Export app token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+
       # This step is to fetch the images unanonymously to have higher bandwidth
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -42,7 +53,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.28 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update -y && sudo apt-get install -y libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -56,7 +56,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.28 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update -y && sudo apt-get install -y libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -37,6 +37,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+      - name: Export app token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+
       # This step is to fetch the images unanonymously to have higher bandwidth
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -45,7 +56,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.28 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update -y && sudo apt-get install -y libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -56,7 +56,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.28 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update -y && sudo apt-get install -y libcurl4-openssl-dev libssl-dev python3-testresources


### PR DESCRIPTION
## Migrate all-pg-azure-storage build to GitHub App token

Propagates the GitHub App token pattern (Phase 5) to the `all-pg-azure-storage` build branch. Pattern is byte-identical to the merged all-citus migration (#1189) and all-citus-unit-tests (#1188).

### Changes (net +24/−2, 2 files)
- **build-package.yml** — add `actions/create-github-app-token@v3` mint + export step after checkout; bump tools pin `v0.8.28 → v0.8.36`. Top-level `GH_TOKEN`/`GITHUB_TOKEN` PAT shadows retained (removed in Phase 6).
- **build-pgazure-nightlies.yml** — same mint + export + pin bump; `GH_TOKEN` shadow retained. (Workflow is `disabled_manually` at repo level — pre-existing, unchanged.)

### ⚠ MERGE HELD — validation is RED, but NOT due to this migration
`build-package` validation on this branch is red. Read-only forensics:
- The `citus/packaging:ubuntu-focal-all` container prints its PG-version banner then exits 1 **silently** (no auth/access error), before git-init.
- **Pin exonerated:** reverting to v0.8.28 fails identically.
- **Token plumbing sound:** the same app-token mint/export is green same-day on all-citus build-package (run 28505518289).
- Leading hypothesis: **environmental drift of the mutable `ubuntu-focal-all` base image** between the base branch's last green (Jun-9) and now — independent of this token migration.

Tracked separately in #1193. **Do not merge** until that environmental red is resolved and this branch re-validates green.