### PR TITLE
Build tdigest for Ubuntu 20.04 (focal) — PG11–16 pipeline

### DIFF
--- a/.github/workflows/build-tdigest-focal.yml
+++ b/.github/workflows/build-tdigest-focal.yml
@@ -5,19 +5,19 @@ name: Build tdigest (focal)
 # stops at tdigest 1.4.3), then signs them with debsigs (--sign=maint) using the
 # existing packaging key.
 #
-# Like build-postgis-focal.yml there is no per-major matrix: the tdigest Debian
-# packaging is multi-version by design (debian/pgversions + pg_buildext), so one
-# source build emits postgresql-<major>-tdigest for every requested major in a
-# single pass. That also means no assemble/de-duplicate job is needed -- each
-# runtime package is self-contained and produced exactly once.
+# There is no per-major matrix: the tdigest Debian packaging is multi-version by
+# design (debian/pgversions + pg_buildext), so one source build emits
+# postgresql-<major>-tdigest for every requested major in a single pass. That
+# also means no assemble/de-duplicate job is needed -- each runtime package is
+# self-contained and produced exactly once.
 
 on:
   workflow_dispatch:
     inputs:
       tdigest_version:
-        description: "tdigest upstream version to build (e.g. 1.4.5)"
+        description: "tdigest upstream version to build (e.g. 1.4.6)"
         required: true
-        default: "1.4.5"
+        default: "1.4.6"
       pg_versions:
         description: "Space-separated PostgreSQL majors (tdigest supports 10+)"
         required: false
@@ -43,12 +43,12 @@ concurrency:
 
 jobs:
   build-and-sign:
-    name: Build & sign tdigest ${{ github.event.inputs.tdigest_version || '1.4.5' }} (focal)
+    name: Build & sign tdigest ${{ github.event.inputs.tdigest_version || '1.4.6' }} (focal)
     runs-on: ubuntu-latest
     env:
       PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
       PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
-      TDIGEST_VERSION: ${{ github.event.inputs.tdigest_version || '1.4.5' }}
+      TDIGEST_VERSION: ${{ github.event.inputs.tdigest_version || '1.4.6' }}
       PG_VERSIONS: ${{ github.event.inputs.pg_versions || '11 12 13 14 15 16' }}
       TDIGEST_SHA256: ${{ github.event.inputs.tdigest_sha256 || '' }}
       RUN_TESTS: ${{ github.event.inputs.run_tests || '0' }}
@@ -111,18 +111,23 @@ jobs:
           exit $rc
 
       - name: Verify the set is self-contained
-        # Every runtime must ship its own extension control file and SQL, so a
-        # package can never be paired with another version's SQL and there is no
-        # separate -scripts package to depend on.
+        # Every runtime must ship its own extension control file and the full SQL
+        # tree, so a package can never be paired with another version's SQL and
+        # there is no separate -scripts package to depend on. tdigest is installed
+        # from the base script and reaches the built version through the shipped
+        # upgrade chain, whose terminal script names that version (e.g.
+        # tdigest--1.4.5--1.4.6.sql), so match either that or a direct
+        # tdigest--<version>.sql.
         run: |
           rc=0
           for v in ${PG_VERSIONS}; do
             deb="$(ls packages/focal/tdigest/postgresql-${v}-tdigest_*.deb)"
-            if ! dpkg-deb -c "$deb" | grep -q 'extension/tdigest\.control'; then
+            contents="$(dpkg-deb -c "$deb")"
+            if ! grep -q 'extension/tdigest\.control' <<<"$contents"; then
               echo "::error::PG${v} runtime ships no extension control file" >&2; rc=1
             fi
-            if ! dpkg-deb -c "$deb" | grep -q "extension/tdigest--${TDIGEST_VERSION}\.sql"; then
-              echo "::error::PG${v} runtime ships no tdigest--${TDIGEST_VERSION}.sql" >&2; rc=1
+            if ! grep -qE "extension/tdigest--([0-9.]+--)?${TDIGEST_VERSION}\.sql" <<<"$contents"; then
+              echo "::error::PG${v} runtime ships no SQL producing tdigest ${TDIGEST_VERSION}" >&2; rc=1
             fi
           done
           exit $rc
@@ -143,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PG_VERSIONS: ${{ github.event.inputs.pg_versions || '11 12 13 14 15 16' }}
-      TDIGEST_VERSION: ${{ github.event.inputs.tdigest_version || '1.4.5' }}
+      TDIGEST_VERSION: ${{ github.event.inputs.tdigest_version || '1.4.6' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/build-tdigest-focal.yml
+++ b/.github/workflows/build-tdigest-focal.yml
@@ -1,0 +1,171 @@
+name: Build tdigest (focal)
+
+# Builds tdigest .deb packages for Ubuntu 20.04 (focal) from upstream source
+# (PGDG removed focal entirely -- focal-pgdg 404s and the frozen archive mirror
+# stops at tdigest 1.4.3), then signs them with debsigs (--sign=maint) using the
+# existing packaging key.
+#
+# Like build-postgis-focal.yml there is no per-major matrix: the tdigest Debian
+# packaging is multi-version by design (debian/pgversions + pg_buildext), so one
+# source build emits postgresql-<major>-tdigest for every requested major in a
+# single pass. That also means no assemble/de-duplicate job is needed -- each
+# runtime package is self-contained and produced exactly once.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tdigest_version:
+        description: "tdigest upstream version to build (e.g. 1.4.5)"
+        required: true
+        default: "1.4.5"
+      pg_versions:
+        description: "Space-separated PostgreSQL majors (tdigest supports 10+)"
+        required: false
+        default: "12 13 14 15 16"
+      tdigest_sha256:
+        description: "sha256 of tdigest-<version>.tar.gz. Blank = use the pinned default in scripts/build_tdigest_focal (only valid for that version)."
+        required: false
+        default: ""
+      run_tests:
+        description: "Run upstream regression suite (1=yes, much slower)"
+        required: false
+        default: "0"
+  push:
+    branches:
+      - tdigest-focal
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-sign:
+    name: Build & sign tdigest ${{ github.event.inputs.tdigest_version || '1.4.5' }} (focal)
+    runs-on: ubuntu-latest
+    env:
+      PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
+      PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
+      TDIGEST_VERSION: ${{ github.event.inputs.tdigest_version || '1.4.5' }}
+      PG_VERSIONS: ${{ github.event.inputs.pg_versions || '12 13 14 15 16' }}
+      TDIGEST_SHA256: ${{ github.event.inputs.tdigest_sha256 || '' }}
+      RUN_TESTS: ${{ github.event.inputs.run_tests || '0' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USER_NAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build focal tdigest builder image
+        run: |
+          docker build -t focal-tdigest-builder \
+            -f dockerfiles/focal-tdigest-builder/Dockerfile .
+
+      - name: Build tdigest packages
+        run: |
+          mkdir -p packages
+          docker run --rm \
+            -e TDIGEST_VERSION="${TDIGEST_VERSION}" \
+            -e PG_VERSIONS="${PG_VERSIONS}" \
+            -e TDIGEST_SHA256="${TDIGEST_SHA256}" \
+            -e RUN_TESTS="${RUN_TESTS}" \
+            -v "${PWD}/packages:/packages" \
+            focal-tdigest-builder
+          echo "Built packages:"
+          ls -1 packages/focal/tdigest/*.deb
+
+      - name: Sign packages (debsigs --sign=maint)
+        # Use the prebuilt, deployed debsigner image (the one all Citus signing
+        # uses). Its entrypoint signs exactly "/packages/*/*.deb" (one dir level
+        # deep), so mount the parent of the output dir: with
+        # "${PWD}/packages/focal:/packages" the debs land at
+        # /packages/tdigest/*.deb, which is what that glob expects.
+        run: |
+          if [ -z "${PACKAGING_SECRET_KEY}" ] || [ -z "${PACKAGING_PASSPHRASE}" ]; then
+            echo "::error::PACKAGING_SECRET_KEY / PACKAGING_PASSPHRASE secrets are not set" >&2
+            exit 1
+          fi
+          printf '%s' "${PACKAGING_PASSPHRASE}" | docker run --rm -i \
+            -e PACKAGING_SECRET_KEY \
+            -e PACKAGING_PASSPHRASE \
+            -v "${PWD}/packages/focal:/packages" \
+            citusdata/packaging:debsigner
+
+      - name: Verify signatures are embedded
+        run: |
+          rc=0
+          for deb in packages/focal/tdigest/*.deb; do
+            if ar t "$deb" | grep -q '^_gpgmaint$'; then
+              echo "signed: $deb"
+            else
+              echo "::error::missing _gpgmaint signature in $deb" >&2
+              rc=1
+            fi
+          done
+          exit $rc
+
+      - name: Verify the set is self-contained
+        # Every runtime must ship its own extension control file and SQL, so a
+        # package can never be paired with another version's SQL and there is no
+        # separate -scripts package to depend on.
+        run: |
+          rc=0
+          for v in ${PG_VERSIONS}; do
+            deb="$(ls packages/focal/tdigest/postgresql-${v}-tdigest_*.deb)"
+            if ! dpkg-deb -c "$deb" | grep -q 'extension/tdigest\.control'; then
+              echo "::error::PG${v} runtime ships no extension control file" >&2; rc=1
+            fi
+            if ! dpkg-deb -c "$deb" | grep -q "extension/tdigest--${TDIGEST_VERSION}\.sql"; then
+              echo "::error::PG${v} runtime ships no tdigest--${TDIGEST_VERSION}.sql" >&2; rc=1
+            fi
+          done
+          exit $rc
+
+      - name: Upload signed packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: tdigest-focal-deb
+          path: |
+            packages/focal/tdigest/*.deb
+            packages/focal/tdigest/*.changes
+            packages/focal/tdigest/*.buildinfo
+          if-no-files-found: error
+
+  install-smoke-test:
+    needs: build-and-sign
+    name: Install smoke test (focal)
+    runs-on: ubuntu-latest
+    env:
+      PG_VERSIONS: ${{ github.event.inputs.pg_versions || '12 13 14 15 16' }}
+      TDIGEST_VERSION: ${{ github.event.inputs.tdigest_version || '1.4.5' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download built packages
+        uses: actions/download-artifact@v4
+        with:
+          name: tdigest-focal-deb
+          path: debs
+
+      - name: Install and verify in a clean focal container
+        # The jobs above only prove the packages exist, are signed and are
+        # self-contained -- not that the extension can actually be created. This
+        # installs the set into a stock ubuntu:20.04 twice: clean, and over
+        # PGDG's tdigest 1.4.3 (the in-place upgrade path), then runs
+        # CREATE EXTENSION / ALTER EXTENSION UPDATE on every major.
+        run: |
+          docker run --rm \
+            -v "${PWD}/debs:/debs:ro" \
+            -v "${PWD}/scripts/smoke_test_focal_tdigest_debs:/usr/local/bin/smoke_test_focal_tdigest_debs:ro" \
+            -e DEBS_DIR=/debs \
+            -e PG_VERSIONS="${PG_VERSIONS}" \
+            -e EXPECTED_TDIGEST="${TDIGEST_VERSION}" \
+            ubuntu:20.04 \
+            /usr/local/bin/smoke_test_focal_tdigest_debs

--- a/.github/workflows/build-tdigest-focal.yml
+++ b/.github/workflows/build-tdigest-focal.yml
@@ -21,7 +21,7 @@ on:
       pg_versions:
         description: "Space-separated PostgreSQL majors (tdigest supports 10+)"
         required: false
-        default: "12 13 14 15 16"
+        default: "11 12 13 14 15 16"
       tdigest_sha256:
         description: "sha256 of tdigest-<version>.tar.gz. Blank = use the pinned default in scripts/build_tdigest_focal (only valid for that version)."
         required: false
@@ -49,7 +49,7 @@ jobs:
       PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
       PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
       TDIGEST_VERSION: ${{ github.event.inputs.tdigest_version || '1.4.5' }}
-      PG_VERSIONS: ${{ github.event.inputs.pg_versions || '12 13 14 15 16' }}
+      PG_VERSIONS: ${{ github.event.inputs.pg_versions || '11 12 13 14 15 16' }}
       TDIGEST_SHA256: ${{ github.event.inputs.tdigest_sha256 || '' }}
       RUN_TESTS: ${{ github.event.inputs.run_tests || '0' }}
     steps:
@@ -142,7 +142,7 @@ jobs:
     name: Install smoke test (focal)
     runs-on: ubuntu-latest
     env:
-      PG_VERSIONS: ${{ github.event.inputs.pg_versions || '12 13 14 15 16' }}
+      PG_VERSIONS: ${{ github.event.inputs.pg_versions || '11 12 13 14 15 16' }}
       TDIGEST_VERSION: ${{ github.event.inputs.tdigest_version || '1.4.5' }}
     steps:
       - name: Checkout repository

--- a/dockerfiles/focal-tdigest-builder/Dockerfile
+++ b/dockerfiles/focal-tdigest-builder/Dockerfile
@@ -1,7 +1,7 @@
 # vim:set ft=dockerfile:
 #
 # Builder image for tdigest packages targeting Ubuntu 20.04 (focal). One image
-# builds every focal-buildable PostgreSQL major at once (PG 12..16 by default);
+# builds every focal-buildable PostgreSQL major at once (PG 11..16 by default);
 # like PostGIS -- and unlike PostgreSQL core -- the tdigest Debian packaging is
 # multi-version by design (debian/pgversions + the pgxs_loop debhelper addon
 # drive pg_buildext), so a single source build emits postgresql-<major>-tdigest
@@ -33,13 +33,11 @@ RUN set -ex; \
     install -d /usr/share/keyrings; \
     curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
       | gpg --dearmor -o /usr/share/keyrings/pgdg-archive.gpg; \
-    # 'main' carries the build tooling and the tdigest source package; each
-    # PostgreSQL major is a separate component. tdigest supports PG12+ here and
-    # Marlin still ships PG12, so component 12 is listed even though
-    # focal-pg-builder omits it.
-    echo "deb [signed-by=/usr/share/keyrings/pgdg-archive.gpg] https://apt-archive.postgresql.org/pub/repos/apt focal-pgdg main 12 13 14 15 16" \
+    # 'main' carries the build tooling, the tdigest source package and the PG11
+    # binaries; PG12..16 are each a separate component.
+    echo "deb [signed-by=/usr/share/keyrings/pgdg-archive.gpg] https://apt-archive.postgresql.org/pub/repos/apt focal-pgdg main 11 12 13 14 15 16" \
       > /etc/apt/sources.list.d/pgdg-archive.list; \
-    echo "deb-src [signed-by=/usr/share/keyrings/pgdg-archive.gpg] https://apt-archive.postgresql.org/pub/repos/apt focal-pgdg main 12 13 14 15 16" \
+    echo "deb-src [signed-by=/usr/share/keyrings/pgdg-archive.gpg] https://apt-archive.postgresql.org/pub/repos/apt focal-pgdg main 11 12 13 14 15 16" \
       >> /etc/apt/sources.list.d/pgdg-archive.list; \
     apt-get update; \
     # base build tooling; per-build Build-Depends are resolved at run time by

--- a/dockerfiles/focal-tdigest-builder/Dockerfile
+++ b/dockerfiles/focal-tdigest-builder/Dockerfile
@@ -2,18 +2,16 @@
 #
 # Builder image for tdigest packages targeting Ubuntu 20.04 (focal). One image
 # builds every focal-buildable PostgreSQL major at once (PG 11..16 by default);
-# like PostGIS -- and unlike PostgreSQL core -- the tdigest Debian packaging is
-# multi-version by design (debian/pgversions + the pgxs_loop debhelper addon
-# drive pg_buildext), so a single source build emits postgresql-<major>-tdigest
-# for each major in one pass.
+# the tdigest Debian packaging is multi-version by design (debian/pgversions +
+# the pgxs_loop debhelper addon drive pg_buildext), so a single source build
+# emits postgresql-<major>-tdigest for each major in one pass.
 #
 # Why this exists:
 #   apt.postgresql.org (PGDG) no longer ships focal binaries -- focal-pgdg 404s
 #   and the frozen apt-archive mirror tops out at tdigest 1.4.3. Anything newer
-#   (e.g. 1.4.5 for the memory-safety fixes) has to be rebuilt from upstream
-#   source.
+#   (e.g. 1.4.6) has to be rebuilt from upstream source.
 #
-# Strategy (mirrors dockerfiles/focal-postgis-builder/Dockerfile):
+# Strategy:
 #   - Upstream source: tdigest-<version>.tar.gz from GitHub, sha256-pinned.
 #   - Debian packaging: the frozen focal-era debian/ from PGDG's last focal
 #     tdigest source package (1.4.3-1.pgdg20.04+1), fetched with `apt-get source`

--- a/dockerfiles/focal-tdigest-builder/Dockerfile
+++ b/dockerfiles/focal-tdigest-builder/Dockerfile
@@ -1,0 +1,69 @@
+# vim:set ft=dockerfile:
+#
+# Builder image for tdigest packages targeting Ubuntu 20.04 (focal). One image
+# builds every focal-buildable PostgreSQL major at once (PG 12..16 by default);
+# like PostGIS -- and unlike PostgreSQL core -- the tdigest Debian packaging is
+# multi-version by design (debian/pgversions + the pgxs_loop debhelper addon
+# drive pg_buildext), so a single source build emits postgresql-<major>-tdigest
+# for each major in one pass.
+#
+# Why this exists:
+#   apt.postgresql.org (PGDG) no longer ships focal binaries -- focal-pgdg 404s
+#   and the frozen apt-archive mirror tops out at tdigest 1.4.3. Anything newer
+#   (e.g. 1.4.5 for the memory-safety fixes) has to be rebuilt from upstream
+#   source.
+#
+# Strategy (mirrors dockerfiles/focal-postgis-builder/Dockerfile):
+#   - Upstream source: tdigest-<version>.tar.gz from GitHub, sha256-pinned.
+#   - Debian packaging: the frozen focal-era debian/ from PGDG's last focal
+#     tdigest source package (1.4.3-1.pgdg20.04+1), fetched with `apt-get source`
+#     so it is authenticated by the archive's signed Release.
+#   - Build tooling restored from the PGDG *archive*, which keeps the removed
+#     focal-pgdg suite.
+#
+# The heavy lifting lives in scripts/build_tdigest_focal (the entrypoint).
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+# PGDG repository signing key fingerprint:
+#   B97B 0AFC AA1A 47F0 44F2  44A0 7FCC 7D46 ACCC 4CF8
+RUN set -ex; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg; \
+    install -d /usr/share/keyrings; \
+    curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+      | gpg --dearmor -o /usr/share/keyrings/pgdg-archive.gpg; \
+    # 'main' carries the build tooling and the tdigest source package; each
+    # PostgreSQL major is a separate component. tdigest supports PG12+ here and
+    # Marlin still ships PG12, so component 12 is listed even though
+    # focal-pg-builder omits it.
+    echo "deb [signed-by=/usr/share/keyrings/pgdg-archive.gpg] https://apt-archive.postgresql.org/pub/repos/apt focal-pgdg main 12 13 14 15 16" \
+      > /etc/apt/sources.list.d/pgdg-archive.list; \
+    echo "deb-src [signed-by=/usr/share/keyrings/pgdg-archive.gpg] https://apt-archive.postgresql.org/pub/repos/apt focal-pgdg main 12 13 14 15 16" \
+      >> /etc/apt/sources.list.d/pgdg-archive.list; \
+    apt-get update; \
+    # base build tooling; per-build Build-Depends are resolved at run time by
+    # scripts/build_tdigest_focal via mk-build-deps against debian/control.
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        devscripts \
+        equivs \
+        fakeroot \
+        quilt \
+        dpkg-dev \
+        debhelper \
+        dh-exec \
+        postgresql-common-dev \
+        postgresql-server-dev-all \
+        xz-utils; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fail the image build early if the archived focal-pgdg debhelper (>= 13) is not
+# what we picked up (debhelper-compat (= 13) is required by the packaging).
+RUN dpkg-query -W -f='${Package} ${Version}\n' debhelper postgresql-common-dev dh-exec
+
+COPY scripts/build_tdigest_focal /usr/local/bin/build_tdigest_focal
+RUN chmod +x /usr/local/bin/build_tdigest_focal
+
+VOLUME /packages
+ENTRYPOINT ["/usr/local/bin/build_tdigest_focal"]

--- a/scripts/build_tdigest_focal
+++ b/scripts/build_tdigest_focal
@@ -1,0 +1,173 @@
+#!/bin/bash
+#
+# build_tdigest_focal -- rebuild tdigest Debian packages for Ubuntu 20.04 (focal).
+#
+# PGDG removed focal entirely (focal-pgdg 404s; the frozen apt-archive mirror
+# stops at tdigest 1.4.3), so a newer tdigest on focal has to be rebuilt from
+# upstream source.
+#
+# Approach (see dockerfiles/focal-tdigest-builder/Dockerfile for the rationale):
+#   upstream tdigest-<version>.tar.gz  +  the frozen focal-era debian/ packaging
+#   from PGDG's last focal tdigest source package
+#   -> dpkg-buildpackage inside a focal environment with the archived focal-pgdg
+#      build tooling available.
+#
+# Like PostGIS -- and unlike PostgreSQL core -- one source build emits packages
+# for *every* PostgreSQL major at once. tdigest is a plain PGXS extension whose
+# Debian packaging is multi-version by design (debian/pgversions + the
+# pgxs_loop debhelper addon drive pg_buildext), so a single source build emits
+# postgresql-<major>-tdigest for each requested major in one pass. There is no
+# per-major matrix here.
+#
+# tdigest's packaging is much simpler than PostGIS's: there is no arch-independent
+# -scripts package and no update-alternatives dance -- each runtime package ships
+# its own extension control file and SQL, so none of the PostGIS control-suffix /
+# alternatives workarounds are needed.
+#
+# Output: unsigned *.deb in ${OUTPUT_DIR} (default /packages/focal/tdigest).
+# Signing is a separate step performed by the debsigner image (debsigs
+# --sign=maint), so the build and the signing key never live in the same
+# container.
+#
+# Examples:
+#   build_tdigest_focal                                   # 1.4.5 for PG12..16
+#   TDIGEST_VERSION=1.4.6 build_tdigest_focal
+#   PG_VERSIONS="15 16" RUN_TESTS=1 build_tdigest_focal
+
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# Inputs (override via env)
+# ----------------------------------------------------------------------------
+TDIGEST_VERSION="${TDIGEST_VERSION:-1.4.5}"
+
+# tdigest supports PostgreSQL 10+, but focal-relevant Citus/Marlin ships PG12+,
+# so the default set matches the focal PostGIS pipeline. Add "11" here if a
+# PG11 build is ever needed.
+PG_VERSIONS="${PG_VERSIONS:-12 13 14 15 16}"
+
+# The last focal tdigest source package PGDG published. Its debian/ is frozen
+# (focal is EOL); override only if the archive is ever re-touched.
+PACKAGING_SRC_VERSION="${PACKAGING_SRC_VERSION:-1.4.3-1.pgdg20.04+1}"
+
+# sha256 of the upstream tarball. Pinned by default: the GitHub tag archive
+# serves no detached signature, so this is the only integrity check available
+# and it must not silently degrade to "whatever was served".
+TDIGEST_SHA256="${TDIGEST_SHA256:-4b84834e88a87f2b3538fbd2ac56033642b7e14b2744e78344b16d6e609733af}"
+
+DEB_REVISION="${DEB_REVISION:-1.citus20.04+1}"
+TARGET_VERSION="${TARGET_VERSION:-${TDIGEST_VERSION}-${DEB_REVISION}}"
+
+# Set RUN_TESTS=1 to run the upstream regression suite (much slower, and pulls
+# in postgresql-all for a full test matrix).
+RUN_TESTS="${RUN_TESTS:-0}"
+
+OUTPUT_DIR="${OUTPUT_DIR:-/packages/focal/tdigest}"
+WORK="${WORK_DIR:-/build}"
+UPSTREAM_URL="${UPSTREAM_URL:-https://github.com/tvondra/tdigest/archive/refs/tags/v${TDIGEST_VERSION}.tar.gz}"
+
+export DEBEMAIL="${DEBEMAIL:-packaging@citusdata.com}"
+export DEBFULLNAME="${DEBFULLNAME:-Citus Data}"
+export DEBIAN_FRONTEND=noninteractive
+
+echo "==> Building tdigest ${TDIGEST_VERSION} as ${TARGET_VERSION} for PG${PG_VERSIONS// /,} (focal)"
+
+mkdir -p "${WORK}" "${OUTPUT_DIR}"
+cd "${WORK}"
+
+echo "==> [1/6] Fetch frozen focal debian/ packaging (tdigest ${PACKAGING_SRC_VERSION})"
+apt-get update
+# apt-get source validates against the archive's signed Release file.
+apt-get source "tdigest=${PACKAGING_SRC_VERSION}"
+PKG_DIR="$(find "${WORK}" -maxdepth 1 -type d -name 'tdigest-*' -exec test -d '{}/debian' \; -print | head -1)"
+[ -n "${PKG_DIR}" ] || { echo "ERROR: could not locate unpacked packaging source" >&2; exit 1; }
+
+echo "==> [2/6] Fetch and verify upstream tdigest-${TDIGEST_VERSION}.tar.gz"
+curl -4 -fsSL -o "tdigest-${TDIGEST_VERSION}.tar.gz" "${UPSTREAM_URL}"
+echo "${TDIGEST_SHA256}  tdigest-${TDIGEST_VERSION}.tar.gz" | sha256sum -c -
+
+SRCDIR="${WORK}/tdigest-${TDIGEST_VERSION}"
+rm -rf "${SRCDIR}"
+tar xzf "tdigest-${TDIGEST_VERSION}.tar.gz"
+cp -a "${PKG_DIR}/debian" "${SRCDIR}/debian"
+cd "${SRCDIR}"
+
+echo "==> [3/6] Triage quilt patches against the new upstream"
+if [ -f debian/patches/series ]; then
+  KEPT=""
+  while read -r patch; do
+    [ -z "${patch}" ] && continue
+    case "${patch}" in \#*) continue ;; esac
+    if patch -p1 --dry-run --silent < "debian/patches/${patch}" >/dev/null 2>&1; then
+      echo "    keep  ${patch}"; KEPT="${KEPT}${patch}\n"
+    else
+      echo "    drop  ${patch} (does not apply to ${TDIGEST_VERSION})"
+    fi
+  done < debian/patches/series
+  printf "%b" "${KEPT}" > debian/patches/series
+else
+  echo "    no debian/patches/series -- nothing to triage"
+fi
+
+echo "==> [4/6] Target PostgreSQL majors: ${PG_VERSIONS}"
+# debian/control ships with every major PGDG built (10..17); regenerate it from
+# debian/control.in so only the requested majors are declared and built.
+printf '%s\n' ${PG_VERSIONS} > debian/pgversions
+pg_buildext updatecontrol
+echo "    binary packages now declared:"
+grep '^Package:' debian/control | sed 's/^/      /'
+
+echo "==> [5/6] Set version to ${TARGET_VERSION} and install Build-Depends"
+dch --newversion "${TARGET_VERSION}" --distribution focal --force-distribution \
+    "Rebuild of tdigest ${TDIGEST_VERSION} for focal (upstream PGDG focal-pgdg discontinued)."
+
+BUILD_OPTIONS="parallel=$(nproc)"
+BUILD_PROFILES=""
+if [ "${RUN_TESTS}" != "1" ]; then
+  # nocheck drops the postgresql-all <!nocheck> Build-Depends (a full server
+  # matrix pulled in only for the upstream test suite) and skips dh_auto_test.
+  BUILD_OPTIONS="${BUILD_OPTIONS} nocheck"
+  BUILD_PROFILES="nocheck"
+fi
+export DEB_BUILD_OPTIONS="${BUILD_OPTIONS}"
+export DEB_BUILD_PROFILES="${BUILD_PROFILES}"
+
+mk-build-deps --install --remove \
+  --tool 'apt-get -o Debug::pkgProblemResolver=yes --yes --no-install-recommends' \
+  debian/control
+
+echo "==> [6/6] Build binary packages (DEB_BUILD_OPTIONS='${BUILD_OPTIONS}')"
+dpkg-buildpackage -b -uc -us
+
+echo "==> Collect artifacts into ${OUTPUT_DIR}"
+for v in ${PG_VERSIONS}; do
+  cp -v "${WORK}"/postgresql-${v}-tdigest_*.deb "${OUTPUT_DIR}/"
+  # Debug-symbol packages are emitted as .ddeb on Ubuntu. Ship them as .deb (the
+  # on-disk format is identical) so they flow through the same signing,
+  # verification and publishing as everything else. Consumers commonly install
+  # with an `*.deb` glob, which does not match `.ddeb`; because a dbgsym depends
+  # on its runtime with an exact `=` version, silently dropping it strands the
+  # previously installed dbgsym and breaks `apt --fix-broken install`.
+  for ddeb in "${WORK}"/postgresql-${v}-tdigest-dbgsym_*.ddeb; do
+    [ -e "${ddeb}" ] || continue
+    cp -v "${ddeb}" "${OUTPUT_DIR}/$(basename "${ddeb}" .ddeb).deb"
+  done
+done
+cp -v "${WORK}"/*.buildinfo "${WORK}"/*.changes "${OUTPUT_DIR}/" 2>/dev/null || true
+
+echo "==> Verify runtime <-> dbgsym pairing"
+for v in ${PG_VERSIONS}; do
+  rt="$(dpkg-deb -f "${OUTPUT_DIR}"/postgresql-${v}-tdigest_*.deb Version)"
+  for dbg in "${OUTPUT_DIR}"/postgresql-${v}-tdigest-dbgsym_*.deb; do
+    [ -e "${dbg}" ] || continue
+    dep="$(dpkg-deb -f "${dbg}" Depends)"
+    if [ "${dep}" != "postgresql-${v}-tdigest (= ${rt})" ]; then
+      echo "ERROR: PG${v} dbgsym wants '${dep}' but runtime is '${rt}'" >&2
+      exit 1
+    fi
+  done
+  echo "    PG${v} OK (${rt})"
+done
+
+echo "==> DONE. Packages:"
+ls -1 "${OUTPUT_DIR}"/*.deb

--- a/scripts/build_tdigest_focal
+++ b/scripts/build_tdigest_focal
@@ -12,17 +12,14 @@
 #   -> dpkg-buildpackage inside a focal environment with the archived focal-pgdg
 #      build tooling available.
 #
-# Like PostGIS -- and unlike PostgreSQL core -- one source build emits packages
-# for *every* PostgreSQL major at once. tdigest is a plain PGXS extension whose
-# Debian packaging is multi-version by design (debian/pgversions + the
-# pgxs_loop debhelper addon drive pg_buildext), so a single source build emits
-# postgresql-<major>-tdigest for each requested major in one pass. There is no
-# per-major matrix here.
+# One source build emits packages for *every* PostgreSQL major at once. tdigest
+# is a plain PGXS extension whose Debian packaging is multi-version by design
+# (debian/pgversions + the pgxs_loop debhelper addon drive pg_buildext), so a
+# single source build emits postgresql-<major>-tdigest for each requested major
+# in one pass. There is no per-major matrix here.
 #
-# tdigest's packaging is much simpler than PostGIS's: there is no arch-independent
-# -scripts package and no update-alternatives dance -- each runtime package ships
-# its own extension control file and SQL, so none of the PostGIS control-suffix /
-# alternatives workarounds are needed.
+# Each runtime package ships its own extension control file and SQL; there is no
+# separate -scripts package and no update-alternatives handling to worry about.
 #
 # Output: unsigned *.deb in ${OUTPUT_DIR} (default /packages/focal/tdigest).
 # Signing is a separate step performed by the debsigner image (debsigs
@@ -30,7 +27,7 @@
 # container.
 #
 # Examples:
-#   build_tdigest_focal                                   # 1.4.5 for PG11..16
+#   build_tdigest_focal                                   # 1.4.6 for PG11..16
 #   TDIGEST_VERSION=1.4.6 build_tdigest_focal
 #   PG_VERSIONS="15 16" RUN_TESTS=1 build_tdigest_focal
 
@@ -39,10 +36,10 @@ set -euo pipefail
 # ----------------------------------------------------------------------------
 # Inputs (override via env)
 # ----------------------------------------------------------------------------
-TDIGEST_VERSION="${TDIGEST_VERSION:-1.4.5}"
+TDIGEST_VERSION="${TDIGEST_VERSION:-1.4.6}"
 
 # tdigest supports PostgreSQL 10+. focal shipped PG11..16, so the default set
-# covers every focal-buildable major; drop "11" if only PG12+ is needed.
+# covers every focal-buildable major
 PG_VERSIONS="${PG_VERSIONS:-11 12 13 14 15 16}"
 
 # The last focal tdigest source package PGDG published. Its debian/ is frozen
@@ -52,7 +49,7 @@ PACKAGING_SRC_VERSION="${PACKAGING_SRC_VERSION:-1.4.3-1.pgdg20.04+1}"
 # sha256 of the upstream tarball. Pinned by default: the GitHub tag archive
 # serves no detached signature, so this is the only integrity check available
 # and it must not silently degrade to "whatever was served".
-TDIGEST_SHA256="${TDIGEST_SHA256:-4b84834e88a87f2b3538fbd2ac56033642b7e14b2744e78344b16d6e609733af}"
+TDIGEST_SHA256="${TDIGEST_SHA256:-5158d3a57e96883262a299d559ffb18da80616825b13f29f1c8b3113dd467a95}"
 
 DEB_REVISION="${DEB_REVISION:-1.citus20.04+1}"
 TARGET_VERSION="${TARGET_VERSION:-${TDIGEST_VERSION}-${DEB_REVISION}}"

--- a/scripts/build_tdigest_focal
+++ b/scripts/build_tdigest_focal
@@ -30,7 +30,7 @@
 # container.
 #
 # Examples:
-#   build_tdigest_focal                                   # 1.4.5 for PG12..16
+#   build_tdigest_focal                                   # 1.4.5 for PG11..16
 #   TDIGEST_VERSION=1.4.6 build_tdigest_focal
 #   PG_VERSIONS="15 16" RUN_TESTS=1 build_tdigest_focal
 
@@ -41,10 +41,9 @@ set -euo pipefail
 # ----------------------------------------------------------------------------
 TDIGEST_VERSION="${TDIGEST_VERSION:-1.4.5}"
 
-# tdigest supports PostgreSQL 10+, but focal-relevant Citus/Marlin ships PG12+,
-# so the default set matches the focal PostGIS pipeline. Add "11" here if a
-# PG11 build is ever needed.
-PG_VERSIONS="${PG_VERSIONS:-12 13 14 15 16}"
+# tdigest supports PostgreSQL 10+. focal shipped PG11..16, so the default set
+# covers every focal-buildable major; drop "11" if only PG12+ is needed.
+PG_VERSIONS="${PG_VERSIONS:-11 12 13 14 15 16}"
 
 # The last focal tdigest source package PGDG published. Its debian/ is frozen
 # (focal is EOL); override only if the archive is ever re-touched.

--- a/scripts/smoke_test_focal_tdigest_debs
+++ b/scripts/smoke_test_focal_tdigest_debs
@@ -18,7 +18,7 @@
 #
 # Overridable via environment:
 #   DEBS_DIR            directory holding the *.deb set        (default /debs)
-#   PG_VERSIONS         majors to verify                       (default "12 13 14 15 16")
+#   PG_VERSIONS         majors to verify                       (default "11 12 13 14 15 16")
 #   EXPECTED_TDIGEST    expected extension version             (default 1.4.5)
 #   OLD_TDIGEST         PGDG version to upgrade from in test B (default 1.4.3-1.pgdg20.04+1)
 #   PGDG_ARCHIVE_SUITE  archive suite to enable                (default focal-pgdg)
@@ -26,7 +26,7 @@
 set -uo pipefail
 
 DEBS_DIR="${DEBS_DIR:-/debs}"
-PG_VERSIONS="${PG_VERSIONS:-12 13 14 15 16}"
+PG_VERSIONS="${PG_VERSIONS:-11 12 13 14 15 16}"
 EXPECTED_TDIGEST="${EXPECTED_TDIGEST:-1.4.5}"
 OLD_TDIGEST="${OLD_TDIGEST:-1.4.3-1.pgdg20.04+1}"
 PGDG_ARCHIVE_SUITE="${PGDG_ARCHIVE_SUITE:-focal-pgdg}"
@@ -59,7 +59,7 @@ note "[2/6] Enabling the PGDG archive"
 install -d /usr/share/keyrings
 curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
   | gpg --dearmor -o /usr/share/keyrings/pgdg-archive.gpg
-echo "deb [signed-by=/usr/share/keyrings/pgdg-archive.gpg] ${PGDG_ARCHIVE_URL} ${PGDG_ARCHIVE_SUITE} main 12 13 14 15 16" \
+echo "deb [signed-by=/usr/share/keyrings/pgdg-archive.gpg] ${PGDG_ARCHIVE_URL} ${PGDG_ARCHIVE_SUITE} main 11 12 13 14 15 16" \
   > /etc/apt/sources.list.d/pgdg-archive.list
 apt-get update -qq
 

--- a/scripts/smoke_test_focal_tdigest_debs
+++ b/scripts/smoke_test_focal_tdigest_debs
@@ -19,7 +19,7 @@
 # Overridable via environment:
 #   DEBS_DIR            directory holding the *.deb set        (default /debs)
 #   PG_VERSIONS         majors to verify                       (default "11 12 13 14 15 16")
-#   EXPECTED_TDIGEST    expected extension version             (default 1.4.5)
+#   EXPECTED_TDIGEST    expected extension version             (default 1.4.6)
 #   OLD_TDIGEST         PGDG version to upgrade from in test B (default 1.4.3-1.pgdg20.04+1)
 #   PGDG_ARCHIVE_SUITE  archive suite to enable                (default focal-pgdg)
 
@@ -27,7 +27,7 @@ set -uo pipefail
 
 DEBS_DIR="${DEBS_DIR:-/debs}"
 PG_VERSIONS="${PG_VERSIONS:-11 12 13 14 15 16}"
-EXPECTED_TDIGEST="${EXPECTED_TDIGEST:-1.4.5}"
+EXPECTED_TDIGEST="${EXPECTED_TDIGEST:-1.4.6}"
 OLD_TDIGEST="${OLD_TDIGEST:-1.4.3-1.pgdg20.04+1}"
 PGDG_ARCHIVE_SUITE="${PGDG_ARCHIVE_SUITE:-focal-pgdg}"
 PGDG_ARCHIVE_URL="${PGDG_ARCHIVE_URL:-https://apt-archive.postgresql.org/pub/repos/apt}"

--- a/scripts/smoke_test_focal_tdigest_debs
+++ b/scripts/smoke_test_focal_tdigest_debs
@@ -1,0 +1,138 @@
+#!/bin/bash
+#
+# smoke_test_focal_tdigest_debs -- install the built tdigest .deb set inside a
+# clean Ubuntu 20.04 (focal) container and prove it actually works.
+#
+# The build pipeline already checks the packages exist, are signed, and pair
+# correctly with their dbgsym. None of that proves the extension is usable, so
+# this installs the set into a stock ubuntu:20.04 and runs CREATE EXTENSION plus
+# a real aggregate query on every major.
+#
+# It tests both paths that matter:
+#   A. clean install on a stock focal + PGDG PostgreSQL
+#   B. install *over* PGDG's tdigest 1.4.3 and ALTER EXTENSION ... UPDATE, which
+#      is what an in-place upgrade on an existing host actually does
+#
+# Usage (inside a stock ubuntu:20.04 container, as root):
+#   DEBS_DIR=/debs smoke_test_focal_tdigest_debs
+#
+# Overridable via environment:
+#   DEBS_DIR            directory holding the *.deb set        (default /debs)
+#   PG_VERSIONS         majors to verify                       (default "12 13 14 15 16")
+#   EXPECTED_TDIGEST    expected extension version             (default 1.4.5)
+#   OLD_TDIGEST         PGDG version to upgrade from in test B (default 1.4.3-1.pgdg20.04+1)
+#   PGDG_ARCHIVE_SUITE  archive suite to enable                (default focal-pgdg)
+
+set -uo pipefail
+
+DEBS_DIR="${DEBS_DIR:-/debs}"
+PG_VERSIONS="${PG_VERSIONS:-12 13 14 15 16}"
+EXPECTED_TDIGEST="${EXPECTED_TDIGEST:-1.4.5}"
+OLD_TDIGEST="${OLD_TDIGEST:-1.4.3-1.pgdg20.04+1}"
+PGDG_ARCHIVE_SUITE="${PGDG_ARCHIVE_SUITE:-focal-pgdg}"
+PGDG_ARCHIVE_URL="${PGDG_ARCHIVE_URL:-https://apt-archive.postgresql.org/pub/repos/apt}"
+
+export DEBIAN_FRONTEND=noninteractive
+export LANG=C.UTF-8
+
+fail=0
+note() { echo "==> $*"; }
+err()  { echo "::error::$*" >&2; fail=1; }
+
+shopt -s nullglob
+debs=("${DEBS_DIR}"/*.deb)
+shopt -u nullglob
+[ ${#debs[@]} -gt 0 ] || { echo "ERROR: no .deb files found in ${DEBS_DIR}" >&2; exit 1; }
+
+note "[1/6] Preparing container environment (${#debs[@]} packages)"
+# postgresql-NN.postinst ends in `invoke-rc.d postgresql start $VERSION` under
+# `set -e`, and there is no systemd in a container. A policy-rc.d denying the
+# action makes invoke-rc.d return 0 so the postinst still creates the cluster;
+# clusters are started explicitly below.
+printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d
+chmod +x /usr/sbin/policy-rc.d
+
+apt-get update -qq
+apt-get install -y -qq --no-install-recommends ca-certificates curl gnupg >/dev/null
+
+note "[2/6] Enabling the PGDG archive"
+install -d /usr/share/keyrings
+curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+  | gpg --dearmor -o /usr/share/keyrings/pgdg-archive.gpg
+echo "deb [signed-by=/usr/share/keyrings/pgdg-archive.gpg] ${PGDG_ARCHIVE_URL} ${PGDG_ARCHIVE_SUITE} main 12 13 14 15 16" \
+  > /etc/apt/sources.list.d/pgdg-archive.list
+apt-get update -qq
+
+psql_v() { su postgres -c "psql --cluster $1/main -qtAX -c \"$2\"" 2>&1; }
+
+ensure_cluster() {
+  pg_lsclusters -h | awk '{print $1"/"$2}' | grep -qx "$1/main" \
+    || pg_createcluster "$1" main >/dev/null 2>&1
+  pg_ctlcluster "$1" main start >/dev/null 2>&1
+}
+
+# Median of 1..1000 is ~500. t-digest is approximate, so accept a small window.
+check_percentile() {
+  local v="$1" p
+  p="$(psql_v "${v}" "SELECT round(tdigest_percentile(i, 100, 0.5)) FROM generate_series(1,1000) i;")"
+  awk -v p="${p}" 'BEGIN{exit !(p+0>=480 && p+0<=520)}'
+}
+
+note "[3/6] Scenario A: clean install"
+for v in ${PG_VERSIONS}; do
+  apt-get install -y -qq postgresql-${v} >/dev/null 2>&1
+done
+dpkg -i --force-all "${DEBS_DIR}"/*.deb >/dev/null 2>&1
+if ! apt-get --fix-broken install -y >/dev/null 2>&1; then
+  err "apt --fix-broken install failed after clean install"
+fi
+
+for v in ${PG_VERSIONS}; do
+  ensure_cluster "${v}"
+  psql_v "${v}" "CREATE EXTENSION tdigest;" >/dev/null 2>&1
+  ext="$(psql_v "${v}" "SELECT extversion FROM pg_extension WHERE extname='tdigest';")"
+  if [ "${ext}" = "${EXPECTED_TDIGEST}" ] && check_percentile "${v}"; then
+    echo "    PG${v} OK   ext=${ext}"
+  else
+    err "PG${v} clean install: ext='${ext}' (expected ${EXPECTED_TDIGEST}) or percentile check failed"
+  fi
+  pg_ctlcluster "${v}" main stop >/dev/null 2>&1
+done
+
+note "[4/6] Scenario B: upgrade over PGDG tdigest ${OLD_TDIGEST}"
+for v in ${PG_VERSIONS}; do
+  apt-get remove -y -qq postgresql-${v}-tdigest >/dev/null 2>&1
+  pg_dropcluster "${v}" main >/dev/null 2>&1
+  pg_createcluster "${v}" main >/dev/null 2>&1
+  apt-get install -y -qq --allow-downgrades \
+    postgresql-${v}-tdigest=${OLD_TDIGEST} >/dev/null 2>&1
+  ensure_cluster "${v}"
+  psql_v "${v}" "CREATE EXTENSION tdigest;" >/dev/null 2>&1
+  pg_ctlcluster "${v}" main stop >/dev/null 2>&1
+done
+
+# Mirrors how consumers apply the set: force-all dpkg, then let apt settle.
+dpkg -i --force-all "${DEBS_DIR}"/*.deb >/dev/null 2>&1
+if ! apt-get --fix-broken install -y >/dev/null 2>&1; then
+  err "apt --fix-broken install failed after upgrade over ${OLD_TDIGEST}"
+fi
+
+note "[5/6] Verifying the extension upgrades and works after the package upgrade"
+for v in ${PG_VERSIONS}; do
+  ensure_cluster "${v}"
+  out="$(psql_v "${v}" "ALTER EXTENSION tdigest UPDATE;")"
+  ext="$(psql_v "${v}" "SELECT extversion FROM pg_extension WHERE extname='tdigest';")"
+  if [ "${ext}" = "${EXPECTED_TDIGEST}" ] && check_percentile "${v}"; then
+    echo "    PG${v} OK   ext=${ext}"
+  else
+    err "PG${v} after upgrade: ext='${ext}' (expected ${EXPECTED_TDIGEST}) ${out}"
+  fi
+  pg_ctlcluster "${v}" main stop >/dev/null 2>&1
+done
+
+note "[6/6] Result"
+if [ "${fail}" -ne 0 ]; then
+  echo "SMOKE TEST FAILED" >&2
+  exit 1
+fi
+echo "SMOKE TEST PASSED"


### PR DESCRIPTION
## What and why

PGDG no longer publishes packages for Ubuntu 20.04 (`focal-pgdg` returns 404), and its archive is frozen. This pipeline rebuilds the **latest stable upstream tdigest release for PostgreSQL 11–16**, including matching debug-symbol packages, using the archived focal Debian packaging and build tooling.

## Release and packaging discovery

- `tdigest_version` defaults to `latest`. The workflow resolves GitHub's latest stable release once and passes the resolved version, source URL, archive format, and SHA-256 into the builder. The smoke-test job uses that same resolved version.
- Automatic builds download the upstream release ZIP and verify it against the SHA-256 digest published by GitHub. Missing assets, missing digests, and checksum mismatches fail the build.
- Explicit versions remain supported. For historical releases without a checksummed release ZIP, callers can provide the SHA-256 for the GitHub tag tarball.
- APT selects the archived tdigest source package used for `debian/`. Upgrade-test baselines are discovered from APT separately for each PostgreSQL major, before installing the newly built packages.
- There are no hard-coded tdigest release versions or checksums in the pipeline. Resolved source details and the selected Debian packaging source version are saved in `tdigest-source.env` alongside the artifacts.

## Implementation

| File | Role |
|---|---|
| `dockerfiles/focal-tdigest-builder/Dockerfile` | Ubuntu 20.04 builder with archived PGDG tooling and release-discovery/archive utilities |
| `scripts/resolve_tdigest_focal` | Validates PostgreSQL majors and resolves the upstream release, source URL, and checksum |
| `scripts/build_tdigest_focal` | Combines upstream source with archived Debian packaging, builds packages, and validates debug symbols |
| `scripts/smoke_test_focal_tdigest_debs` | Verifies clean installation and upgrades in a stock focal container |
| `.github/workflows/build-tdigest-focal.yml` | Orchestrates discovery, build, signing, artifact checks, and smoke tests |

One multi-version PGXS source build covers all requested majors. The builder writes `debian/pgversions` and regenerates `debian/control` with `pg_buildext updatecontrol`, so only the requested packages are declared and built. The default is **11 12 13 14 15 16**; values outside that range are rejected before the build.

Each major produces:

- `postgresql-<major>-tdigest`, containing its own library, extension control file, and SQL upgrade chain.
- `postgresql-<major>-tdigest-dbgsym`, containing matching debug information.

The build enables debug information and requires exactly one debug-symbol package per major. Ubuntu `.ddeb` artifacts are renamed to `.deb` so runtime and symbol packages follow the same signing and artifact-upload path.

Archived packaging and upstream source are extracted into separate directories within a fresh build workspace. This fixes the source-directory collision when rebuilding the same upstream version as the archived packaging. Explicit historical rebuilds also handle Debian changelog version ordering.

## Verification performed by the pipeline

- **Source integrity:** verify the upstream archive checksum; obtain archived Debian packaging through APT's signed repository metadata.
- **Package signing:** sign every runtime and debug-symbol `.deb` with the existing debsigner image and require an embedded `_gpgmaint` signature.
- **Self-contained runtime:** require the extension control file and SQL reaching the resolved upstream version.
- **Debug symbols:** require an exact runtime-version dependency and actual DWARF debug information matching the runtime library's ELF build ID.
- **Clean install:** install runtime and symbol packages, confirm both remain installed at the expected package versions, create the extension, check `extversion`, and execute a percentile aggregate on every major.
- **Upgrade:** install the dynamically selected archived runtime and symbol packages, verify the extension baseline, upgrade both packages, run `ALTER EXTENSION tdigest UPDATE`, and repeat version and aggregate checks.
- **Optional upstream regressions:** `run_tests=1` runs the upstream regression suite through the multi-version packaging build.

## Local validation

Tested using **Podman with Ubuntu 20.04 containers**:

- Built all **12 runtime/debug-symbol packages** for PG11–16 and passed dependency, ELF build-ID, and DWARF checks.
- Passed **41 upstream regression tests on each major**: **246 tests total**.
- Passed clean-install and archived-package upgrade smoke tests on all six majors.
- After removing the remaining archive-version pins, rebuilt all 12 packages and reran the smoke tests with dynamically discovered APT baselines.
- Verified a historical rebuild matching the archived upstream version for PG11 and PG16.
- Passed resolver input checks, Bash syntax checks, ShellCheck, actionlint, YAML parsing, and `git diff --check`.

Package signing was not exercised locally; it requires the repository's GitHub Actions secrets.

## Workflow inputs

| Input | Default | Behavior |
|---|---|---|
| `tdigest_version` | `latest` | Blank or `latest` discovers the latest stable release; an explicit version selects that release |
| `pg_versions` | `11 12 13 14 15 16` | Space-separated subset of supported PostgreSQL majors |
| `tdigest_sha256` | blank | Blank uses the release ZIP and GitHub-published digest; an explicit checksum selects tag-tarball verification |
| `run_tests` | `0` | Set to `1` to run upstream regression tests |

The workflow supports manual dispatch and runs on pushes to `tdigest-focal`. The package revision defaults to `1.citus20.04+1`; the upstream part of the package version comes from release discovery.
