### PR TITLE
Add PostgreSQL 19 packaging images

### DIFF
--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -49,6 +49,8 @@ jobs:
           - 17
           - 18
         include:
+          - TARGET_PLATFORM: almalinux,9
+            POSTGRES_VERSION: 19
           - TARGET_PLATFORM: debian,bullseye
           - TARGET_PLATFORM: debian,bookworm
           - TARGET_PLATFORM: debian,trixie

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -49,6 +49,8 @@ jobs:
           - 17
           - 18
         include:
+          - TARGET_PLATFORM: almalinux,9
+            POSTGRES_VERSION: 19
           - TARGET_PLATFORM: debian,bullseye
           - TARGET_PLATFORM: debian,bookworm
           - TARGET_PLATFORM: debian,trixie

--- a/.github/workflows/image-health-check.yml
+++ b/.github/workflows/image-health-check.yml
@@ -51,6 +51,8 @@ jobs:
           - 17
           - 18
         include:
+          - TARGET_PLATFORM: almalinux,9
+            POSTGRES_VERSION: 19
           - TARGET_PLATFORM: debian,bullseye
           - TARGET_PLATFORM: debian,bookworm
           - TARGET_PLATFORM: debian,trixie

--- a/ci/push_images
+++ b/ci/push_images
@@ -48,6 +48,10 @@ while read -r line; do
             if [ -n "${POSTGRES_VERSION}" ] && [ "${pgversion}" != "${POSTGRES_VERSION}" ] ; then
                 continue
             fi
+            if [[ "${release}" = '8' ]] && [[ "${pgversion}" = '19' ]]; then
+                # PGDG does not publish PostgreSQL 19 packages for EL8.
+                continue
+            fi
             if { [[ "${os}" = 'centos' ]] || [[ "${os}" = 'oraclelinux' ]]; } && \
                  [[ "${release}" = '6' ]] && [[ "${pgversion}" = '13' ]]; then
                 # CentOS and OracleLinux 6 doesn't have pg13 packages yet.

--- a/ci/push_images
+++ b/ci/push_images
@@ -4,7 +4,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-pgversions='12 13 14 15 16 17 18'
+pgversions='12 13 14 15 16 17 18 19'
 topdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 dockerfiles_dir="${topdir}/dockerfiles"
 
@@ -31,6 +31,10 @@ while read -r line; do
     IFS=',' read -r os release <<< "$line"
     if [ ! -z ${TARGET_PLATFORM} ] && [ ${line} != ${TARGET_PLATFORM} ]; then
         continue
+    fi
+    if [[ "${release}" = '8' ]] && [[ "${POSTGRES_VERSION}" = '19' ]]; then
+        echo "${line} unsupported: PGDG does not publish PostgreSQL 19 packages for EL8" >&2
+        exit 1
     fi
     if [[ "${os}" = 'debian' ]] || [[ "${os}" = 'ubuntu' ]]; then
         tag="${os}-${release}-all"

--- a/dockerfiles/almalinux-9-pg19/Dockerfile
+++ b/dockerfiles/almalinux-9-pg19/Dockerfile
@@ -1,13 +1,13 @@
 # vim:set ft=dockerfile:
-FROM %%os%%:%%release%%
-RUN [[ %%os%% != centos ]] || [[ %%release%% != 8 ]] || ( \
+FROM almalinux:9
+RUN [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
     )
 
 RUN yum -y update
 
-RUN  [[ %%os%% != centos ]] || [[ %%release%% != 8 ]] || ( \
+RUN  [[ almalinux != centos ]] || [[ 9 != 8 ]] || ( \
     dnf install epel-release -y && \
     dnf install dnf-plugins-core -y && \
     dnf install epel-release -y && \
@@ -15,7 +15,7 @@ RUN  [[ %%os%% != centos ]] || [[ %%release%% != 8 ]] || ( \
     dnf install -y perl-IPC-Run \
     )
 
-RUN  [[ %%os%% != almalinux ]] || [[ %%release%% != 8 ]] || ( \
+RUN  [[ almalinux != almalinux ]] || [[ 9 != 8 ]] || ( \
     dnf install epel-release -y && \
     dnf install dnf-plugins-core -y && \
     dnf install epel-release -y && \
@@ -23,7 +23,7 @@ RUN  [[ %%os%% != almalinux ]] || [[ %%release%% != 8 ]] || ( \
     dnf install -y perl-IPC-Run \
     )
 
-RUN  [[ %%os%% != oraclelinux ]] || [[ %%release%% != 8 ]] || ( \
+RUN  [[ almalinux != oraclelinux ]] || [[ 9 != 8 ]] || ( \
     curl -sO  https://vault.centos.org/centos/8/PowerTools/x86_64/os/Packages/perl-IO-Tty-1.12-11.el8.x86_64.rpm && \
     curl -sO  https://vault.centos.org/centos/8/PowerTools/x86_64/os/Packages/perl-IPC-Run-0.99-1.el8.noarch.rpm && \
     dnf install perl-IO-Tty-1.12-11.el8.x86_64.rpm -y  && \
@@ -32,7 +32,7 @@ RUN  [[ %%os%% != oraclelinux ]] || [[ %%release%% != 8 ]] || ( \
     rm -f perl-IO-Tty-1.12-11.el8.x86_64.rpm \
     )
 
-RUN  [[ %%os%% != almalinux ]] || [[ %%release%% != 9 ]] || ( \
+RUN  [[ almalinux != almalinux ]] || [[ 9 != 9 ]] || ( \
     dnf install epel-release -y && \
     dnf -y install dnf-plugins-core && \
     dnf config-manager --enable epel && \
@@ -46,7 +46,7 @@ RUN ( yum install -y yum-plugin-ovl || yum install -y yum-plugin-ovl || touch /v
 
 # Enable some other repos for some dependencies in OL/7 
 # see https://yum.oracle.com/getting-started.html#installing-from-oracle-linux-yum-server
-RUN [[ %%os%% != oraclelinux ]] || [[ %%release%% != 7 ]] || ( \
+RUN [[ almalinux != oraclelinux ]] || [[ 9 != 7 ]] || ( \
        yum install -y oraclelinux-release-el7 oracle-softwarecollection-release-el7 oracle-epel-release-el7  oraclelinux-developer-release-el7 \
        && yum-config-manager --enable \
             ol7_software_collections \
@@ -63,10 +63,10 @@ RUN [[ %%os%% != oraclelinux ]] || [[ %%release%% != 7 ]] || ( \
 # in oracle 7 repos. So package from centos repo was used
 # There is no package in oracle repos for lz4. Also it is not preloaded. So both lz4 and lz4-devel packages
 # were downloaded from centos el/6 repos
-RUN if [[ %%os%%   == oraclelinux ]] && [[ %%release%% == 7 ]]; then yum install -y wget \
+RUN if [[ almalinux   == oraclelinux ]] && [[ 9 == 7 ]]; then yum install -y wget \
         && wget http://mirror.centos.org/centos/7/os/x86_64/Packages/lz4-devel-1.8.3-1.el7.x86_64.rpm \
         && rpm -ivh lz4-devel-1.8.3-1.el7.x86_64.rpm ; \
-        elif [[ %%os%%   == oraclelinux ]] && [[ %%release%% == 6 ]]; then yum install -y wget \
+        elif [[ almalinux   == oraclelinux ]] && [[ 9 == 6 ]]; then yum install -y wget \
         && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-r131-1.el6.x86_64.rpm \
         && rpm -ivh lz4-r131-1.el6.x86_64.rpm \
         && wget https://cbs.centos.org/kojifiles/packages/lz4/r131/1.el6/x86_64/lz4-devel-r131-1.el6.x86_64.rpm \
@@ -74,9 +74,9 @@ RUN if [[ %%os%%   == oraclelinux ]] && [[ %%release%% == 7 ]]; then yum install
         else yum install -y lz4 lz4-devel; fi
 
 # install build tools and PostgreSQL development files
-RUN ( yum install -y https://%%rpm_url%%  \
-    && ( [[ %%pgshort%% != 19 ]] || sed -i '/\[pgdg19-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
-    && [[ -z "%%extra-repositories%%" ]] || yum install -y %%extra-repositories%%) \
+RUN ( yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm  \
+    && ( [[ 19 != 19 ]] || sed -i '/\[pgdg19-updates-testing\]/{n;n;n;s/.*/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo ) \
+    && [[ -z "epel-release" ]] || yum install -y epel-release) \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y \
         bzip2-devel \
@@ -98,9 +98,9 @@ RUN ( yum install -y https://%%rpm_url%%  \
         tar \
         libzstd \
         libzstd-devel \
-        %%extra-packages%% \
-    && ( [[ %%release%% != 8 ]] || dnf -qy module disable postgresql ) \
-    && yum install -y postgresql%%pgshort%%-server postgresql%%pgshort%%-devel \
+        llvm-toolset ccache rpmdevtools krb5-devel \
+    && ( [[ 9 != 8 ]] || dnf -qy module disable postgresql ) \
+    && yum install -y postgresql19-server postgresql19-devel \
     && yum clean all
 
 # install jq to process JSON API responses
@@ -133,7 +133,7 @@ RUN yum -y install  perl-IPC-Cmd libuuid-devel cmake3
 # Git 2.7.1 is minimum requirement for cmake so we remove and reinstall latests git from an up-to-date repo
 # Symbolic link is not being created for cmake from cmake3 by default. Therefore, we need to create the link as well.
 # devtoolset-8-gcc-c++ is required to compile azure sdk in pg azure storage project
-RUN [[ %%os%% != centos ]] || [[ %%release%% != 7 ]] || ( \
+RUN [[ almalinux != centos ]] || [[ 9 != 7 ]] || ( \
     yum -y install  perl-IPC-Cmd libuuid-devel cmake3 && \
     ln -s /usr/bin/cmake3 /usr/bin/cmake  && \
     yum -y remove git && \
@@ -166,7 +166,7 @@ RUN touch /rpmlintrc \
     && echo '%_build_pkgcheck %{_bindir}/rpmlint -f /rpmlintrc' >> /etc/rpm/macros
 
 # set PostgreSQL version, place scripts on path, and declare output volume
-ENV PGVERSION=%%pgversion%% \
+ENV PGVERSION=19 \
     PATH=/scripts:$PATH
 COPY scripts /scripts
 VOLUME /packages

--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -44,7 +44,7 @@ RUN ( [ debian != debian ] || [ bookworm != buster ] ) || ( \
 
 # install build tools and PostgreSQL development files
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main 19' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' > /et
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
-        postgresql-server-dev-18 \
+        postgresql-server-dev-19 \
         wget \
         zlib1g-dev \
         python3-pip \
@@ -127,8 +127,8 @@ RUN set -ex \
     && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
-# Added for pg18  package support.
-ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18"
+# Added for pg19 beta package support.
+ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18 19"
 
 # place scripts on path and declare output volume
 ENV PATH /scripts:$PATH

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -44,7 +44,7 @@ RUN ( [ debian != debian ] || [ bullseye != buster ] ) || ( \
 
 # install build tools and PostgreSQL development files
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main 19' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /et
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
-        postgresql-server-dev-18 \
+        postgresql-server-dev-19 \
         wget \
         zlib1g-dev \
         python3-pip \
@@ -127,8 +127,8 @@ RUN set -ex \
     && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
-# Added for pg18  package support.
-ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18"
+# Added for pg19 beta package support.
+ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18 19"
 
 # place scripts on path and declare output volume
 ENV PATH /scripts:$PATH

--- a/dockerfiles/debian-trixie-all/Dockerfile
+++ b/dockerfiles/debian-trixie-all/Dockerfile
@@ -44,7 +44,7 @@ RUN ( [ debian != debian ] || [ trixie != buster ] ) || ( \
 
 # install build tools and PostgreSQL development files
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ trixie-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ trixie-pgdg main 19' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ trixie-pgdg main' > /etc/
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
-        postgresql-server-dev-18 \
+        postgresql-server-dev-19 \
         wget \
         zlib1g-dev \
         python3-pip \
@@ -127,8 +127,8 @@ RUN set -ex \
     && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
-# Added for pg18  package support.
-ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18"
+# Added for pg19 beta package support.
+ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18 19"
 
 # place scripts on path and declare output volume
 ENV PATH /scripts:$PATH

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -44,7 +44,7 @@ RUN ( [ ubuntu != debian ] || [ jammy != buster ] ) || ( \
 
 # install build tools and PostgreSQL development files
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main 19' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main' > /etc/a
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
-        postgresql-server-dev-18 \
+        postgresql-server-dev-19 \
         wget \
         zlib1g-dev \
         python3-pip \
@@ -127,8 +127,8 @@ RUN set -ex \
     && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
-# Added for pg18  package support.
-ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18"
+# Added for pg19 beta package support.
+ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18 19"
 
 # place scripts on path and declare output volume
 ENV PATH /scripts:$PATH

--- a/dockerfiles/ubuntu-noble-all/Dockerfile
+++ b/dockerfiles/ubuntu-noble-all/Dockerfile
@@ -44,7 +44,7 @@ RUN ( [ ubuntu != debian ] || [ noble != buster ] ) || ( \
 
 # install build tools and PostgreSQL development files
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ noble-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ noble-pgdg main 19' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ noble-pgdg main' > /etc/a
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
-        postgresql-server-dev-18 \
+        postgresql-server-dev-19 \
         wget \
         zlib1g-dev \
         python3-pip \
@@ -127,8 +127,8 @@ RUN set -ex \
     && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
-# Added for pg18  package support.
-ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18"
+# Added for pg19 beta package support.
+ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18 19"
 
 # place scripts on path and declare output volume
 ENV PATH /scripts:$PATH

--- a/dockerfiles/ubuntu-resolute-all/Dockerfile
+++ b/dockerfiles/ubuntu-resolute-all/Dockerfile
@@ -44,7 +44,7 @@ RUN ( [ ubuntu != debian ] || [ resolute != buster ] ) || ( \
 
 # install build tools and PostgreSQL development files
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ resolute-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ resolute-pgdg main 19' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ resolute-pgdg main' > /et
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
-        postgresql-server-dev-18 \
+        postgresql-server-dev-19 \
         wget \
         zlib1g-dev \
         python3-pip \
@@ -127,8 +127,8 @@ RUN set -ex \
     && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
-# Added for pg18  package support.
-ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18"
+# Added for pg19 beta package support.
+ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18 19"
 
 # place scripts on path and declare output volume
 ENV PATH /scripts:$PATH

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -44,7 +44,7 @@ RUN ( [ %%os%% != debian ] || [ %%release%% != buster ] ) || ( \
 
 # install build tools and PostgreSQL development files
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main 19' > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         autotools-dev \
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main' > 
         libxslt-dev \
         lintian \
         postgresql-server-dev-all \
-        postgresql-server-dev-18 \
+        postgresql-server-dev-19 \
         wget \
         zlib1g-dev \
         python3-pip \
@@ -127,8 +127,8 @@ RUN set -ex \
     && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 
-# Added for pg18  package support.
-ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18"
+# Added for pg19 beta package support.
+ENV DEB_PG_SUPPORTED_VERSIONS="14 15 16 17 18 19"
 
 # place scripts on path and declare output volume
 ENV PATH /scripts:$PATH

--- a/update_dockerfiles
+++ b/update_dockerfiles
@@ -4,7 +4,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-pgversions='14 15 16 17 18'
+pgversions='14 15 16 17 18 19'
 topdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 dockerfiles_dir="${topdir}/dockerfiles"
 templates_dir="${topdir}"/templates
@@ -61,7 +61,11 @@ function update_rpm_dockerfile {
     mkdir -p "${target_subdir}"
 
     template="${templates_dir}"/Dockerfile-rpm.tmpl
-    sed "$sed_cmd; s#%%rpm_url%%#${rpm_url}#g; s/%%pgshort%%/${pgshort}/g; s/%%pgversion%%/${pgversion}/g" \
+    pg19_sed_cmd=''
+    if [[ "${pgversion}" != '19' ]]; then
+        pg19_sed_cmd='/pgdg19-updates-testing/d;'
+    fi
+    sed "$sed_cmd; ${pg19_sed_cmd} s#%%rpm_url%%#${rpm_url}#g; s/%%pgshort%%/${pgshort}/g; s/%%pgversion%%/${pgversion}/g" \
         "${template}" > "${target_subdir}/Dockerfile"
 
 
@@ -92,6 +96,10 @@ while read -r line; do
         # redhat variants need a Dockerfile for each PostgreSQL version
         IFS=' '
         for pgversion in ${pgversions}; do
+            if [[ "${release}" = '8' ]] && [[ "${pgversion}" = '19' ]]; then
+                # PGDG does not publish PostgreSQL 19 packages for EL8.
+                continue
+            fi
             if { [[ "${os}" = 'centos' ]] || [[ "${os}" = 'oraclelinux' ]]; } && \
                  [[ "${release}" = '6' ]] && [[ "${pgversion}" = '13' ]]; then
                 # CentOS and OracleLinux 6 doesn't have pg13 packages yet.

--- a/update_image
+++ b/update_image
@@ -48,6 +48,10 @@ elif [[ "${os}" = 'centos' ]] || [[ "${os}" = 'oraclelinux' ]] || [[ "${os}" = '
         if [ -n "${POSTGRES_VERSION}" ] && [ "${pgversion}" != "${POSTGRES_VERSION}" ] ; then
             continue
         fi
+        if [[ "${release}" = '8' ]] && [[ "${pgversion}" = '19' ]]; then
+            # PGDG does not publish PostgreSQL 19 packages for EL8.
+            continue
+        fi
         if { [[ "${os}" = 'centos' ]] || [[ "${os}" = 'oraclelinux' ]]; } && \
              [[ "${release}" = '6' ]] && [[ "${pgversion}" = '13' ]]; then
             # CentOS and OracleLinux 6 doesn't have pg13 packages yet.

--- a/update_image
+++ b/update_image
@@ -9,7 +9,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-pgversions='14 15 16 17 18'
+pgversions='14 15 16 17 18 19'
 topdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 dockerfiles_dir="${topdir}/dockerfiles"
 
@@ -26,6 +26,11 @@ else
 fi
 
 IFS=',' read -r os release <<< "${TARGET_PLATFORM}"
+
+if [[ "${release}" = '8' ]] && [[ "${POSTGRES_VERSION}" = '19' ]]; then
+    echo "${TARGET_PLATFORM} unsupported: PGDG does not publish PostgreSQL 19 packages for EL8" >&2
+    exit 1
+fi
 
 if [[ "${os},${release}" =~ ^ubuntu,(focal|bionic)$ ]]; then
     echo "${TARGET_PLATFORM} unsupported: PGDG apt repo for ${release} is no longer available" >&2


### PR DESCRIPTION
## Summary

- add PostgreSQL 19 Beta 2 support to the Debian/Ubuntu all-version packaging images for Debian bullseye, bookworm, and trixie plus Ubuntu jammy, noble, and resolute
- add the generated `citus/packaging:almalinux-9-pg19` image definition and enable the PGDG 19 updates-testing repository used by the Beta 2 packages
- add only AlmaLinux 9 / PostgreSQL 19 to package-build, package-test, and image-health workflow matrices
- explicitly reject or skip PostgreSQL 19 for EL8, where PGDG does not publish the required packages

## Unsupported targets

- Oracle Linux 8 and AlmaLinux 8 are intentionally excluded because PGDG has no PostgreSQL 19 server/devel packages for EL8
- Ubuntu focal is intentionally excluded because its PGDG repository exposes components only through PostgreSQL 18, so it cannot provide a usable PostgreSQL 19 `pg_config`

## Generated files

The source changes update `templates/Dockerfile-deb.tmpl`, `templates/Dockerfile-rpm.tmpl`, and `update_dockerfiles`. The committed generated scope is limited to:

- new `dockerfiles/almalinux-9-pg19/Dockerfile`
- refreshed all-version Dockerfiles for Debian bullseye/bookworm/trixie and Ubuntu jammy/noble/resolute

## Validation

- parsed all changed workflow YAML
- checked shell syntax for `update_dockerfiles`, `update_image`, and `ci/push_images` in WSL
- regenerated Dockerfiles in a clean Linux tree and confirmed byte-identical output
- verified EL8 / PostgreSQL 19 is rejected before Docker execution
- verified the AlmaLinux 9 image enables `pgdg19-updates-testing` and installs `postgresql19-devel`
- verified all six supported DEB images install `postgresql-server-dev-19`

No images were manually published.

Tracks citusdata/citus#8731.