### PR TITLE
Fix arm64 topn debsigner build context

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build arm64 debsigner image
         if: matrix.arch == 'arm64'
-        run: docker build -t citusdata/packaging:debsigner -f tooling/dockerfiles/debsigner/Dockerfile tooling
+        run: docker build -t citusdata/packaging:debsigner tooling/dockerfiles/debsigner
 
       - name: Build packages
         run: |


### PR DESCRIPTION
## Summary

Target branch: `debian-topn`.

The arm64 workflow clones `develop` into `tooling`, but builds the debsigner with `tooling` as its Docker context. The signer's `COPY scripts /scripts` therefore copies the unrelated top-level scripts and omits its `/scripts/import_and_sign` entrypoint.

Build from `tooling/dockerfiles/debsigner` instead. Docker selects the same default Dockerfile and copies the intended signer scripts. This is exactly one workflow line (+1/-1); amd64 behavior is unchanged.

## Validation and scope

- Confirmed the signer Dockerfile and script layout on `develop`; the diff is exactly the approved context replacement and passes `git diff --check` with CRLF preserved.
- Runtime validation used only CI automatically triggered by the feature-branch push; no local Docker, manual dispatch, or rerun.
- Bullseye repository metadata failures are out of scope and will be handled separately. No platform removal or apt-validity bypass.
- No Dockerfile, tools-pin, bootstrap-guard backport, secret, or publication-gate changes. No stable publication, tags, or overwrite of previously published topn packages.

## Automatic head CI results

[Run 34240897064](https://github.com/citusdata/packaging/actions/runs/34240897064), head `6d906ead66c5164d7bcc5e7d2fd7c65c08ce4214`: completed with **failure**, seven successful jobs and three failed jobs.

| Jobs | Result | Evidence |
| --- | --- | --- |
| All five amd64 platforms | Success | Existing amd64 path passed. |
| [Bookworm arm64](https://github.com/citusdata/packaging/actions/runs/34240897064/job/102110471854) | Success | Signer image and package job passed; 12 topn/dbgsym arm64 packages for PostgreSQL 14-19 went through debsigs; log ends `DEB signing finished successfully.` |
| [Jammy arm64](https://github.com/citusdata/packaging/actions/runs/34240897064/job/102110471967) | Success | Signer image and package job passed; 12 topn/dbgsym arm64 packages for PostgreSQL 14-19 went through debsigs; log ends `DEB signing finished successfully.` |
| [Trixie arm64](https://github.com/citusdata/packaging/actions/runs/34240897064/job/102110471995) | Failure | Builder and signer images passed. Package output validation rejected `dpkg-shlibdeps: warning: diversions involved - output may be incorrect` (exit 1), before signing. |
| [Noble arm64](https://github.com/citusdata/packaging/actions/runs/34240897064/job/102110471931) | Failure | Builder and signer images passed. Same package output-validation failure as Trixie (exit 1), before signing. |
| [Bullseye arm64](https://github.com/citusdata/packaging/actions/runs/34240897064/job/102110471844) | Failure | Builder apt-get update rejected expired bullseye-security/InRelease metadata; signer and package steps skipped. Explicitly out of scope. |

Bookworm and Jammy arm64 logs explicitly confirm `Package publishing skipped since current branch is not equal to debian-topn`. Other failures remain unchanged and are not addressed by this one-line signer-context PR.

## References

- Related: citusdata/citus#8612
- Same nightly failure: https://github.com/citusdata/packaging/actions/runs/34216854535/job/102030690421
- Bootstrap guard already merged into `develop`: #1216