### PR TITLE
Add PostgreSQL 19 support (hll 2.21)

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -41,7 +41,7 @@ jobs:
           echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
 
       - name: Clone tools branch
-        run: git clone -b v0.8.35 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -4,7 +4,6 @@ env:
   MAIN_BRANCH: "redhat-hll"
   PACKAGE_CLOUD_REPO_NAME: "citusdata/community"
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
   PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
 on:
@@ -29,6 +28,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+      - name: Export app token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
 
       - name: Clone tools branch
         run: git clone -b v0.8.35 --depth=1  https://github.com/citusdata/tools.git tools

--- a/hll.spec
+++ b/hll.spec
@@ -5,11 +5,11 @@
 
 Summary:	HyperLogLog extension for PostgreSQL
 Name:		%{sname}_%{pgmajorversion}
-Version:	2.19.citus
+Version:	2.21.citus
 Release:	1%{dist}
 License:	ASL 2.0
 Group:		Applications/Databases
-Source0:	https://github.com/citusdata/postgresql-hll/archive/v2.19.tar.gz
+Source0:	https://github.com/citusdata/postgresql-hll/archive/v2.21.tar.gz
 URL:		https://github.com/citusdata/postgresql-hll
 BuildRequires:	postgresql%{pgmajorversion}-devel libxml2-devel
 BuildRequires:	libxslt-devel openssl-devel pam-devel readline-devel
@@ -60,6 +60,9 @@ PATH=%{pginstdir}/bin:$PATH
 %endif
 
 %changelog
+* Thu Aug 20 2026 - Ibrahim Halatci <ihalatci@microsoft.com> 2.21.citus-1
+- Support for PostgreSQL 19
+
 * Wed Feb 11 2026 - Ibrahim Halatci <ihalatci@microsoft.com> 2.19.citus-1
 - Support for PostgreSQL 18
 

--- a/pg_exclude.yml
+++ b/pg_exclude.yml
@@ -3,3 +3,5 @@ exclude:
     ol/7: [15]
   release:
     ol/7: [15]
+    el/8: [19]  # no pg19 build image for almalinux-8
+    ol/8: [19]  # no pg19 build image for oraclelinux-8

--- a/pkgvars
+++ b/pkgvars
@@ -1,4 +1,4 @@
 pkgname=hll
 hubproj=postgresql-hll
 pkgdesc=HyperLogLog
-pkglatest=2.19.citus-1
+pkglatest=2.21.citus-1

--- a/postgres-matrix.yml
+++ b/postgres-matrix.yml
@@ -10,3 +10,5 @@ version_matrix:
       postgres_versions: [ 11, 12, 13, 14, 15, 16, 17 ]
   - 2.19:
       postgres_versions: [16, 17, 18 ]
+  - 2.21:
+      postgres_versions: [ 16, 17, 18, 19 ]


### PR DESCRIPTION
Adds PostgreSQL 19 to the `postgresql-hll` RPM packaging, bumping to upstream `v2.21`.

## Changes

- `pkgvars` — `pkglatest` `2.19.citus-1` -> `2.21.citus-1`
- `postgres-matrix.yml` — new entry `2.21: postgres_versions: [ 16, 17, 18, 19 ]` (appended last; nightly reads `version_matrix[-1]`)
- `hll.spec` — `Version` `2.19.citus` -> `2.21.citus`, source archive `v2.19.tar.gz` -> `v2.21.tar.gz`, new `%changelog` entry
- `pg_exclude.yml` — `el/8: [19]` and `ol/8: [19]` under `release:`
- `.github/workflows/build-package.yml` — migrated off the retired `secrets.GH_TOKEN` PAT to `actions/create-github-app-token@v3`, matching `all-citus`

## Why `el/8` / `ol/8` exclude PG19

PGDG does not publish PostgreSQL 19 for EL8. `update_dockerfiles` on the packaging-images branch carries the same guard explicitly (`if [[ "${release}" = '8' ]] && [[ "${pgversion}" = '19' ]]; then continue`), so no `almalinux-8-pg19` / `oraclelinux-8-pg19` build image exists. `ol/8` needs its own key because `citus_package.py`'s `docker_image_names` has no `ol/8` entry — it falls through to `oraclelinux-8`, not `almalinux-8`.

## Why the workflow change is in here

`scripts/fetch_and_build_rpm` writes `Authorization: token ${GITHUB_TOKEN}` into `~/.curlrc` and resolves the upstream tag through the GitHub API. `secrets.GH_TOKEN` no longer exists, so that call returned 401 on a request that succeeds anonymously. `MAIN_BRANCH` still references the dead secret, so this fix has to land here for the branch to build at all.

## Verification

Dry run on the feature branch: all 4 rpm platforms green (`el/8`, `el/9`, `ol/8`, `ol/9`).
`Package publishing skipped since current branch is not equal to redhat-hll` confirmed in the logs — nothing was uploaded.

## ⚠️ Merging publishes

`on: push: branches: ["**"]` with `--build_type release`, and `upload_to_package_cloud.py` only skips when `current_branch != MAIN_BRANCH`. Merging this PR ships `hll 2.21.citus-1` to `citusdata/community`.

Depends on upstream tag `v2.21` (exists, GPG signature verifies).
