### PR TITLE
Retire Bullseye from pgautofailover package builds

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -28,7 +28,6 @@ jobs:
           - ol/8
           - debian/stretch
           - debian/buster
-          - debian/bullseye
           - ubuntu/bionic
           - ubuntu/focal
 


### PR DESCRIPTION
## Summary

- retire Debian Bullseye from future pgautofailover package builds after its LTS ended on August 31
- remove Bullseye eligibility from push-triggered and manually dispatched builds
- preserve all other distro and PostgreSQL matrices, build history, and existing packages

## Change

The exact YAML delta was reviewed: one `debian/bullseye` entry was removed from `.github/workflows/build-package.yml`; no other workflow behavior changed.