### PR TITLE
Retire Bullseye from enterprise package builds

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -29,7 +29,6 @@ jobs:
           - ol/8
           - debian/stretch
           - debian/buster
-          - debian/bullseye
           - ubuntu/bionic
           - ubuntu/focal
           - ubuntu/jammy


### PR DESCRIPTION
## Summary

- Retire Debian Bullseye from future enterprise package build targets following the end of upstream LTS on August 31.
- Leave all other distributions, PostgreSQL versions, build history, and published assets unchanged.

## Change

The exact YAML delta was checked: this removes only the Bullseye entry from the enterprise package build matrix.