### PR TITLE
Add PostgreSQL 19 support (topn 2.7.1)

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -4,7 +4,6 @@ env:
   MAIN_BRANCH: "debian-topn"
   PACKAGE_CLOUD_REPO_NAME: "citusdata/community"
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
   PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
 on:
@@ -31,6 +30,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+      - name: Export app token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
 
       - name: Clone tools branch
         run: git clone -b v0.8.35 --depth=1  https://github.com/citusdata/tools.git tools

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -43,7 +43,7 @@ jobs:
           echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
 
       - name: Clone tools branch
-        run: git clone -b v0.8.35 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+topn (2.7.1.citus-1) stable; urgency=low
+
+  * Support for PostgreSQL 19
+
+ -- Ibrahim Halatci <ihalatci@microsoft.com>  Thu, 20 Aug 2026 12:00:00 +0300
+
 topn (2.7.0.citus-1) stable; urgency=low
 
   * Support for PostgreSQL 17

--- a/pkgvars
+++ b/pkgvars
@@ -1,3 +1,3 @@
 pkgname=postgresql-topn
 pkgdesc='Counter Based Implementation for top-n Approximation'
-pkglatest=2.7.0.citus-1
+pkglatest=2.7.1.citus-1

--- a/postgres-matrix.yml
+++ b/postgres-matrix.yml
@@ -10,3 +10,5 @@ version_matrix:
       postgres_versions: [ 11, 12, 13, 14, 15, 16 ]
   - 2.7:
       postgres_versions: [ 11, 12, 13, 14, 15, 16, 17, 18 ]
+  - 2.7.1:
+      postgres_versions: [ 11, 12, 13, 14, 15, 16, 17, 18, 19 ]


### PR DESCRIPTION
Adds PostgreSQL 19 to the `postgresql-topn` Debian/Ubuntu packaging, bumping to upstream `v2.7.1`.

## Changes

- `pkgvars` — `pkglatest` `2.7.0.citus-1` -> `2.7.1.citus-1`
- `postgres-matrix.yml` — new entry `2.7.1: postgres_versions: [ 11, 12, 13, 14, 15, 16, 17, 18, 19 ]` (appended last; nightly reads `version_matrix[-1]`)
- `debian/changelog` — new `2.7.1.citus-1` entry
- `.github/workflows/build-package.yml` — migrated off the retired `secrets.GH_TOKEN` PAT to `actions/create-github-app-token@v3`, matching `all-citus`

## Note on 11/12/13 in the matrix

Left as-is deliberately. On deb there is a single `*-all` build image whose `DEB_PG_SUPPORTED_VERSIONS` is `"14 15 16 17 18 19"`, which intersects the matrix down — so 11/12/13 are inert here and cause no build. The RPM path is different (one container per PG version, so every entry is really compiled), which is why the redhat-topn PR does narrow the range.

## Why the workflow change is in here

`scripts/fetch_and_build_deb` writes `Authorization: token ${GITHUB_TOKEN}` into `~/.curlrc` and resolves the upstream tag through the GitHub API. `secrets.GH_TOKEN` no longer exists, so that call returned 401 on a request that succeeds anonymously, and the build died with `could not determine commit for git tag v2.7.1`. `MAIN_BRANCH` still references the dead secret, so this fix has to land here for the branch to build at all.

## Upstream tag note

`v2.7.1` was originally signed with a key that GitHub reported as `unknown_key`, which trips the signature gate in `fetch_and_build_deb`. The tag has been re-signed with the established release key (`4FB72F64B64E3FFC`) and force-pushed upstream — same commit, same message, GitHub now reports `verification=true, reason=valid`. Local clones may need `git fetch --tags --force`.

## Verification

Dry run on the feature branch: all 5 deb platforms green (bullseye, bookworm, trixie, jammy, noble).
`Package publishing skipped since current branch is not equal to debian-topn` confirmed in the logs — nothing was uploaded.

## ⚠️ Merging publishes

`on: push: branches: ["**"]` with `--build_type release`, and `upload_to_package_cloud.py` only skips when `current_branch != MAIN_BRANCH`. Merging this PR ships `topn 2.7.1.citus-1` to `citusdata/community`.
