### PR TITLE
Fix Citus nightly PostgreSQL version matrix

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -52,7 +52,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.39 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: |
@@ -72,4 +72,3 @@ jobs:
           --passphrase "${PACKAGING_PASSPHRASE}" \
           --output_dir "$(pwd)/packages/" \
           --input_files_dir "$(pwd)"
-

--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -72,3 +72,4 @@ jobs:
           --passphrase "${PACKAGING_PASSPHRASE}" \
           --output_dir "$(pwd)/packages/" \
           --input_files_dir "$(pwd)"
+

--- a/pg_exclude.yml
+++ b/pg_exclude.yml
@@ -6,3 +6,5 @@ exclude:
     debian/bookworm: [12,13]   # if PGDG dropped 12/13 there
     ubuntu/noble: [12,13]
     ubuntu/jammy: [12,13]      # adjust per PGDG availability
+    el/8: [19]                 # PGDG does not publish PostgreSQL 19 for EL8
+    ol/8: [19]                 # PGDG does not publish PostgreSQL 19 for EL8

--- a/pg_exclude.yml
+++ b/pg_exclude.yml
@@ -1,8 +1,8 @@
 exclude:
-  nightly: {}
+  nightly:
+    all: [19]
   release:
     debian/trixie: [12,13]
     debian/bookworm: [12,13]   # if PGDG dropped 12/13 there
     ubuntu/noble: [12,13]
     ubuntu/jammy: [12,13]      # adjust per PGDG availability
-

--- a/postgres-matrix.yml
+++ b/postgres-matrix.yml
@@ -27,4 +27,6 @@ version_matrix:
   - 13.2:
       postgres_versions: [ 15, 16, 17 ]  
   - 14.0:
-      postgres_versions: [ 16, 17, 18 ]  
+      postgres_versions: [ 16, 17, 18 ]
+  - 15.0:
+      postgres_versions: [ 17, 18, 19 ]


### PR DESCRIPTION
## Summary

- Citus `main` (`15.0devel`) supports PostgreSQL 17, 18, and 19, so append the `15.0` version matrix entry.
- Exclude PostgreSQL 19 from nightly packaging until PGDG packages are available.
- Pin the Citus community nightly workflow directly to `citusdata/tools` `v0.8.39`, which includes the corrected nightly exclusion filtering.

The focused tools [#426](https://github.com/citusdata/tools/pull/426) fix was superseded by the merged tools [#423](https://github.com/citusdata/tools/pull/423), released as `v0.8.39`. With that tools version, nightly packaging resolves to PostgreSQL 17 and 18.

## Validation

Using the actual `citusdata/tools` `v0.8.39` code with this branch's `postgres-matrix.yml` and `pg_exclude.yml` in WSL:

- YAML parsing succeeds for `postgres-matrix.yml`, `pg_exclude.yml`, and `build-citus-community-nightlies.yml`.
- Nightly resolves to PostgreSQL 17/18 for `el/9`, `ubuntu/jammy`, and `debian/trixie`.
- Release mappings remain unchanged:
  - `12.1.14` -> PostgreSQL 14/15/16
  - `13.4.0` -> PostgreSQL 15/16/17
  - `14.2.0` -> PostgreSQL 16/17/18
