### PR TITLE
Align workflow tools pins to v0.8.40

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -68,7 +68,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.39 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.40 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Clone build branch
         run: git clone -b "${MAIN_BRANCH}" --depth=1  https://github.com/citusdata/packaging.git packaging

--- a/.github/workflows/build-package-test.yml
+++ b/.github/workflows/build-package-test.yml
@@ -92,7 +92,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.37 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.40 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -92,7 +92,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.37 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.40 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/build-pgazure-nightlies.yml
+++ b/.github/workflows/build-pgazure-nightlies.yml
@@ -60,7 +60,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.40 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Clone build branch
         run: git clone -b "${MAIN_BRANCH}" --depth=1  https://github.com/citusdata/packaging.git packaging

--- a/.github/workflows/image-health-check.yml
+++ b/.github/workflows/image-health-check.yml
@@ -94,7 +94,7 @@ jobs:
           POSTGRES_VERSION: ${{ matrix.POSTGRES_VERSION }}
 
       - name: Clone tools repo for test
-        run: git clone -b v0.8.37 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.40 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Execute packaging tests
         run: |

--- a/.github/workflows/update-pgxn-version.yml
+++ b/.github/workflows/update-pgxn-version.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev libssl-dev
 
       - name: Clone Tools branch
-        run: git clone --branch v0.8.36 https://github.com/citusdata/tools.git
+        run: git clone --branch v0.8.40 https://github.com/citusdata/tools.git
 
       - name: Install Python requirements
         run: python -m pip install -r tools/packaging_automation/requirements.txt

--- a/.github/workflows/update_package_properties.yml
+++ b/.github/workflows/update_package_properties.yml
@@ -23,7 +23,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Clone Tools branch
-        run: git clone --depth 1 --branch v0.8.36 https://github.com/citusdata/tools.git
+        run: git clone --depth 1 --branch v0.8.40 https://github.com/citusdata/tools.git
 
       # Runs a set of commands using the runners shell
       - name: Execute Package Properties Update


### PR DESCRIPTION
Aligns the tools clone pins in seven develop workflows to v0.8.40.

The changes are limited to the pin strings; clone options, spacing, and workflow behavior are otherwise unchanged. Bullseye retirement is already present on develop via #1234.

This is separate from #1224.