### PR TITLE
Fix arm64 hll debsigner build context

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build arm64 debsigner image
         if: matrix.arch == 'arm64'
-        run: docker build -t citusdata/packaging:debsigner -f tooling/dockerfiles/debsigner/Dockerfile tooling
+        run: docker build -t citusdata/packaging:debsigner tooling/dockerfiles/debsigner
 
       - name: Build packages
         run: |


### PR DESCRIPTION
## Summary
Fix the arm64 debsigner Docker build context on `debian-hll` with one workflow-line change.

The workflow clones `develop` into `tooling`. The debsigner Dockerfile uses `COPY scripts /scripts` and `ENTRYPOINT ["/scripts/import_and_sign"]`, but the old `tooling`-root context copies the unrelated `tooling/scripts` directory and omits that entrypoint. Building with `tooling/dockerfiles/debsigner` as the context selects the same default Dockerfile and copies the intended adjacent signing scripts.

The step remains arm64-only; amd64 behavior is unchanged. No Dockerfile, tools-version, secret, publish-gate, or platform changes are included. Bullseye repository-metadata failures and its removal are explicitly out of scope. The `develop` bootstrap guard from #1216 is not duplicated here.

## Scope and evidence
- Exactly `.github/workflows/build-package.yml`, +1/-1; `git diff --check` passes.
- Runtime validation is limited to automatic push CI on this feature branch; no local Docker build or manual workflow dispatch/rerun.
- Existing failure evidence: https://github.com/citusdata/packaging/actions/runs/34216854535/job/102030690421
- Related: citusdata/citus#8612

Draft for review; this change does not alter stable publication gates or authorize overwriting already published hll versions.