### PR TITLE
Update Citus main packaging to PostgreSQL 17-19

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -52,7 +52,8 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
+        # v0.8.39 fixes nightly exclusions incorrectly using release versions.
+        run: git clone -b v0.8.39 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: |
@@ -72,4 +73,3 @@ jobs:
           --passphrase "${PACKAGING_PASSPHRASE}" \
           --output_dir "$(pwd)/packages/" \
           --input_files_dir "$(pwd)"
-

--- a/pg_exclude.yml
+++ b/pg_exclude.yml
@@ -1,8 +1,14 @@
 exclude:
-  nightly: {}
+  nightly:
+    # PGDG does not publish PostgreSQL 19 packages for EL8.
+    el/8: [19]
+    ol/8: [19]
+    almalinux/8: [19]
   release:
+    el/8: [19]
+    ol/8: [19]
+    almalinux/8: [19]
     debian/trixie: [12,13]
     debian/bookworm: [12,13]   # if PGDG dropped 12/13 there
     ubuntu/noble: [12,13]
     ubuntu/jammy: [12,13]      # adjust per PGDG availability
-

--- a/postgres-matrix.yml
+++ b/postgres-matrix.yml
@@ -27,4 +27,7 @@ version_matrix:
   - 13.2:
       postgres_versions: [ 15, 16, 17 ]  
   - 14.0:
-      postgres_versions: [ 16, 17, 18 ]  
+      postgres_versions: [ 16, 17, 18 ]
+  # Nightly builds use the last entry; keep older release mappings intact.
+  - 15.0:
+      postgres_versions: [ 17, 18, 19 ]


### PR DESCRIPTION
Add Citus 15 support for PostgreSQL 17, 18, and 19 while preserving older release mappings. Exclude PG19 on EL8 and bump nightly tools to v0.8.39 for correct exclusion handling.

Requires the develop nightly-tools prerequisite to merge first.

Related to #1209.