### PR TITLE
Bump tools pin to v0.8.40 in all release workflows

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -52,7 +52,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.39 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.40 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -61,7 +61,7 @@ jobs:
           echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.39 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -61,7 +61,7 @@ jobs:
           echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
 
       - name: Clone tools branch
-        run: git clone -b v0.8.39 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.40 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: |

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev libssl-dev python3-testresources
 
       - name: Clone tools branch
-        run: git clone -b v0.8.39 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.40 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Set git name and email
         run: |

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev libssl-dev python3-testresources
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.39 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Set git name and email
         run: |


### PR DESCRIPTION
Retargets the `citusdata/tools` clone pin to **`v0.8.40`** (`5c2b3e5e`) in all three workflows that consume it, so they share one pin instead of drifting.

| Workflow | Before | After |
|---|---|---|
| `build-package.yml` (L64) | `v0.8.36` | `v0.8.40` |
| `update_package_properties.yml` (L53) | `v0.8.36` | `v0.8.40` |
| `build-citus-community-nightlies.yml` (L55) | `v0.8.39` | `v0.8.40` |

`+3/−3`, pin strings only.

## Why

The original driver was a bug in `citus_package.py::get_postgres_versions()`, fixed in `v0.8.39`. Its nightly exclusion filter iterated the wrong list:

```python
nightly_versions = [v for v in release_versions   # should be nightly_versions
                    if v not in exclude_dict_nightly[platform_key_nightly]]
```

This was dormant while `pg_exclude.yml` had `nightly: {}` (falsy). It became reachable the moment `all-citus` gained a non-empty `nightly: all: [19]` for the PG19 work, at which point nightly builds would silently resolve the wrong PG set rather than fail loudly.

Since then `v0.8.40` shipped, so this pins to that instead.

## What `v0.8.40` adds over `v0.8.39`

- [citusdata/tools#433](https://github.com/citusdata/tools/pull/433) — handle known ARM64 `libc6` protective-diversion warnings in `packaging_warning_handler.py`
- [citusdata/tools#432](https://github.com/citusdata/tools/pull/432) — retire Debian Bullseye
- [citusdata/tools#425](https://github.com/citusdata/tools/pull/425) — do not delete the caller's directory in pipeline mode

## ⚠️ Merge order: [#1233](https://github.com/citusdata/packaging/pull/1233) must land first

[citusdata/tools#432](https://github.com/citusdata/tools/pull/432) removes `bullseye` from `supported_platforms` in `common_tool_methods.py`, from `platform_names` in `citus_package.py`, and from the package-cloud distro map in `upload_to_package_cloud.py`. `citus_package.py` builds its `--platform` argparse `choices` from those maps, so `debian/bullseye` is no longer an accepted value and the job dies during argument parsing, before any build work.

This is now **confirmed on this PR**, not just predicted — all three `debian/bullseye` legs fail within seconds:

```
citus_package.py: error: argument --platform: invalid choice: 'debian/bullseye'
##[error]Process completed with exit code 2.
```

`build-package.yml` and `build-citus-community-nightlies.yml` both still list `debian/bullseye` in their platform matrices. [#1233](https://github.com/citusdata/packaging/pull/1233) removes it from both.

- **[#1233](https://github.com/citusdata/packaging/pull/1233) merges first → this is safe.**
- **This merges first → the `debian/bullseye` legs break as above.**

There is no textual conflict between the two PRs; they touch different lines.

`update_package_properties.yml` is not platform-scoped and is unaffected either way.

## Notes

- The branch name still says `v0839`; renaming it would close and recreate this PR, so it is left as-is.
- The `debian/bullseye` legs were *already* failing on `all-citus` before this change, for an unrelated reason — Bullseye is EOL and its `bullseye-security` `InRelease` file is expired, which breaks `apt-get update` in the test image. This change simply moves the failure earlier. Either way the fix is [#1233](https://github.com/citusdata/packaging/pull/1233) retiring the platform.
