### PR TITLE
Retire Bullseye from pgazure package workflows

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -24,7 +24,6 @@ jobs:
         platform:
           # - el/7
           # - debian/buster
-          # - debian/bullseye
           - ubuntu/focal
           # - ubuntu/jammy
 

--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -28,7 +28,6 @@ jobs:
         platform:
           - el/7
           - debian/buster
-          - debian/bullseye
           - ubuntu/focal
           - ubuntu/jammy
 


### PR DESCRIPTION
## Summary

- remove the Bullseye target from the disabled pgazure nightly workflow
- remove the commented-out Bullseye target from the package workflow
- keep the native GitHub nightly workflow disabled and preserve all other workflow behavior

## Rationale

Debian Bullseye has reached upstream LTS end of life. Removing both the active target in the disabled nightly workflow and the stale commented target prevents Bullseye packaging from being accidentally re-enabled later.

## Semantic delta tests

- confirmed the change is limited to the two Bullseye target deletions
- confirmed all other package targets and workflow behavior remain unchanged
- confirmed the native GitHub nightly workflow remains disabled