### PR TITLE
Add PostgreSQL 19 support (topn 2.7.1) and fix RPM matrix

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -55,7 +55,7 @@ jobs:
           docker system prune -af
 
       - name: Clone tools branch
-        run: git clone -b v0.8.35 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -4,7 +4,6 @@ env:
   MAIN_BRANCH: "redhat-topn"
   PACKAGE_CLOUD_REPO_NAME: "citusdata/community"
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
   PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
 on:
@@ -30,6 +29,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+      - name: Export app token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
 
       - name: Free up disk space
         run: |

--- a/pg_exclude.yml
+++ b/pg_exclude.yml
@@ -3,4 +3,6 @@ exclude:
     ol/7: [15]
   release:
     ol/7: [15]
+    el/8: [19]  # no pg19 build image for almalinux-8
+    ol/8: [19]  # no pg19 build image for oraclelinux-8
 

--- a/pkgvars
+++ b/pkgvars
@@ -1,4 +1,4 @@
 pkgname=topn
 hubproj=postgresql-topn
 pkgdesc='Counter Based Implementation for top-n Approximation'
-pkglatest=2.7.0.citus-1
+pkglatest=2.7.1.citus-1

--- a/postgres-matrix.yml
+++ b/postgres-matrix.yml
@@ -11,4 +11,4 @@ version_matrix:
   - 2.7.0:
       postgres_versions: [ 11, 12, 13, 14, 15, 16, 17, 18 ]
   - 2.7.1:
-      postgres_versions: [ 11, 12, 13, 14, 15, 16, 17, 18, 19 ]
+      postgres_versions: [ 14, 15, 16, 17, 18, 19 ]

--- a/postgres-matrix.yml
+++ b/postgres-matrix.yml
@@ -10,3 +10,5 @@ version_matrix:
       postgres_versions: [ 11, 12, 13, 14, 15, 16 ]
   - 2.7.0:
       postgres_versions: [ 11, 12, 13, 14, 15, 16, 17, 18 ]
+  - 2.7.1:
+      postgres_versions: [ 11, 12, 13, 14, 15, 16, 17, 18, 19 ]

--- a/topn.spec
+++ b/topn.spec
@@ -5,11 +5,11 @@
 
 Summary:	Counter Based Implementation for top-n Approximation
 Name:		%{sname}_%{pgmajorversion}
-Version:	2.7.0.citus
+Version:	2.7.1.citus
 Release:	1%{dist}
 License:	AGPLv3
 Group:		Applications/Databases
-Source0:	https://github.com/citusdata/postgresql-topn/archive/v2.7.0.tar.gz
+Source0:	https://github.com/citusdata/postgresql-topn/archive/v2.7.1.tar.gz
 URL:		https://github.com/citusdata/posgresql-topn
 BuildRequires:	postgresql%{pgmajorversion}-devel libxml2-devel
 BuildRequires:	libxslt-devel openssl-devel pam-devel readline-devel
@@ -57,6 +57,9 @@ PATH=%{pginstdir}/bin:$PATH
 %endif
 
 %changelog
+* Thu Aug 20 2026 - Ibrahim Halatci <ihalatci@microsoft.com> 2.7.1.citus-1
+- Support for PostgreSQL 19
+
 * Thu Jan 23 2025 - Mehmet Yilmaz <mehmetyilmaz@Microsoft.com> 2.7.0.citus-1
 - Support for PostgreSQL 17
 


### PR DESCRIPTION
Adds PostgreSQL 19 to the `postgresql-topn` RPM packaging, bumping to upstream `v2.7.1`, and repairs the currently-broken RPM matrix.

## Changes

- `pkgvars` — `pkglatest` `2.7.0.citus-1` -> `2.7.1.citus-1`
- `postgres-matrix.yml` — new entry `2.7.1: postgres_versions: [ 14, 15, 16, 17, 18, 19 ]` (appended last; nightly reads `version_matrix[-1]`)
- `topn.spec` — `Version` `2.7.0.citus` -> `2.7.1.citus`, source archive `v2.7.0.tar.gz` -> `v2.7.1.tar.gz`, new `%changelog` entry
- `pg_exclude.yml` — `el/8: [19]` and `ol/8: [19]` under `release:`
- `.github/workflows/build-package.yml` — migrated off the retired `secrets.GH_TOKEN` PAT to `actions/create-github-app-token@v3`, matching `all-citus`

## Why the matrix drops PG 11-13

This branch is currently red on `MAIN_BRANCH` and has been since 2026-02-11 — every RPM build since then has failed, on PG11, roughly two minutes in.

Root cause is [3b0fcfe](https://github.com/citusdata/packaging/commit/3b0fcfe) ("remove pg 10-13 from image checks", 2026-01-24), which changed `update_dockerfiles` from `pgversions='11 12 13 14 15 16 17 18'` to `'14 15 16 17 18'`. The RPM path runs one container per PG version, so a matrix entry with no corresponding build image is a hard failure. The first `redhat-topn` build after that commit is the first failure — exact correlation.

`redhat-hll` hit the same wall and was narrowed at 2.19 (`[11..17]` -> `[16, 17, 18]`). `redhat-topn` never was. `[14, 15, 16, 17, 18, 19]` matches the current image set (`pgversions='14 15 16 17 18 19'` on the packaging-images branch) and the deb `DEB_PG_SUPPORTED_VERSIONS`.

The historical `2.7.0` entry is left untouched. The deb branch is unaffected — see that PR for why.

## Why `el/8` / `ol/8` exclude PG19

PGDG does not publish PostgreSQL 19 for EL8; `update_dockerfiles` carries the same guard explicitly, so no `almalinux-8-pg19` / `oraclelinux-8-pg19` image exists. `ol/8` needs its own key because `citus_package.py`'s `docker_image_names` has no `ol/8` entry — it falls through to `oraclelinux-8`, not `almalinux-8`.

## Why the workflow change is in here

`scripts/fetch_and_build_rpm` writes `Authorization: token ${GITHUB_TOKEN}` into `~/.curlrc` and resolves the upstream tag through the GitHub API. `secrets.GH_TOKEN` no longer exists, so that call returned 401 on a request that succeeds anonymously. `MAIN_BRANCH` still references the dead secret, so this fix has to land here for the branch to build at all.

## Upstream tag note

`v2.7.1` was originally signed with a key GitHub reported as `unknown_key`, which trips the signature gate in `fetch_and_build_rpm`. The tag has been re-signed with the established release key (`4FB72F64B64E3FFC`) and force-pushed upstream — same commit, same message, GitHub now reports `verification=true, reason=valid`. Local clones may need `git fetch --tags --force`.

## Verification

Dry run on the feature branch: all 4 rpm platforms green (`el/8`, `el/9`, `ol/8`, `ol/9`) — the first green RPM build on this branch since January.

Resolved versions confirmed in the logs:
- `el/8` -> `Release versions: 14,15,16,17,18` (PG19 correctly excluded)
- `el/9` -> `Release versions: 14,15,16,17,18,19`

`Package publishing skipped since current branch is not equal to redhat-topn` confirmed — nothing was uploaded.

All required build images verified present on Docker Hub, including `almalinux-8-pg14/15` and `oraclelinux-8-pg14/15`, which this matrix exercises for the first time.

## ⚠️ Merging publishes

`on: push: branches: ["**"]` with `--build_type release`, and `upload_to_package_cloud.py` only skips when `current_branch != MAIN_BRANCH`. Merging this PR ships `topn 2.7.1.citus-1` to `citusdata/community`.
