### PR TITLE
deb: install jq from distro package so deb builder images work on arm64

### DIFF
--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -94,10 +94,11 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' > /et
     && rm -rf /var/lib/apt/lists/*
 
 
-# install jq to process JSON API responses
-RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-         -o /usr/bin/jq \
-    && chmod +x /usr/bin/jq
+# install jq to process JSON API responses (distro package is arch-independent,
+# unlike the amd64-only jq-linux64 release binary, so it works on arm64 too)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # install packagecloud repos for pg_auto_failover
 RUN curl https://install.citusdata.com/community/deb.sh | bash \

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -94,10 +94,11 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /et
     && rm -rf /var/lib/apt/lists/*
 
 
-# install jq to process JSON API responses
-RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-         -o /usr/bin/jq \
-    && chmod +x /usr/bin/jq
+# install jq to process JSON API responses (distro package is arch-independent,
+# unlike the amd64-only jq-linux64 release binary, so it works on arm64 too)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # install packagecloud repos for pg_auto_failover
 RUN curl https://install.citusdata.com/community/deb.sh | bash \

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -94,10 +94,11 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' > /etc/
     && rm -rf /var/lib/apt/lists/*
 
 
-# install jq to process JSON API responses
-RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-         -o /usr/bin/jq \
-    && chmod +x /usr/bin/jq
+# install jq to process JSON API responses (distro package is arch-independent,
+# unlike the amd64-only jq-linux64 release binary, so it works on arm64 too)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # install packagecloud repos for pg_auto_failover
 RUN curl https://install.citusdata.com/community/deb.sh | bash \

--- a/dockerfiles/debian-stretch-all/Dockerfile
+++ b/dockerfiles/debian-stretch-all/Dockerfile
@@ -92,10 +92,11 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc
 
 RUN pip3 install sphinx
 
-# install jq to process JSON API responses
-RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-         -o /usr/bin/jq \
-    && chmod +x /usr/bin/jq
+# install jq to process JSON API responses (distro package is arch-independent,
+# unlike the amd64-only jq-linux64 release binary, so it works on arm64 too)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # install packagecloud repos for pg_auto_failover
 RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \

--- a/dockerfiles/debian-trixie-all/Dockerfile
+++ b/dockerfiles/debian-trixie-all/Dockerfile
@@ -94,10 +94,11 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ trixie-pgdg main' > /etc/
     && rm -rf /var/lib/apt/lists/*
 
 
-# install jq to process JSON API responses
-RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-         -o /usr/bin/jq \
-    && chmod +x /usr/bin/jq
+# install jq to process JSON API responses (distro package is arch-independent,
+# unlike the amd64-only jq-linux64 release binary, so it works on arm64 too)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # install packagecloud repos for pg_auto_failover
 RUN curl https://install.citusdata.com/community/deb.sh | bash \

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -95,10 +95,11 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main' > /etc/
     && rm -rf /var/lib/apt/lists/*
 
 
-# install jq to process JSON API responses
-RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-         -o /usr/bin/jq \
-    && chmod +x /usr/bin/jq
+# install jq to process JSON API responses (distro package is arch-independent,
+# unlike the amd64-only jq-linux64 release binary, so it works on arm64 too)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # install packagecloud repos for pg_auto_failover
 RUN curl https://install.citusdata.com/community/deb.sh | bash \

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -95,10 +95,11 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/a
     && rm -rf /var/lib/apt/lists/*
 
 
-# install jq to process JSON API responses
-RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-         -o /usr/bin/jq \
-    && chmod +x /usr/bin/jq
+# install jq to process JSON API responses (distro package is arch-independent,
+# unlike the amd64-only jq-linux64 release binary, so it works on arm64 too)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # install packagecloud repos for pg_auto_failover
 RUN curl https://install.citusdata.com/community/deb.sh | bash \

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -94,10 +94,11 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main' > /etc/a
     && rm -rf /var/lib/apt/lists/*
 
 
-# install jq to process JSON API responses
-RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-         -o /usr/bin/jq \
-    && chmod +x /usr/bin/jq
+# install jq to process JSON API responses (distro package is arch-independent,
+# unlike the amd64-only jq-linux64 release binary, so it works on arm64 too)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # install packagecloud repos for pg_auto_failover
 RUN curl https://install.citusdata.com/community/deb.sh | bash \

--- a/dockerfiles/ubuntu-noble-all/Dockerfile
+++ b/dockerfiles/ubuntu-noble-all/Dockerfile
@@ -94,10 +94,11 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ noble-pgdg main' > /etc/a
     && rm -rf /var/lib/apt/lists/*
 
 
-# install jq to process JSON API responses
-RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-         -o /usr/bin/jq \
-    && chmod +x /usr/bin/jq
+# install jq to process JSON API responses (distro package is arch-independent,
+# unlike the amd64-only jq-linux64 release binary, so it works on arm64 too)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # install packagecloud repos for pg_auto_failover
 RUN curl https://install.citusdata.com/community/deb.sh | bash \

--- a/dockerfiles/ubuntu-resolute-all/Dockerfile
+++ b/dockerfiles/ubuntu-resolute-all/Dockerfile
@@ -94,10 +94,11 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ resolute-pgdg main' > /et
     && rm -rf /var/lib/apt/lists/*
 
 
-# install jq to process JSON API responses
-RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-         -o /usr/bin/jq \
-    && chmod +x /usr/bin/jq
+# install jq to process JSON API responses (distro package is arch-independent,
+# unlike the amd64-only jq-linux64 release binary, so it works on arm64 too)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # install packagecloud repos for pg_auto_failover
 RUN curl https://install.citusdata.com/community/deb.sh | bash \

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -94,10 +94,11 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ %%release%%-pgdg main' > 
     && rm -rf /var/lib/apt/lists/*
 
 
-# install jq to process JSON API responses
-RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-         -o /usr/bin/jq \
-    && chmod +x /usr/bin/jq
+# install jq to process JSON API responses (distro package is arch-independent,
+# unlike the amd64-only jq-linux64 release binary, so it works on arm64 too)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # install packagecloud repos for pg_auto_failover
 RUN curl https://install.citusdata.com/community/deb.sh | bash \


### PR DESCRIPTION
## What / why

The deb builder installs `jq` via the **amd64-only** `jq-linux64` GitHub release binary:

```dockerfile
RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
         -o /usr/bin/jq \
    && chmod +x /usr/bin/jq
```

`jq` is used only in the **release** path of `scripts/fetch_and_build_deb` (GPG tag-signature
verification — `.object.sha` and `.verification.verified`), so it never surfaced on the jq-free
nightly path. But that hardcoded x86-64 binary **hard-fails when the builder image runs on
arm64**, which blocks the upcoming gated arm64 **release** `.deb` builds.

This swaps it for the distribution `jq` package, which is architecture-independent and present in
Debian/Ubuntu `main` across every target distro:

```dockerfile
RUN apt-get update \
    && apt-get install -y --no-install-recommends jq \
    && rm -rf /var/lib/apt/lists/*
```

The two `jq` filters in use are trivial and work on any `jq >= 1.5`, so **amd64 behavior is
unchanged**.

## Scope (surgical)

- `templates/Dockerfile-deb.tmpl` — the source of truth.
- 10 generated `dockerfiles/*-all/Dockerfile` (debian bookworm/bullseye/buster/stretch/trixie,
  ubuntu bionic/focal/jammy/noble/resolute) — regenerated from the template.

11 files, identical block swap in each (`git diff --stat`: 55 insertions / 44 deletions).
RPM (`Dockerfile-rpm.tmpl`) and `pgxn` dockerfiles are untouched.

## Integrity

`check_docker_files_integrity` runs `./update_dockerfiles` then `git diff --exit-code dockerfiles`.
Verified locally: after staging these edits, re-running the generator reproduces the committed
dockerfiles **byte-for-byte** (`git diff --quiet dockerfiles` → exit 0), so the check stays green.

## Guardrails

- **Draft** — do not merge / mark ready without operator go.
- **No arch gate here** — this is a pure prerequisite for the gated (`DEB_BUILD_MULTI_ARCH`,
  default OFF) arm64 release deb legs on `all-citus` / `debian-hll` / `debian-topn` (follow-up PRs).
- **No amd64 change** — same jq binary is available, filters unchanged.

Part of Track 2 of citusdata/citus#8612 (arm64 Debian Docker images). Follows the merged nightly
leg citusdata/packaging#1198.
