### PR TITLE
Pin community nightlies to tools v0.8.39

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -69,7 +69,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.37 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.39 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Clone build branch
         run: git clone -b "${MAIN_BRANCH}" --depth=1  https://github.com/citusdata/packaging.git packaging


### PR DESCRIPTION
## Summary

Pin the develop-scheduled community-nightlies workflow to tools `v0.8.39`, which correctly derives nightly PostgreSQL versions.

## Interdependence

This is interdependent with [packaging#1215](https://github.com/citusdata/packaging/pull/1215): the develop-scheduled community-nightlies workflow goes green on amd64 only when both land.

- This PR provides tools `v0.8.39`, which correctly derives nightly PG versions.
- #1215 (base `all-citus`) provides `15.0: [17,18,19]` plus `nightly: all: [19]`, read from the all-citus clone.
- Neither alone fixes the issue: tools `v0.8.37` incorrectly filters `release_versions`, and #1215 alone still runs under `v0.8.37` in the develop workflow.

## Root cause evidence

Run [33705146211](https://github.com/citusdata/packaging/actions/runs/33705146211) fails with `Citus is not compatible with the detected PostgreSQL version 16`.

## Arm64 context

Context only: arm64 has a separate builder-image bootstrap blocker addressed by draft [packaging#1216](https://github.com/citusdata/packaging/pull/1216). This PR + #1215 fix amd64; #1216 fixes arm64.