### PR TITLE
deb: skip pg_auto_failover community repo bootstrap on non-amd64 (unblock arm64 debs)

### DIFF
--- a/dockerfiles/debian-bookworm-all/Dockerfile
+++ b/dockerfiles/debian-bookworm-all/Dockerfile
@@ -100,8 +100,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/*
 
-# install packagecloud repos for pg_auto_failover
-RUN curl https://install.citusdata.com/community/deb.sh | bash \
+# install packagecloud repos for pg_auto_failover (amd64 only: the community
+# repo has no non-x86_64 packages and its installer aborts on other arches)
+RUN [ "$(dpkg --print-architecture)" != "amd64" ] || curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/debian-bullseye-all/Dockerfile
+++ b/dockerfiles/debian-bullseye-all/Dockerfile
@@ -100,8 +100,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/*
 
-# install packagecloud repos for pg_auto_failover
-RUN curl https://install.citusdata.com/community/deb.sh | bash \
+# install packagecloud repos for pg_auto_failover (amd64 only: the community
+# repo has no non-x86_64 packages and its installer aborts on other arches)
+RUN [ "$(dpkg --print-architecture)" != "amd64" ] || curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/debian-buster-all/Dockerfile
+++ b/dockerfiles/debian-buster-all/Dockerfile
@@ -100,8 +100,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/*
 
-# install packagecloud repos for pg_auto_failover
-RUN curl https://install.citusdata.com/community/deb.sh | bash \
+# install packagecloud repos for pg_auto_failover (amd64 only: the community
+# repo has no non-x86_64 packages and its installer aborts on other arches)
+RUN [ "$(dpkg --print-architecture)" != "amd64" ] || curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors

--- a/dockerfiles/debian-stretch-all/Dockerfile
+++ b/dockerfiles/debian-stretch-all/Dockerfile
@@ -98,8 +98,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/*
 
-# install packagecloud repos for pg_auto_failover
-RUN curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
+# install packagecloud repos for pg_auto_failover (amd64 only: the community
+# repo has no non-x86_64 packages and its installer aborts on other arches)
+RUN [ "$(dpkg --print-architecture)" != "amd64" ] || curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors

--- a/dockerfiles/debian-trixie-all/Dockerfile
+++ b/dockerfiles/debian-trixie-all/Dockerfile
@@ -100,8 +100,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/*
 
-# install packagecloud repos for pg_auto_failover
-RUN curl https://install.citusdata.com/community/deb.sh | bash \
+# install packagecloud repos for pg_auto_failover (amd64 only: the community
+# repo has no non-x86_64 packages and its installer aborts on other arches)
+RUN [ "$(dpkg --print-architecture)" != "amd64" ] || curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/ubuntu-bionic-all/Dockerfile
+++ b/dockerfiles/ubuntu-bionic-all/Dockerfile
@@ -101,8 +101,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/*
 
-# install packagecloud repos for pg_auto_failover
-RUN curl https://install.citusdata.com/community/deb.sh | bash \
+# install packagecloud repos for pg_auto_failover (amd64 only: the community
+# repo has no non-x86_64 packages and its installer aborts on other arches)
+RUN [ "$(dpkg --print-architecture)" != "amd64" ] || curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors

--- a/dockerfiles/ubuntu-focal-all/Dockerfile
+++ b/dockerfiles/ubuntu-focal-all/Dockerfile
@@ -101,8 +101,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/*
 
-# install packagecloud repos for pg_auto_failover
-RUN curl https://install.citusdata.com/community/deb.sh | bash \
+# install packagecloud repos for pg_auto_failover (amd64 only: the community
+# repo has no non-x86_64 packages and its installer aborts on other arches)
+RUN [ "$(dpkg --print-architecture)" != "amd64" ] || curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 # patch pg_buildext to use multiple processors

--- a/dockerfiles/ubuntu-jammy-all/Dockerfile
+++ b/dockerfiles/ubuntu-jammy-all/Dockerfile
@@ -100,8 +100,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/*
 
-# install packagecloud repos for pg_auto_failover
-RUN curl https://install.citusdata.com/community/deb.sh | bash \
+# install packagecloud repos for pg_auto_failover (amd64 only: the community
+# repo has no non-x86_64 packages and its installer aborts on other arches)
+RUN [ "$(dpkg --print-architecture)" != "amd64" ] || curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/ubuntu-noble-all/Dockerfile
+++ b/dockerfiles/ubuntu-noble-all/Dockerfile
@@ -100,8 +100,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/*
 
-# install packagecloud repos for pg_auto_failover
-RUN curl https://install.citusdata.com/community/deb.sh | bash \
+# install packagecloud repos for pg_auto_failover (amd64 only: the community
+# repo has no non-x86_64 packages and its installer aborts on other arches)
+RUN [ "$(dpkg --print-architecture)" != "amd64" ] || curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/ubuntu-resolute-all/Dockerfile
+++ b/dockerfiles/ubuntu-resolute-all/Dockerfile
@@ -100,8 +100,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/*
 
-# install packagecloud repos for pg_auto_failover
-RUN curl https://install.citusdata.com/community/deb.sh | bash \
+# install packagecloud repos for pg_auto_failover (amd64 only: the community
+# repo has no non-x86_64 packages and its installer aborts on other arches)
+RUN [ "$(dpkg --print-architecture)" != "amd64" ] || curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/templates/Dockerfile-deb.tmpl
+++ b/templates/Dockerfile-deb.tmpl
@@ -100,8 +100,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/*
 
-# install packagecloud repos for pg_auto_failover
-RUN curl https://install.citusdata.com/community/deb.sh | bash \
+# install packagecloud repos for pg_auto_failover (amd64 only: the community
+# repo has no non-x86_64 packages and its installer aborts on other arches)
+RUN [ "$(dpkg --print-architecture)" != "amd64" ] || curl https://install.citusdata.com/community/deb.sh | bash \
     && rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
## What / why

The deb builder image bootstrap unconditionally runs the PackageCloud community installer solely to add the `pg_auto_failover` repos:

```dockerfile
# install packagecloud repos for pg_auto_failover
RUN curl https://install.citusdata.com/community/deb.sh | bash \
    && rm -rf /var/lib/apt/lists/*
```

On non-`x86_64` arches that installer **hard-aborts**:

> Unfortunately, the Citus repository does not contain packages for non-x86_64 architectures.

(exit `123`), so the `RUN` fails **before** any debsign / build / publish. This is a bootstrap deadlock: we can't build arm64 packages because building the arm64 builder image itself refuses on arm64, because the community repo has no arm64 packages. It blocks **all** arm64 (`.deb`) legs — nightly and release.

Now that the org variable `DEB_BUILD_MULTI_ARCH` is `true`, the develop community-nightlies armed the gated arm64 legs, and every arm64 `.deb` leg fails at this step.

**Evidence:** run [33705146211](https://github.com/citusdata/packaging/actions/runs/33705146211), job `Build package (debian/bookworm, arm64)`, step `Build arm64 builder image` — fails with the error above.

## The fix

Guard the step on the Debian architecture so it runs **only on amd64** and becomes a no-op elsewhere:

```dockerfile
# install packagecloud repos for pg_auto_failover (amd64 only: the community
# repo has no non-x86_64 packages and its installer aborts on other arches)
RUN [ "$(dpkg --print-architecture)" != "amd64" ] || curl https://install.citusdata.com/community/deb.sh | bash \
    && rm -rf /var/lib/apt/lists/*
```

`A || B | bash && C` groups as `((A || (curl | bash)) && rm -rf …)`:

- **amd64:** `A` is false → `curl | bash` runs exactly as before; if it fails the `RUN` still fails. amd64 behavior is byte-for-byte unchanged.
- **arm64 (and other non-amd64):** `A` is true → `curl | bash` is skipped → `rm -rf` runs → the step succeeds as a no-op.

This step exists only for `pg_auto_failover` (per its comment) and is not needed for the citus arm64 build.

## Scope

- Source of truth: `templates/Dockerfile-deb.tmpl`.
- Applied to **all 10** deb dockerfiles + the template — the exact 11-file set touched by [#1204](https://github.com/citusdata/packaging/pull/1204), so the deb dockerfile family stays in lockstep with the template. The 6 matrix targets (`debian-{bullseye,bookworm,trixie}`, `ubuntu-{jammy,noble,resolute}`) are what `os-list.csv` / `./update_dockerfiles` regenerate and what the arm64 build matrix actually builds; the other 4 (`debian-buster`, `debian-stretch`, `ubuntu-bionic`, `ubuntu-focal`) are kept consistent even though they are not currently in the build matrix.
- Note: `debian-stretch` already used the older `packagecloud.io/.../script.deb.sh` installer URL (a pre-existing divergence from the template that #1204 did not normalize). Only the amd64 guard + comment were added there; its installer URL is left unchanged to keep this change minimal and focused on the arm64 fix.

## Validation

- No Docker build was run (Docker may be off); validation is the shell-logic reasoning plus the clean diff.
- Verified `A || B | bash && C` precedence under `/bin/sh` (dash, the Dockerfile `RUN` shell):
  - **arm64:** installer skipped, `rm` runs, exit 0 (no-op success).
  - **amd64 + installer success:** installer runs, `rm` runs, exit 0 (unchanged).
  - **amd64 + installer failure:** installer runs, `rm` skipped, exit 1 (RUN still fails — unchanged).

## Notes

- Companion arm64-enablement fix to [#1204](https://github.com/citusdata/packaging/pull/1204) (the `jq` distro-package fix; same file family, base `develop`).
- Broader arm64 context: [citusdata/citus#8612](https://github.com/citusdata/citus/issues/8612).
- amd64 is unchanged — the installer still runs on amd64 exactly as before.
