### PR TITLE
Retire Bullseye from packaging test builds

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -25,7 +25,6 @@ jobs:
           - el/9
           - ol/8
           - ol/9
-          - debian/bullseye
           - debian/bookworm
           - ubuntu/noble
           - ubuntu/jammy


### PR DESCRIPTION
Debian 11 LTS ended on August 31, 2026. This retires the Bullseye packaging test target while retaining the other matrix entries and repository history.

A semantic YAML comparison confirmed that the only behavior change is removal of the `debian/bullseye` platform.

This is part of the coordinated Bullseye retirement. Consumers land before the packaging `develop` builder removal.