### PR TITLE
ci: add gated arm64 (.deb) release leg to debian-hll (hll -> citusdata/community)

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -17,7 +17,8 @@ on:
 jobs:
   build_package:
     name: Build package
-    runs-on: ubuntu-latest
+    # arm64 legs run on native ARM64 runners; amd64 stays on ubuntu-latest.
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -27,6 +28,9 @@ jobs:
           - debian/trixie
           - ubuntu/jammy
           - ubuntu/noble
+        # arm64 debs are gated behind the DEB_BUILD_MULTI_ARCH repo variable
+        # (default OFF -> amd64 only, so the existing release pipeline is unchanged).
+        arch: ${{ fromJSON(vars.DEB_BUILD_MULTI_ARCH == 'true' && '["amd64", "arm64"]' || '["amd64"]') }}
 
     steps:
       - name: Checkout repository
@@ -40,6 +44,32 @@ jobs:
 
       - name: Install python requirements
         run: python -m pip install -r tools/packaging_automation/requirements.txt
+
+      # The arm64 builder/signer images are not published to Docker Hub yet, so
+      # build them natively in-job by cloning develop's tooling (this branch has
+      # none). "docker run" prefers a local image, so citus_package picks these up
+      # automatically; amd64 keeps pulling the published images from Docker Hub.
+      - name: Login to Docker Hub
+        if: matrix.arch == 'arm64'
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USER_NAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build arm64 builder image
+        if: matrix.arch == 'arm64'
+        run: |
+          git clone -b develop --depth=1 https://github.com/citusdata/packaging.git tooling
+          cd tooling
+          export TEST=false
+          export TARGET_PLATFORM="${PLATFORM/\//,}"
+          ./update_image
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
+      - name: Build arm64 debsigner image
+        if: matrix.arch == 'arm64'
+        run: docker build -t citusdata/packaging:debsigner -f tooling/dockerfiles/debsigner/Dockerfile tooling
 
       - name: Build packages
         run: |


### PR DESCRIPTION
## What / why

Adds a **gated arm64 `.deb` release leg** to the `debian-hll` release build+publish workflow so
arm64 `hll` packages land in **`citusdata/community`** — the apt index that feeds the **stable**
Debian Citus Docker images. `hll` is a stable Citus dependency (`hll=2.19.citus-1`), pinned by the
Docker images, so it must ship arm64 for the images to install on arm64.

Mirrors the merged nightly leg citusdata/packaging#1198 and the all-citus release leg
citusdata/packaging#1205. Part of Track 2 of citusdata/citus#8612 (ARM64 Debian Docker images).

## The gate (amd64 unchanged)

Everything arm64 is behind the `DEB_BUILD_MULTI_ARCH` repo variable, **default OFF**:

```yaml
arch: ${{ fromJSON(vars.DEB_BUILD_MULTI_ARCH == 'true' && '["amd64", "arm64"]' || '["amd64"]') }}
```

- **Gate OFF (default):** `arch = ["amd64"]` → matrix = `platform × ["amd64"]`, every leg on
  `ubuntu-latest`, all `if: matrix.arch == 'arm64'` steps skipped. Existing amd64 pipeline is
  **byte-for-byte unchanged**.
- **Gate ON:** arm64 runs on native `ubuntu-24.04-arm` runners. The matrix is **deb-only**, so no
  RPM `exclude` block is needed.
- Publish is doubly safe: `upload_to_package_cloud` only publishes when `current_branch == debian-hll`.

## How the arm64 leg builds (Option B — in-job image build)

The release workflow runs *from* the `debian-hll` branch, which carries **no build tooling**. The
arm64 leg builds its builder + signer images **in-job** by cloning develop's tooling:

- `TEST=false ./update_image` → builds `citus/packaging:<distro>-all` natively on arm64.
- `docker build … dockerfiles/debsigner/Dockerfile` → builds `citusdata/packaging:debsigner`.

The same `citus/packaging:<distro>-all` builder image builds all three projects (citus/hll/topn) —
the package inputs are mounted at runtime. `citus_package`'s `docker run` has **no `--platform`
flag** and prefers a local image, so the native arm64 images are picked up automatically. amd64
keeps pulling the published images from Docker Hub (Docker Hub login is itself gated to arm64).

## Scope (surgical)

One file: `.github/workflows/build-package.yml` (+31 / −1). No changes to `debian/control.in`
(already `Architecture: any`), the deb entrypoint, or the upload script → version strings are
identical to amd64 by construction (`hll=2.19.citus-1`), satisfying the Docker exact-version pins.

## Prerequisite

Requires the develop **jq fix** citusdata/packaging#1204 merged first (arm64 builder images are
cloned from develop). Nothing here runs until **both** #1204 is merged **and** the operator flips
`DEB_BUILD_MULTI_ARCH` on.

## Guardrails

- **Draft** — do not merge / mark ready without operator go.
- **Gate OFF** — `DEB_BUILD_MULTI_ARCH` unset ⇒ amd64 only.
- Validated: YAML parse OK, actionlint clean (no warnings).
