### PR TITLE
Modernize pg_cron 1.6.8 package builds

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -4,7 +4,6 @@ env:
   MAIN_BRANCH: "debian-cron"
   PACKAGE_CLOUD_REPO_NAME: "citusdata/community"
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
   PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
 on:
@@ -17,26 +16,44 @@ on:
 jobs:
   build_package:
     name: Build package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         platform:
-          - debian/buster
           - debian/bookworm
-          - ubuntu/bionic
-          - ubuntu/focal
+          - debian/trixie
           - ubuntu/jammy
+          - ubuntu/noble
+          - ubuntu/resolute
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export App token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Clone tools branch
-        run: git clone -b v0.8.30 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.39 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
-        run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev libssl-dev python3-testresources
 
       - name: Install python requirements
         run: python -m pip install -r tools/packaging_automation/requirements.txt
@@ -54,11 +71,12 @@ jobs:
           --output_validation
 
       - name: Publish packages
+        if: github.ref == format('refs/heads/{0}', env.MAIN_BRANCH)
         run: |
           python -m  tools.packaging_automation.upload_to_package_cloud \
           --platform "${{ matrix.platform }}" \
           --package_cloud_api_token "${PACKAGE_CLOUD_API_TOKEN}" \
           --repository_name "${PACKAGE_CLOUD_REPO_NAME}" \
           --output_file_path "$(pwd)/packages" \
-          --current_branch "${GITHUB_REF##*/}" \
+          --current_branch "${GITHUB_REF_NAME}" \
           --main_branch "${MAIN_BRANCH}"

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -23,7 +23,6 @@ jobs:
       matrix:
         platform:
           - debian/buster
-          - debian/bullseye
           - debian/bookworm
           - ubuntu/bionic
           - ubuntu/focal

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+pgcron (1.6.8.citus-1) stable; urgency=low
+
+  * Official 1.6.8 release of PG Cron
+  * Build for supported PostgreSQL 14 through 18
+
+ -- Ibrahim Halatci <ihalatci@microsoft.com>  Wed, 09 Sep 2026 15:33:31 +0000
+
 pgcron (1.6.5.citus-1) stable; urgency=low
 
   * Official 1.6.5 release of PG Cron

--- a/debian/control.in
+++ b/debian/control.in
@@ -10,6 +10,7 @@ Homepage: https://github.com/citusdata/pg_cron
 Package: postgresql-PGVERSION-pgcron
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-PGVERSION
+Breaks: ${postgresql:Breaks}
 Description: Periodic job scheduler for PostgreSQL
  This extension runs a background worker that can schedule SQL commands
  to be run periodically.

--- a/pkgvars
+++ b/pkgvars
@@ -1,4 +1,4 @@
 pkgname=pgcron
 hubproj=pg_cron
 pkgdesc='Periodic job scheduler of PostgreSQL'
-pkglatest=1.6.5.citus-1
+pkglatest=1.6.8.citus-1

--- a/postgres-matrix.yml
+++ b/postgres-matrix.yml
@@ -8,3 +8,5 @@ version_matrix:
       postgres_versions: [ 10, 11, 12, 13, 14, 15 ]
   - 1.6.0:
       postgres_versions: [ 10, 11, 12, 13, 14, 15, 16 ]
+  - 1.6.8:
+      postgres_versions: [ 14, 15, 16, 17, 18 ]


### PR DESCRIPTION
## Summary

- Update pg_cron package metadata and the Debian changelog from 1.6.5 to **1.6.8.citus-1**.
- Build the new release for supported PostgreSQL **14, 15, 16, 17, and 18**, preserving historical version-matrix entries. PostgreSQL 19 remains excluded while it is in beta.
- Replace retired Debian Buster/Bullseye and Ubuntu Bionic/Focal targets with **Debian Bookworm/Trixie** and **Ubuntu Jammy/Noble/Resolute**.
- Update packaging tools from **v0.8.30 to v0.8.39**, pin **Python 3.12** on **Ubuntu 24.04**, refresh the checkout action, and use the GitHub App authentication pattern already used by other extension workflows. The previous tooling failed while building its old greenlet dependency on Python 3.12.
- Consume `${postgresql:Breaks}` in the Debian package template so the new builder's LLVM compatibility constraints are retained rather than ignored.

## Publishing scope

- Preserve the existing `citusdata/community` destination and `debian-cron` release branch.
- Gate publishing on the exact `refs/heads/debian-cron` ref and pass the full branch name to the uploader. Builds on this PR branch do not publish packages.

## Validation

- Built pg_cron 1.6.8 in WSL/Docker for all five target distributions with packaging output validation enabled: **50 Debian packages**, covering PostgreSQL 14-18 and their debug-symbol packages.
- Inspected generated package versions, PostgreSQL-specific shared libraries, and LLVM compatibility constraints.
- Confirmed target-platform support in both the builder and Packagecloud uploader; checked metadata consistency and non-release publishing guards.
- Passed the two targeted tooling tests for platform decoding and PostgreSQL version selection.
- Production signing and Packagecloud uploads were not exercised locally.