### PR TITLE
Enable PG19 nightlies after PostgreSQL 19 GA

### DIFF
--- a/pg_exclude.yml
+++ b/pg_exclude.yml
@@ -1,6 +1,7 @@
 exclude:
   nightly:
-    all: [19]
+    el/8: [19]
+    ol/8: [19]
   release:
     debian/trixie: [12,13]
     debian/bookworm: [12,13]   # if PGDG dropped 12/13 there


### PR DESCRIPTION
## DRAFT — DO NOT MERGE

Do not merge until PostgreSQL 19 is GA **and** Citus PG19 nightly readiness has been confirmed.

## Motivation

`exclude.nightly.all: [19]` currently disables PostgreSQL 19 nightly packaging on every platform. Replace that global exclusion with EL8- and OL8-specific exclusions so supported platforms can run PG19 nightlies while retaining protection for the unsupported EL8/OL8 builders.

## Change

- Update only `pg_exclude.yml` (`+2/-1`).
- Keep release exclusions, packaging tools pins, workflow matrices, and PostgreSQL 17/18 behavior unchanged.
- Do not introduce any new CI platforms.
- Keep EL8 and OL8 excluded from PG19 while preserving PG17/18 there.

The merged packaging tools pin (`v0.8.40`) already contains the nightly filter fix; no tools pin change is needed.

## Merge gates

- [ ] PostgreSQL 19 GA is available and target builder images have been refreshed to GA.
- [ ] Citus nightly source is compatible with PostgreSQL 19 and representative nightly package builds have been confirmed.
- [ ] EL8 and OL8 remain excluded from PG19 while PostgreSQL 17/18 remain enabled.

## Draft and CI behavior

Draft status is the operator/merge gate; this change does not add executable PostgreSQL version detection. Existing push workflows can attempt PG19 builds on this draft branch before GA, and failures are not automatically classified as expected. This PR intentionally adds no workflow suppression, manual dispatch, or rerun behavior.

This closes the separate packaging-nightly handoff gap associated with citusdata/docker#387. Docker rollout remains tracked in that issue.

## Validation

YAML parsing and nightly filter assertions confirm EL8/OL8 select PostgreSQL 17/18, while Bookworm, Trixie, Jammy, Noble, EL9, and OL9 select PostgreSQL 17/18/19. No package builds were run.