### PR TITLE
Fix arm64 Citus release debsigner build context

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build arm64 debsigner image
         if: matrix.arch == 'arm64'
-        run: docker build -t citusdata/packaging:debsigner -f tooling/dockerfiles/debsigner/Dockerfile tooling
+        run: docker build -t citusdata/packaging:debsigner tooling/dockerfiles/debsigner
 
       - name: Build packages
         run: |


### PR DESCRIPTION
## Summary
Correct the stable Citus arm64 debsigner build context on `all-citus` with exactly one changed workflow line:

```diff
-        run: docker build -t citusdata/packaging:debsigner -f tooling/dockerfiles/debsigner/Dockerfile tooling
+        run: docker build -t citusdata/packaging:debsigner tooling/dockerfiles/debsigner
```

The workflow clones `develop` into `tooling`. The debsigner Dockerfile uses `COPY scripts /scripts` and `ENTRYPOINT /scripts/import_and_sign`. The old tooling-root context copies `tooling/scripts`, which does not contain that entrypoint. Using `tooling/dockerfiles/debsigner` selects the same default Dockerfile and copies the correct adjacent scripts.

The identical wrong context caused [`/scripts/import_and_sign` not found in nightly CI](https://github.com/citusdata/packaging/actions/runs/34216854535/job/102030690421). Refs citusdata/citus#8612.

## Scope
Only `.github/workflows/build-package.yml` changes (+1/-1). The amd64 path, Dockerfiles, tools pin, secrets, platform matrix, and publication gates are unchanged. The `develop` bootstrap guard from #1216 is already merged and requires no port to this branch.

Bullseye's repository-metadata failure is explicitly out of scope. No release publication is dispatched, and no existing PackageCloud packages are overwritten or deleted. This feature branch remains publish-gated.

## Validation
- `git diff --check` passed.
- Confirmed the file matches the original with only the approved replacement, including preserved indentation and line endings.
- Used only automatically triggered push CI for head `555499ac62ebdb2dda84899de32da1aed2d8f8bf`; no local Docker build, manual dispatch, or rerun.

| Automatic head run | Final outcome |
| --- | --- |
| [Build Package 34240822123](https://github.com/citusdata/packaging/actions/runs/34240822123) | Failure: 11 package jobs succeeded, 3 failed; downstream package-test trigger skipped. |
| [Nightly 34240822451](https://github.com/citusdata/packaging/actions/runs/34240822451) | Success: all 6 amd64 jobs succeeded. |

All four non-Bullseye arm64 builder and debsigner-image steps succeeded. [Jammy arm64](https://github.com/citusdata/packaging/actions/runs/34240822123/job/102110221320) and [Bookworm arm64](https://github.com/citusdata/packaging/actions/runs/34240822123/job/102110221699) completed successfully: both logs show `DEB signing finished successfully.` and `Package publishing skipped since current branch is not equal to all-citus`.

[Trixie arm64](https://github.com/citusdata/packaging/actions/runs/34240822123/job/102110221322) and [Noble arm64](https://github.com/citusdata/packaging/actions/runs/34240822123/job/102110221554) failed before signing because existing build-output validation rejects `dpkg-shlibdeps: warning: diversions involved - output may be incorrect`. These are separate package-build warnings, not the missing signer entrypoint. Bullseye arm64 failed at the excluded builder-image stage. All 9 stable amd64 jobs succeeded. No changes were added for these out-of-scope failures.