### PR TITLE
Phase 6A: drop PAT shadow on all-citus-unit-tests build-package + migrate update_package_properties to app token

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -4,8 +4,6 @@ env:
   MAIN_BRANCH: "all-citus"
   PACKAGE_CLOUD_REPO_NAME: "citusdata/community"
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
   PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
   PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
 on:

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -2,7 +2,6 @@ name: Update Package Properties
 
 env:
   PRJ_NAME: "citus"
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 on:
   workflow_dispatch:
     inputs:
@@ -31,15 +30,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Export app token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
       - name: Install dependencies
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources
 
       - name: Clone tools branch
-        run: git clone -b v0.8.10 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Set git name and email
         run: |


### PR DESCRIPTION
## Phase 6A — drop dead org PAT on `all-citus-unit-tests`

Part of the migration off the retired org PAT `secrets.GH_TOKEN` to the `cituspackagingapp` GitHub App token (`actions/create-github-app-token@v3`, creds `vars.GH_APP_ID` + `secrets.GH_APP_KEY`, owner `citusdata`). The org PAT is now dead, so the two remaining references on this base branch are fixed together here.

### `.github/workflows/build-package.yml` — shadow removal only
Removed the two top-level env shadows:
```
GH_TOKEN: ${{ secrets.GH_TOKEN }}
GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
```
Safe: **both** jobs already mint the app token, export it to `$GITHUB_ENV`, and consume the exported value — nothing depends on the top-level shadow. No other change.

### `.github/workflows/update_package_properties.yml` — full migration (unmigrated anomaly)
This workflow was still entirely on the dead PAT. Now fully on the app token:
- Deleted top-level `GH_TOKEN` env (kept `PRJ_NAME`).
- Added `actions/create-github-app-token@v3` (`id: app-token`) as the first step.
- Checkout `token:` now uses `${{ steps.app-token.outputs.token }}` (checkout kept at `@v3`).
- Added an "Export app token to environment" step writing `GH_TOKEN`/`GITHUB_TOKEN` to `$GITHUB_ENV` (the `--gh_token="${GH_TOKEN}"` call resolves via this export).
- Bumped tools pin `v0.8.10` -> `v0.8.36`.

`grep secrets.GH_TOKEN` now returns zero matches on both files. Both files YAML-parse clean (PyYAML).

### Validation
- `build-package.yml` auto-fired on push: run **28934573255** — **success** (https://github.com/citusdata/packaging/actions/runs/28934573255). Publish stays gated OFF because branch != `MAIN_BRANCH` (`all-citus`).
- `update_package_properties.yml` is `workflow_dispatch`-only, so not dispatched here; its structure is at parity with the already-validated `all-citus` version.

### ⛔ MERGE HELD — DRAFT for review
Do not merge / no auto-merge. Kept as a draft pending review.
