### PR TITLE
Retire Bullseye from pgautofailover enterprise builds

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -28,7 +28,6 @@ jobs:
           - ol/8
           - debian/stretch
           - debian/buster
-          - debian/bullseye
           - ubuntu/bionic
           - ubuntu/focal
 


### PR DESCRIPTION
## Summary

- Remove Debian Bullseye from future pgautofailover enterprise package builds after upstream LTS ended on August 31.
- Leave the other distribution selectors and published package history untouched.

The exact YAML delta was independently reviewed.