### PR TITLE
build-pg-focal: refresh the quilt series against the upstream being built

### DIFF
--- a/scripts/build_pg_focal
+++ b/scripts/build_pg_focal
@@ -93,12 +93,11 @@ ORIG_SHA256="${PG_ORIG_SHA256:-}"
 DEBIAN_SHA256="${PG_DEBIAN_SHA256:-}"
 
 # Patches in the frozen focal debian/ packaging that no longer apply to newer
-# upstream (e.g. merged upstream). Space-separated; each is dropped from the
-# quilt series only if present, so the default is safe for every major:
+# upstream *at all* (e.g. merged upstream). Space-separated; each is dropped from
+# the quilt series only if present, so the default is safe for every major:
 #   * hurd-iovec was merged upstream as of 16.14 (pg_iovec.h guards IOV_MAX),
 #     so it fails to apply on 16.x/17.x but is absent from 13/14/15 packaging.
-# If a future minor introduces new drift, append the offending patch name here
-# (or via the PG_DROP_PATCHES env) -- no other code change required.
+# Context drift needs no entry here -- [4/6] refreshes the series instead.
 PG_DROP_PATCHES="${PG_DROP_PATCHES:-hurd-iovec}"
 
 # Set RUN_TESTS=1 to run the upstream regression suite (slower, needs more deps).
@@ -183,11 +182,35 @@ for p in ${PG_DROP_PATCHES}; do
   fi
 done
 
-echo "==> [4/6] Verify the quilt patch series applies cleanly to ${UPSTREAM}"
+echo "==> [4/6] Apply & refresh the quilt patch series against ${UPSTREAM}"
+# Frozen debian/ + newer upstream means patch *context* drifts: 14.24/15.19/16.15
+# added output_plugin_libraries inside the extension_destdir hunk's trailing
+# context. quilt applies that with fuzz; dpkg-source replays the same series in
+# [6/6] with "patch -F 0" and refuses it. So refresh the series against this
+# upstream (context only, no +/- line changes) and gate on zero fuzz here.
 export QUILT_PATCHES=debian/patches
+export QUILT_REFRESH_ARGS="-p ab --no-timestamps --no-index"   # keep PGDG's patch style
+export QUILT_DIFF_OPTS="-p"                                    # ... including @@ function context
 if [ -s debian/patches/series ]; then
-  quilt push -a
-  quilt pop -a
+  push_log="${WORK}/quilt-push-pg${PG_MAJOR}.log"
+  quilt push -a --refresh 2>&1 | tee "${push_log}"
+  quilt pop -a > /dev/null
+
+  # A fuzzy hunk was placed on less context than its author wrote: worth a look.
+  if grep -q 'with fuzz' "${push_log}"; then
+    echo "    NOTE: refreshed patches that no longer match ${UPSTREAM} verbatim:"
+    awk '/^Applying patch / { p = $3 }
+         /with fuzz/        { print "      " p ": " $0 }' "${push_log}"
+  fi
+
+  echo "    verifying the refreshed series applies with zero fuzz (as dpkg-source does)"
+  if ! quilt push -a --fuzz=0 > "${WORK}/quilt-verify-pg${PG_MAJOR}.log" 2>&1; then
+    cat "${WORK}/quilt-verify-pg${PG_MAJOR}.log" >&2
+    echo "ERROR: series does not apply to ${UPSTREAM} at zero fuzz; dpkg-source would" >&2
+    echo "       reject it too. Fix or drop the offending patch (PG_DROP_PATCHES)." >&2
+    exit 1
+  fi
+  quilt pop -a > /dev/null
 fi
 
 echo "==> [5/6] Set version to ${TARGET_VERSION} and install Build-Depends"

--- a/scripts/build_pg_focal
+++ b/scripts/build_pg_focal
@@ -188,20 +188,27 @@ echo "==> [4/6] Apply & refresh the quilt patch series against ${UPSTREAM}"
 # context. quilt applies that with fuzz; dpkg-source replays the same series in
 # [6/6] with "patch -F 0" and refuses it. So refresh the series against this
 # upstream (context only, no +/- line changes) and gate on zero fuzz here.
-export QUILT_PATCHES=debian/patches
+export QUILTRC=/dev/null                                       # /etc/quilt.quiltrc is sourced after
+export QUILT_PATCHES=debian/patches                            # ... the environment and would win
 export QUILT_REFRESH_ARGS="-p ab --no-timestamps --no-index"   # keep PGDG's patch style
 export QUILT_DIFF_OPTS="-p"                                    # ... including @@ function context
 if [ -s debian/patches/series ]; then
   push_log="${WORK}/quilt-push-pg${PG_MAJOR}.log"
-  quilt push -a --refresh 2>&1 | tee "${push_log}"
+  if ! quilt push -a --refresh 2>&1 | tee "${push_log}"; then
+    echo "ERROR: a patch does not apply to ${UPSTREAM} at all. If upstream merged or" >&2
+    echo "       obsoleted it, drop it via PG_DROP_PATCHES." >&2
+    exit 1
+  fi
   quilt pop -a > /dev/null
 
-  # A fuzzy hunk was placed on less context than its author wrote: worth a look.
-  if grep -q 'with fuzz' "${push_log}"; then
-    echo "    NOTE: refreshed patches that no longer match ${UPSTREAM} verbatim:"
-    awk '/^Applying patch / { p = $3 }
-         /with fuzz/        { print "      " p ": " $0 }' "${push_log}"
-  fi
+  # A fuzzy hunk was placed on less context than its author wrote, and --refresh
+  # bakes that placement in, so the gate below can no longer catch it: annotate
+  # the run rather than leave it buried in the build log.
+  awk -v m="${PG_MAJOR}" -v u="${UPSTREAM}" '
+    /^Applying patch / { p = $3 }
+    /^patching file /  { f = substr($0, 15) }
+    /with fuzz/        { print "::warning::PG" m ": " p " needed fuzz against " u " in " f " -- " $0 }
+  ' "${push_log}"
 
   echo "    verifying the refreshed series applies with zero fuzz (as dpkg-source does)"
   if ! quilt push -a --fuzz=0 > "${WORK}/quilt-verify-pg${PG_MAJOR}.log" 2>&1; then


### PR DESCRIPTION
## Problem

14.24/15.19/16.15 add `output_plugin_libraries` to `postgresql.conf.sample` right below the trailing context of the Debian `extension_destdir` hunk. We pair a new orig tarball with the frozen focal-era `debian/`, so the patch stopped matching verbatim and PG14/15/16 failed ([run 31801139919](https://github.com/citusdata/packaging/actions/runs/31801139919)).

The `[4/6]` gate missed it because it was weaker than the real check: `quilt push -a` tolerates fuzz <= 2, while `dpkg-source --before-build` replays the same series in `[6/6]` with `patch -F 0` and refuses it. PG13 was unaffected -- 13.23 doesn't touch that file.

## Fix

`[4/6]` now refreshes the series against the upstream at hand, then gates on zero fuzz:

```sh
quilt push -a --refresh   # apply (fuzz allowed) + rewrite each patch's context
quilt pop -a
quilt push -a --fuzz=0    # what dpkg-source will do in [6/6]
```

Context and line numbers only, no `+`/`-` changes, in PGDG's patch style. A hunk that needed fuzz raises a CI annotation naming the patch and the file, since `--refresh` bakes that placement in and the gate can no longer catch it. A patch that doesn't apply at all points at `PG_DROP_PATCHES`. Frozen packaging plus moving upstream guarantees recurrence, hence a standing fix rather than a per-minor edit.

## Verification

podman locally, plus CI ([run 31805259613](https://github.com/citusdata/packaging/actions/runs/31805259613), all green): refreshed series yields a source tree byte-identical to the fuzzy one; 23 debs per major still linking `libllvm10`, signed; combined 59-deb set installs in stock `ubuntu:20.04` with PG13/14/15/16 online and JIT available.
