### PR TITLE
Add PostgreSQL 19 support (hll 2.21)

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -4,7 +4,6 @@ env:
   MAIN_BRANCH: "debian-hll"
   PACKAGE_CLOUD_REPO_NAME: "citusdata/community"
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
   PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
 on:
@@ -31,6 +30,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+      - name: Export app token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
 
       - name: Clone tools branch
         run: git clone -b v0.8.35 --depth=1  https://github.com/citusdata/tools.git tools

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -43,7 +43,7 @@ jobs:
           echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
 
       - name: Clone tools branch
-        run: git clone -b v0.8.35 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+hll (2.21.citus-1) stable; urgency=low
+
+  * Support for PostgreSQL 19
+
+ -- Ibrahim Halatci <ihalatci@microsoft.com>  Thu, 20 Aug 2026 12:00:00 +0300
+
 hll (2.19.citus-1) stable; urgency=low
 
   * Support for PostgreSQL 16

--- a/pkgvars
+++ b/pkgvars
@@ -1,4 +1,4 @@
 pkgname=hll
 hubproj=postgresql-hll
 pkgdesc=HyperLogLog
-pkglatest=2.19.citus-1
+pkglatest=2.21.citus-1

--- a/postgres-matrix.yml
+++ b/postgres-matrix.yml
@@ -10,3 +10,5 @@ version_matrix:
       postgres_versions: [ 11, 12, 13, 14, 15, 16, 17 ]
   - 2.19:
       postgres_versions: [ 12, 13, 14, 15, 16, 17, 18 ]
+  - 2.21:
+      postgres_versions: [ 12, 13, 14, 15, 16, 17, 18, 19 ]


### PR DESCRIPTION
Adds PostgreSQL 19 to the `postgresql-hll` Debian/Ubuntu packaging, bumping to upstream `v2.21`.

## Changes

- `pkgvars` — `pkglatest` `2.19.citus-1` -> `2.21.citus-1`
- `postgres-matrix.yml` — new entry `2.21: postgres_versions: [ 12, 13, 14, 15, 16, 17, 18, 19 ]` (appended last; nightly reads `version_matrix[-1]`)
- `debian/changelog` — new `2.21.citus-1` entry
- `.github/workflows/build-package.yml` — migrated off the retired `secrets.GH_TOKEN` PAT to `actions/create-github-app-token@v3`, matching `all-citus`

## Why the workflow change is in here

`scripts/fetch_and_build_deb` writes `Authorization: token ${GITHUB_TOKEN}` into `~/.curlrc` and then resolves the upstream tag through the GitHub API. `secrets.GH_TOKEN` no longer exists, so that call returned 401 on a request that succeeds anonymously, and the build died with `could not determine commit for git tag v2.21`. `MAIN_BRANCH` still references the dead secret, so this fix has to land here for the branch to build at all.

## Verification

Dry run on the feature branch: all 5 deb platforms green (bullseye, bookworm, trixie, jammy, noble).
`Package publishing skipped since current branch is not equal to debian-hll` confirmed in the logs — nothing was uploaded.

## ⚠️ Merging publishes

`on: push: branches: ["**"]` with `--build_type release`, and `upload_to_package_cloud.py` only skips when `current_branch != MAIN_BRANCH`. Merging this PR ships `hll 2.21.citus-1` to `citusdata/community`.

Depends on upstream tag `v2.21` (exists, GPG signature verifies).
