### PR TITLE
Fix arm64 nightly debsigner build context

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Build arm64 debsigner image
         if: matrix.arch == 'arm64'
-        run: docker build -t citusdata/packaging:debsigner -f dockerfiles/debsigner/Dockerfile .
+        run: docker build -t citusdata/packaging:debsigner dockerfiles/debsigner
 
       - name: Build packages
         run: |


### PR DESCRIPTION
## Root cause

The nightly arm64 debsigner build used the repository root as its Docker context. `dockerfiles/debsigner/Dockerfile` contains `COPY scripts /scripts` and `ENTRYPOINT ["/scripts/import_and_sign"]`, but the intended signing scripts live in `dockerfiles/debsigner/scripts`, not the root `scripts` directory. The image therefore built successfully but failed when signing started because `/scripts/import_and_sign` was missing.

This was observed in the [combined develop run](https://github.com/citusdata/packaging/actions/runs/34216854535), including the [Bookworm arm64 job](https://github.com/citusdata/packaging/actions/runs/34216854535/job/102030690421). All five non-Bullseye arm64 jobs reached this failure; amd64 succeeded.

## Change

Change only the `Build arm64 debsigner image` command to use `dockerfiles/debsigner` as its build context. Docker selects the same default Dockerfile and copies the correct signing scripts. Exactly one file, one line changed (+1/-1). The arm64 condition and amd64 behavior are unchanged.

## Validation and scope

- Confirmed the Dockerfile and signing-script layout, preserved line endings, and ran `git diff --check`.
- Runtime validation uses the automatically triggered push CI for this PR head; no local Docker build or manual dispatch/rerun.
- Bullseye's expired Debian repository metadata failures are explicitly out of scope and will be handled separately. No platform removal, apt-validity workaround, PG-version changes, tool-pin changes, or gate/secret changes.

Related: citusdata/citus#8612.