### PR TITLE
Bump nightly packaging tools to v0.8.39

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -69,7 +69,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.37 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.39 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Clone build branch
         run: git clone -b "${MAIN_BRANCH}" --depth=1  https://github.com/citusdata/packaging.git packaging


### PR DESCRIPTION
Bump nightly packaging tools to v0.8.39 so nightly exclusions filter nightly versions instead of release versions (citusdata/tools#423).

Merge before the all-citus PG19 matrix update.

Related to #1209.