### PR TITLE
Retire Bullseye and fix ARM64 HLL signing

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - debian/bullseye
           - debian/bookworm
           - debian/trixie
           - ubuntu/jammy

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build arm64 debsigner image
         if: matrix.arch == 'arm64'
-        run: docker build -t citusdata/packaging:debsigner -f tooling/dockerfiles/debsigner/Dockerfile tooling
+        run: docker build -t citusdata/packaging:debsigner tooling/dockerfiles/debsigner
 
       - name: Build packages
         run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -46,7 +46,7 @@ jobs:
           echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.40 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources


### PR DESCRIPTION
## Summary

- Remove Debian Bullseye from the shared HLL platform matrix following the end of Debian LTS on August 31, 2026. This removes both amd64 and ARM64 Bullseye build legs.
- Consolidate the one-line ARM64 debsigner fix from #1221: build with `tooling/dockerfiles/debsigner` as the Docker context so `COPY scripts /scripts` includes the `/scripts/import_and_sign` entrypoint.
- Update the tools pin from `v0.8.36` to `v0.8.40`, adopting the known ARM64 libc6 usr-merge diversion warning fix from citusdata/tools#433. Unknown or incomplete diversion diagnostics remain subject to existing output validation.

## Scope

Three changes in `.github/workflows/build-package.yml` (+2/-3 total): one Bullseye matrix-row deletion, one signer-command replacement, and one tools-pin replacement. The signer commit was cherry-picked from #1221 with its original authorship and source SHA preserved. The tools-pin follow-up is exactly one changed line on top of the previously consolidated PR.

All remaining platforms, the architecture gate, package versions, secrets, and publication gates remain unchanged. `--output_validation` stays enabled. Warning handling comes from the released tools tag; no validator implementation or ignore-policy changes are made here. Existing published packages and images are preserved.

## Validation

The tools-pin follow-up was compared against the previous PR head and changes only `v0.8.36` to `v0.8.40`; all other workflow content is unchanged. `git diff --check` passed. The `v0.8.40` tag resolves to the merged citusdata/tools#433 commit `5c2b3e5e6c8f9b7f11f6f10459dfc45cc6a7d6ec`.

The updated branch push triggers the existing automatic CI. This update does not claim that the new CI run has passed or that stable ARM64 packages have been published or installed. No local Docker build, manual workflow dispatch, or CI rerun was performed for the pin update.

## Coordination

The packaging `develop` builder retirement in #1234 has already merged. This PR removes Bullseye from the consuming HLL matrix, fixes its ARM64 signer context, and adopts the released warning fix. ARM64 builds continue to clone live `develop`; production publication remains gated on the `debian-hll` branch.

Supersedes #1221; retain this PR for the combined changes.