### PR TITLE
Add Ubuntu 26.04 (resolute) as a supported platform

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -35,6 +35,7 @@ jobs:
           - debian/trixie
           - ubuntu/jammy
           - ubuntu/noble
+          - ubuntu/resolute
 
     steps:
       - name: Checkout repository
@@ -61,7 +62,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev6 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Clone build branch
         run: git clone -b "${MAIN_BRANCH}" --depth=1  https://github.com/citusdata/packaging.git packaging

--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -62,7 +62,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36-dev6 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.37 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Clone build branch
         run: git clone -b "${MAIN_BRANCH}" --depth=1  https://github.com/citusdata/packaging.git packaging

--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -55,6 +55,7 @@ jobs:
           - TARGET_PLATFORM: debian,trixie
           - TARGET_PLATFORM: ubuntu,jammy
           - TARGET_PLATFORM: ubuntu,noble
+          - TARGET_PLATFORM: ubuntu,resolute
           - TARGET_PLATFORM: pgxn
     steps:
       - name: Checkout repository
@@ -91,7 +92,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev6 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -92,7 +92,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev6 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.37 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -55,6 +55,7 @@ jobs:
           - TARGET_PLATFORM: debian,trixie
           - TARGET_PLATFORM: ubuntu,jammy
           - TARGET_PLATFORM: ubuntu,noble
+          - TARGET_PLATFORM: ubuntu,resolute
           - TARGET_PLATFORM: pgxn
     steps:
       - name: Checkout repository
@@ -91,7 +92,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev6 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -92,7 +92,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev6 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.37 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/image-health-check.yml
+++ b/.github/workflows/image-health-check.yml
@@ -57,6 +57,7 @@ jobs:
           - TARGET_PLATFORM: debian,trixie
           - TARGET_PLATFORM: ubuntu,jammy
           - TARGET_PLATFORM: ubuntu,noble
+          - TARGET_PLATFORM: ubuntu,resolute
           - TARGET_PLATFORM: pgxn
     steps:
       - name: Checkout repository
@@ -93,7 +94,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev6 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/image-health-check.yml
+++ b/.github/workflows/image-health-check.yml
@@ -94,7 +94,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.36-dev6 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.37 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/dockerfiles/ubuntu-resolute-all/Dockerfile
+++ b/dockerfiles/ubuntu-resolute-all/Dockerfile
@@ -1,0 +1,138 @@
+# vim:set ft=dockerfile:
+FROM ubuntu:resolute
+ARG DEBIAN_FRONTEND=noninteractive
+
+# See https://github.com/tianon/docker-brew-debian/issues/49 for discussion of the following
+#
+# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
+RUN set -x \
+	&& apt-get update \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+	&& mkdir ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
+	&& { \
+		which gpg \
+# prefer gnupg2, to match APT's Recommends
+		|| apt-get install -y --no-install-recommends gnupg2 \
+		|| apt-get install -y --no-install-recommends gnupg \
+	; } \
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+	&& { \
+		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
+		|| apt-get install -y --no-install-recommends dirmngr \
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN set -ex; \
+# pub   4096R/ACCC4CF8 2011-10-13 [expires: 2019-07-02]
+#       Key fingerprint = B97B 0AFC AA1A 47F0 44F2  44A0 7FCC 7D46 ACCC 4CF8
+# uid                  PostgreSQL Debian Repository
+    key='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8'; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# Fix ipv6 issue on travis: https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9#issuecomment-466594168
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf; \
+    gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "$key"; \
+    gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/postgres.gpg; \
+    command -v gpgconf > /dev/null && gpgconf --kill all; \
+    rm -rf "$GNUPGHOME"; \
+    gpg --batch --no-default-keyring --keyring /etc/apt/trusted.gpg.d/postgres.gpg --list-keys || true
+
+# add buster backports repo to be able to download missing packages in buster main repo
+RUN ( [ ubuntu != debian ] || [ resolute != buster ] ) || ( \
+    echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list  \
+    )
+
+# install build tools and PostgreSQL development files
+
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ resolute-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        autotools-dev \
+        build-essential \
+        ca-certificates \
+        curl \
+        debhelper \
+        devscripts \
+        fakeroot \
+        flex \
+        libbz2-dev \
+        libffi-dev \
+        libcurl4-openssl-dev \
+        libdistro-info-perl \
+        libedit-dev \
+        libfile-fcntllock-perl \
+        libicu-dev \
+        libkrb5-dev \
+        libpam0g-dev \
+        libreadline-dev \
+        libselinux1-dev \
+        libssl-dev \
+        libxslt-dev \
+        lintian \
+        postgresql-server-dev-all \
+        postgresql-server-dev-18 \
+        wget \
+        zlib1g-dev \
+        python3-pip \
+        python3-sphinx \
+        python3-setuptools \
+        liblz4-dev \
+        liblz4-1 \
+        libzstd1 \
+        libzstd-dev \
+# below are needed for cmake and pgazure build
+        checkinstall \
+        git \
+        libtemplate-perl \
+        pkg-config \
+        tar \
+        unzip \
+        uuid \
+        uuid-dev \
+        zip \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# install jq to process JSON API responses
+RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+         -o /usr/bin/jq \
+    && chmod +x /usr/bin/jq
+
+# install packagecloud repos for pg_auto_failover
+RUN curl https://install.citusdata.com/community/deb.sh | bash \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# install cmake from source
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz && \
+    tar -zxvf cmake-3.22.2.tar.gz && \
+    cd cmake-3.22.2 && ./bootstrap && \
+    make && \
+    make install && \
+    rm -f cmake-3.22.2.tar.gz && \
+    rm -rf cmake-3.22.2
+
+# install pyenv and python 3.8 to be able to execute tools scripts
+ARG PYTHON_VERSION=3.8.16
+RUN set -ex \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PATH="$HOME/.pyenv/bin:$PATH" \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+
+
+# Added for pg18  package support.
+ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18"
+
+# place scripts on path and declare output volume
+ENV PATH /scripts:$PATH
+COPY scripts /scripts
+VOLUME /packages
+
+ENTRYPOINT ["/scripts/fetch_and_build_deb"]

--- a/os-list.csv
+++ b/os-list.csv
@@ -6,4 +6,5 @@ debian,trixie
 oraclelinux,8
 ubuntu,jammy
 ubuntu,noble
+ubuntu,resolute
 pgxn


### PR DESCRIPTION
## What

Adds **Ubuntu 26.04 LTS (codename `resolute`)** to the supported packaging platforms, mirroring how `noble` (24.04) is wired up.

## Changes (6 files, +147/-4)

- `os-list.csv` — `+ubuntu,resolute` after `ubuntu,noble` (canonical list that drives the image/push loops).
- `dockerfiles/ubuntu-resolute-all/Dockerfile` — **new** generated file (via `./update_dockerfiles`); `FROM ubuntu:resolute`, `resolute-pgdg`, buster guard.
- `.github/workflows/build-package.yml` — resolute matrix entry + tools pin.
- `.github/workflows/build-package-test.yml` — resolute matrix entry + tools pin.
- `.github/workflows/image-health-check.yml` — resolute matrix entry + tag bump.
- `.github/workflows/build-citus-community-nightlies.yml` — `+ubuntu/resolute` + tag bump.

## CI status

Green. The initial `build-package.yml` failure was a **publish race** (the `TEST=false` leg ran `docker run citus/packaging-test:ubuntu-resolute-all` before the `TEST=true` leg finished pushing that image → `manifest unknown`). Re-run after publish passed; resolute leg green across all four workflows.

## ⚠️ Draft — blocked on

1. **Depends on tools PR citusdata/tools#413** ("Add Ubuntu 26.04 (resolute) as a supported platform").
2. The workflow tools pin is currently the **dev tag `v0.8.36-dev6`** and must be swapped to a real tools **release** tag before merge.
3. Real packagecloud `distro_version_id` for `ubuntu/resolute` is still a `-1` placeholder in tools (`upload_to_package_cloud.py`) — deferred to a tools **dev7** cut, needed before packages actually upload.

## Deferred (by design, not in this PR)

- `test-images/ubuntu-resolute/` install-test dir.
- Real (non-placeholder) nightly matrix wiring once packages publish.

## Note on citus#8603 (gcc-15 warnings on 26.04)

Non-blocking. #8603 reports **warnings, not errors**. These packaging workflows build/publish the toolchain image (they don't compile citus source), so they're unaffected; the citus `.c` warnings surface in the downstream package build and remain non-fatal.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>